### PR TITLE
Add node restriction and annotation policies; fix sample

### DIFF
--- a/best-practices/require_drop_all/require_drop_all.yaml
+++ b/best-practices/require_drop_all/require_drop_all.yaml
@@ -24,16 +24,7 @@ spec:
           - securityContext:
               capabilities:
                 drop: ["ALL"]
-  - name: check-init-containers
-    match:
-      resources:
-        kinds:
-        - Pod
-    validate:
-      message: "All capabilities should be dropped with only those required added back."
-      pattern:
-        spec:
-          initContainers:
-          - securityContext:
-              capabilities:
+          =(initContainers):
+          - =(securityContext):
+              (capabilities):
                 drop: ["ALL"]

--- a/other/restrict_annotations.yaml
+++ b/other/restrict_annotations.yaml
@@ -9,9 +9,7 @@ metadata:
       This example policy prevents the use of an annotation beginning with a common
       key name (in this case "fluxcd.io/"). This can be useful to ensure users either
       don't set reserved annotations or to force them to
-      use a newer version of an annotation. By setting autogen-controllers
-      to "none", Kyverno will only look at the top most `metadata` object
-      in the named resource kinds.
+      use a newer version of an annotation.
     pod-policies.kyverno.io/autogen-controllers: None
 spec:
   validationFailureAction: enforce

--- a/other/restrict_annotations.yaml
+++ b/other/restrict_annotations.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-annotations
+  annotations:
+    policies.kyverno.io/title: Restrict Annotations
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/description: >-
+      This example policy prevents the use of an annotation beginning with a common
+      key name (in this case "fluxcd.io/"). This can be useful to ensure users either
+      don't set reserved annotations or to force them to
+      use a newer version of an annotation. By setting autogen-controllers
+      to "none", Kyverno will only look at the top most `metadata` object
+      in the named resource kinds.
+    pod-policies.kyverno.io/autogen-controllers: None
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: block-flux-v1
+    match:
+      resources:
+        kinds:
+        - Deployment
+        - CronJob
+        - Job
+        - StatefulSet
+        - DaemonSet
+        - Pod
+    validate:
+      message: Cannot use Flux v1 annotation.
+      pattern:
+        metadata:
+          =(annotations):
+            X(fluxcd.io/*): "*?"

--- a/other/restrict_controlplane_scheduling.yaml
+++ b/other/restrict_controlplane_scheduling.yaml
@@ -22,5 +22,5 @@ spec:
       message: Pods may not use tolerations which schedule on control plane nodes.
       pattern:
         spec:
-        =(tolerations):
-          - X(key): "node-role.kubernetes.io/master"
+          =(tolerations):
+            - X(key): "node-role.kubernetes.io/master"

--- a/other/restrict_controlplane_scheduling.yaml
+++ b/other/restrict_controlplane_scheduling.yaml
@@ -1,0 +1,26 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-controlplane-scheduling
+  annotations:
+    policies.kyverno.io/title: Restrict control plane scheduling
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/description: >-
+      This policy prevents users from setting a toleration
+      in a Pod spec which allows running on control plane nodes
+      with the taint key "node-role.kubernetes.io/master".   
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: restrict-controlplane-scheduling
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: Pods may not use tolerations which schedule on control plane nodes.
+      pattern:
+        spec:
+        =(tolerations):
+          - X(key): "node-role.kubernetes.io/master"

--- a/other/restrict_node_label_changes.yaml
+++ b/other/restrict_node_label_changes.yaml
@@ -1,0 +1,50 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: protect-node-label-foo
+  annotations:
+    policies.kyverno.io/title: Restrict node label changes
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/description: >-
+      This policy prevents changes or deletions to label called `foo` on
+      cluster nodes. Use of this policy requires removal of the Node resource filter
+      in the Kyverno ConfigMap ([Node,*,*]). Due to Kubernetes CVE-2021-25735, this policy
+      requires, at minimum, one of the following versions of Kubernetes:
+      v1.18.18, v1.19.10, v1.20.6, or v1.21.0.
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: prevent-label-value-changes
+    match:
+      resources:
+        kinds:
+        - Node
+    validate:
+      message: "Modifying the `foo` label on a Node is not allowed."
+      deny:
+        conditions:
+        - key: "{{ request.object.metadata.labels.foo }}"
+          operator: "NotEquals"
+          value: ""
+        - key: "{{ request.object.metadata.labels.foo }}"
+          operator: "NotEquals"
+          value: "{{ request.oldObject.metadata.labels.foo }}"
+  - name: prevent-label-key-removal
+    match:
+      resources:
+        kinds:
+        - Node
+    preconditions:
+    - key: "{{ request.operation }}"
+      operator: "Equals"
+      value: UPDATE
+    - key: "{{ request.oldObject.metadata.labels.foo }}"
+      operator: "Equals"
+      value: "*"
+    validate:
+      message: "Removing the `foo` label on a Node is not allowed."
+      pattern:
+        metadata:
+          labels:
+            foo: "*"

--- a/other/restrict_node_selection.yaml
+++ b/other/restrict_node_selection.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-node-selection
+  annotations:
+    policies.kyverno.io/title: Restrict node selection
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/description: >-
+      This policy prevents users from targeting specific nodes
+      for scheduling of Pods by prohibiting the use of the `nodeSelector`
+      and `nodeName` fields in a Pod spec.     
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: restrict-nodeselector
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: Setting the nodeSelector field is prohibited.
+      pattern:
+        spec:
+          X(nodeSelector): "null"
+  - name: restrict-nodename
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: Setting the nodeName field is prohibited.
+      pattern:
+        spec:
+          X(nodeName): "null"


### PR DESCRIPTION
Signed-off-by: Chip Zoller <chipzoller@gmail.com>

This PR adds four new sample policies:

* Restrict node label changes
* Restrict node selection
* Restrict control plane scheduling
* Restrict Annotations

It also fixes the `require_drop_all.yaml` policy based on #22 