### PR TITLE
add restrict-service-account sample policy

### DIFF
--- a/other/restrict-service-account.yaml
+++ b/other/restrict-service-account.yaml
@@ -1,0 +1,46 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-service-account
+  annotations:
+    policies.kyverno.io/title: Restrict Service Account
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/description: >-
+      Restrict Pod resources to use a known service account can be useful to
+      ensure workload identity security. Change this policy to match your
+      namespace, image and serviceAccountName
+spec:
+  rules:
+  # this rule requires that workload Controller resources have a service
+  # account explicitly defined. Otherwise the pod will be created with
+  # default service account.
+  - name: require-service-account
+    match:
+      resources:
+        kinds:
+        - Pod
+        namespaces:
+        - staging
+    validate:
+      message: "Service account required for Controllers"
+      pattern:
+        spec:
+          serviceAccountName: "?*"
+          containers:
+          # in a real-world scenario this would be your app's image
+          - =(image): "alpine"
+  - name: validate-service-account
+    match:
+      resources:
+        kinds:
+        - Pod
+        namespaces:
+        - staging
+    validate:
+      message: "Invalid service account"
+      pattern:
+        spec:
+          =(serviceAccountName): "gcs-viewer"
+          containers:
+          # in a real-world scenario this would be your app's image
+          - =(image): "alpine"


### PR DESCRIPTION
Related to https://github.com/kyverno/kyverno/issues/1619

I did a few tests and this approach seems straightforward to me - not sure if there are any gotchas. Notice that the first rule could be optional but in a real-world scenario, I'd like to have it in place to prevent that the pod could be created by a controller using the default service account. We may consider removing the first rule to keep the sample more concise. I'm intentionally leaving init containers out of scope.