### PR TITLE
replaces description for the require-labels policy

### DIFF
--- a/best-practices/require_labels/require_labels.yaml
+++ b/best-practices/require_labels/require_labels.yaml
@@ -5,9 +5,10 @@ metadata:
   annotations:
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/description: >-
-      The ':latest' tag is mutable and can lead to unexpected errors if the 
-      image changes. A best practice is to use an immutable tag that maps to 
-      a specific version of an application pod.  
+      Define and use labels that identify semantic attributes of your application or Deployment.
+      A common set of labels allows tools to work interoperably, describing objects in a common manner that 
+      all tools can understand. The recommended labels describe applications in a way that can be 
+      queried. 
 spec:
   validationFailureAction: audit
   rules:


### PR DESCRIPTION
Hi, the description on the "require-labels" policy was the one for image tags. With this PR an alternative description is suggested. 

The sentences used are copied from https://kubernetes.io/docs/concepts/configuration/overview/#using-labels and https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

Would this be an appropriate description for this policy?