### PR TITLE
Add severity to validation policies

### DIFF
--- a/best-practices/disallow_cri_sock_mount/disallow_cri_sock_mount.yaml
+++ b/best-practices/disallow_cri_sock_mount/disallow_cri_sock_mount.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Disallow CRI socket mounts
     policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Container daemon socket bind mounts allows access to the container engine on the 
       node. This access can be used for privilege escalation and to manage containers 

--- a/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
+++ b/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/title: Disallow Default Namespace
     policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Kubernetes namespaces are an optional feature that provide a way to segment and 
       isolate cluster resources across multiple applications and users. As a best 

--- a/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
+++ b/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Disallow Helm Tiller
     policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Tiller has known security challenges. It requires administrative privileges and acts as a shared
       resource accessible to any authenticated user. Tiller can lead to privilege escalation as

--- a/best-practices/disallow_latest_tag/disallow_latest_tag.yaml
+++ b/best-practices/disallow_latest_tag/disallow_latest_tag.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Disallow Latest Tag
     policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       The ':latest' tag is mutable and can lead to unexpected errors if the 
       image changes. A best practice is to use an immutable tag that maps to 

--- a/best-practices/require_drop_all/require_drop_all.yaml
+++ b/best-practices/require_drop_all/require_drop_all.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Drop All Capabilities
     policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access. All 
       capabilities should be dropped from a pod, with only those required added back.

--- a/best-practices/require_labels/require_labels.yaml
+++ b/best-practices/require_labels/require_labels.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Require Labels
     policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Define and use labels that identify semantic attributes of your application or Deployment.
       A common set of labels allows tools to work collaboratively, describing objects in a common manner that 

--- a/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
+++ b/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Require Limits and Requests 
     policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       As application workloads share cluster resources, it is important to limit resources 
       requested and consumed by each pod. It is recommended to require 'resources.requests' 

--- a/best-practices/require_probes/require_probes.yaml
+++ b/best-practices/require_probes/require_probes.yaml
@@ -6,6 +6,7 @@ metadata:
     pod-policies.kyverno.io/autogen-controllers: DaemonSet,Deployment,StatefulSet
     policies.kyverno.io/title: Require Pod Probes
     policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Liveness and readiness probes need to be configured to correctly manage a pods 
       lifecycle during deployments, restarts, and upgrades. For each pod, a periodic 

--- a/best-practices/require_ro_rootfs/require_ro_rootfs.yaml
+++ b/best-practices/require_ro_rootfs/require_ro_rootfs.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Require Read-Only Root Filesystem
     policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       A read-only root file system helps to enforce an immutable infrastructure strategy; 
       the container only needs to write on the mounted volume that persists the state. 

--- a/best-practices/restrict-service-external-ips/restrict-service-external-ips.yaml
+++ b/best-practices/restrict-service-external-ips/restrict-service-external-ips.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict External IPs
     policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Service externalIPs can be used for a MITM attack (CVE-2020-8554).
       Restrict externalIPs or limit to a known set of addresses.

--- a/best-practices/restrict_image_registries/restrict_image_registries.yaml
+++ b/best-practices/restrict_image_registries/restrict_image_registries.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict Image Registries
     policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Images from unknown registries may not be scanned and secured. 
       Requiring use of known registries helps reduce threat exposure.

--- a/best-practices/restrict_node_port/restrict_node_port.yaml
+++ b/best-practices/restrict_node_port/restrict_node_port.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Disallow NodePort
     policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       A Kubernetes service of type NodePort uses a host port to receive traffic from 
       any source. A 'NetworkPolicy' resource cannot be used to control traffic to host ports. 

--- a/other/disallow_secrets_from_env_vars.yaml
+++ b/other/disallow_secrets_from_env_vars.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Disallow Secrets from Env Vars
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Sample policy to disallow using secrets from environment variables 
       which are visible in resource definitions. 

--- a/other/ensure_probes_different.yaml
+++ b/other/ensure_probes_different.yaml
@@ -7,6 +7,7 @@ metadata:
     pod-policies.kyverno.io/autogen-controllers: DaemonSet,Deployment,StatefulSet  
     policies.kyverno.io/title: Validate Probes
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Sample policy to check that liveness and readiness probes are not set to the same values.
 spec:

--- a/other/imagepullpolicy-always.yaml
+++ b/other/imagepullpolicy-always.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Set imagePullPolicy
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Sample policy that sets imagePullPolicy to "Always" when the "latest" tag is used.
 spec:

--- a/other/require_deployments_have_multiple_replicas.yaml
+++ b/other/require_deployments_have_multiple_replicas.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Require Multiple Replicas
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Sample policy that requires more than one replica for deployments.    
 spec:

--- a/other/restrict_automount_sa_token.yaml
+++ b/other/restrict_automount_sa_token.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict Auto-Mount of Service Account Tokens
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Kubernetes automatically mounts service account credentials in each pod. 
       The service account may be assigned roles allowing pods to access API resources. 

--- a/other/restrict_ingress_classes.yaml
+++ b/other/restrict_ingress_classes.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict Ingress Classes
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       It can be useful to restrict Ingress resources to a set of known ingress classes 
       that are allowed in the cluster. You can customize this policy to allow ingress 

--- a/other/restrict_ingress_host.yaml
+++ b/other/restrict_ingress_host.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Unique Ingress Host
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Checks an incoming Ingress resource to ensure its hosts are unique to the cluster.
 spec:

--- a/other/restrict_loadbalancer.yaml
+++ b/other/restrict_loadbalancer.yaml
@@ -4,7 +4,8 @@ metadata:
   name: no-loadbalancer-service
   annotations:
     policies.kyverno.io/title: Disallow Service Type LoadBalancer
-    policies.kyverno.io/category: Sample 
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Sample policy to restrict use of Service type LoadBalancer.
 spec:

--- a/other/restrict_pod_count_per_node.yaml
+++ b/other/restrict_pod_count_per_node.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict Pod Count per Node
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Sample policy to restrict pod count on node 'minikube' to be no more than 10.
     # pod-policies.kyverno.io/autogen-controllers: None

--- a/other/restrict_service_account.yaml
+++ b/other/restrict_service_account.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict Service Account
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Restrict Pod resources to use a known service account can be useful to
       ensure workload identity. This policy uses a ConfigMap resource as an

--- a/other/restrict_usergroup_fsgroup_id.yaml
+++ b/other/restrict_usergroup_fsgroup_id.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Validate User ID, Group ID, and FS Group 
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       All processes inside the pod can be made to run with specific user and groupID 
       by setting 'runAsUser' and 'runAsGroup' respectively. 'fsGroup' can be specified 

--- a/pod-security/default/disallow-adding-capabilities/disallow-adding-capabilities.yaml
+++ b/pod-security/default/disallow-adding-capabilities/disallow-adding-capabilities.yaml
@@ -4,6 +4,7 @@ metadata:
   name: disallow-add-capabilities
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access.
       Adding capabilities beyond the default set must not be allowed.

--- a/pod-security/default/disallow-host-ipc/disallow-host-ipc.yaml
+++ b/pod-security/default/disallow-host-ipc/disallow-host-ipc.yaml
@@ -4,6 +4,7 @@ metadata:
   name: disallow-host-ipc
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: Sharing the host's PID namespace allows visibility of process 
       on the host, potentially exposing process information. Sharing the host's IPC namespace allows 
       the container process to communicate with processes on the host. To avoid pod container from 

--- a/pod-security/default/disallow-host-namespaces/disallow-host-namespaces.yaml
+++ b/pod-security/default/disallow-host-namespaces/disallow-host-namespaces.yaml
@@ -4,6 +4,7 @@ metadata:
   name: disallow-host-namespaces
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >- 
       Host namespaces (Process ID namespace, Inter-Process Communication namespace, and
       network namespace) allow access to shared information and can be used to elevate

--- a/pod-security/default/disallow-host-path/disallow-host-path.yaml
+++ b/pod-security/default/disallow-host-path/disallow-host-path.yaml
@@ -4,6 +4,7 @@ metadata:
   name: disallow-host-path
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       HostPath volumes let pods use host directories and volumes in containers.
       Using host resources can be used to access shared data or escalate privileges

--- a/pod-security/default/disallow-host-ports/disallow-host-ports.yaml
+++ b/pod-security/default/disallow-host-ports/disallow-host-ports.yaml
@@ -4,6 +4,7 @@ metadata:
   name: disallow-host-ports
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Access to host ports allows potential snooping of network traffic and should not be
       allowed, or at minimum restricted to a known list.

--- a/pod-security/default/disallow-privileged-containers/disallow-privileged-containers.yaml
+++ b/pod-security/default/disallow-privileged-containers/disallow-privileged-containers.yaml
@@ -4,6 +4,7 @@ metadata:
   name: disallow-privileged-containers
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Privileged mode disables most security mechanisms and must not be allowed.
 spec:

--- a/pod-security/default/disallow-proc-mount/disallow-proc-mount.yaml
+++ b/pod-security/default/disallow-proc-mount/disallow-proc-mount.yaml
@@ -4,6 +4,7 @@ metadata:
   name: require-default-proc-mount
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       The default /proc masks are set up to reduce attack surface and should be required.
 spec:

--- a/pod-security/default/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security/default/disallow-selinux/disallow-selinux.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Disallow SELinux
     policies.kyverno.io/category: Pod Security Standards (Default)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       SELinux options can be used to escalate privileges and should not be allowed.
 spec:

--- a/pod-security/default/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
+++ b/pod-security/default/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict AppArmor
     policies.kyverno.io/category: Pod Security Standards (Default)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       On supported hosts, the 'runtime/default' AppArmor profile is applied by default. 
       The default policy should prevent overriding or disabling the policy, or restrict 

--- a/pod-security/default/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security/default/restrict-sysctls/restrict-sysctls.yaml
@@ -4,6 +4,7 @@ metadata:
   name: restrict-sysctls
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Default)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Sysctls can disable security mechanisms or affect all containers on a
       host, and should be disallowed except for an allowed "safe" subset. A

--- a/pod-security/restricted/deny-privilege-escalation/deny-privilege-escalation.yaml
+++ b/pod-security/restricted/deny-privilege-escalation/deny-privilege-escalation.yaml
@@ -4,6 +4,7 @@ metadata:
   name: deny-privilege-escalation
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
 spec:

--- a/pod-security/restricted/require-non-root-groups/require-non-root-groups.yaml
+++ b/pod-security/restricted/require-non-root-groups/require-non-root-groups.yaml
@@ -4,6 +4,7 @@ metadata:
   name: require-non-root-groups
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Containers should be forbidden from running with a root primary or supplementary GID.
 spec:

--- a/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -4,6 +4,7 @@ metadata:
   name: require-run-as-non-root
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: Containers must be required to run as non-root users.
 spec:
   background: true

--- a/pod-security/restricted/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security/restricted/restrict-seccomp/restrict-seccomp.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict Seccomp
     policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       The runtime default seccomp profile must be required, or only specific
       additional profiles should be allowed.

--- a/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -4,6 +4,7 @@ metadata:
   name: restrict-volume-types
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       In addition to restricting HostPath volumes, the restricted pod security profile
       limits usage of non-core volume types to those defined through PersistentVolumes.


### PR DESCRIPTION
Signed-off-by: Frank Jogeleit <frank.jogeleit@web.de>

Add Severity for the validation policies. Using `medium` as default value. Similar to the default value in the Kyverno helm chart. 

@chipzoller @JimBugwadia 