### PR TITLE
add policies.kyverno.io/minversion annotations

### DIFF
--- a/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
+++ b/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
@@ -1,10 +1,10 @@
-apiVersion : kyverno.io/v1
+apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   name: disallow-helm-tiller
   annotations:
     policies.kyverno.io/title: Disallow Helm Tiller
-    policies.kyverno.io/category: Security
+    policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Tiller has known security challenges. It requires administrative privileges and acts as a shared
@@ -13,15 +13,15 @@ metadata:
 spec:
   validationFailureAction: audit
   rules:
-  - name: validate-helm-tiller
-    match:
-      resources:
-        kinds:
-        - Pod
-    validate:
-      message: "Helm Tiller is not allowed"  
-      pattern:
-        spec:
-          containers:
-          - name: "*"
-            image: "!*tiller*"
+    - name: validate-helm-tiller
+      match:
+        resources:
+          kinds:
+            - Pod
+      validate:
+        message: "Helm Tiller is not allowed"
+        pattern:
+          spec:
+            containers:
+              - name: "*"
+                image: "!*tiller*"

--- a/best-practices/restrict_image_registries/restrict_image_registries.yaml
+++ b/best-practices/restrict_image_registries/restrict_image_registries.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict Image Registries
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/description: >-
       Images from unknown registries may not be scanned and secured. 
       Requiring use of known registries helps reduce threat exposure.

--- a/other/restrict_annotations.yaml
+++ b/other/restrict_annotations.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict Annotations
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/description: >-
       This example policy prevents the use of an annotation beginning with a common
       key name (in this case "fluxcd.io/"). This can be useful to ensure users either

--- a/other/restrict_ingress_host.yaml
+++ b/other/restrict_ingress_host.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Unique Ingress Host
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.2
     policies.kyverno.io/description: >-
       Checks an incoming Ingress resource to ensure its hosts are unique to the cluster.
 spec:

--- a/other/restrict_pod_count_per_node.yaml
+++ b/other/restrict_pod_count_per_node.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict Pod Count per Node
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.2
     policies.kyverno.io/description: >-
       Sample policy to restrict pod count on node 'minikube' to be no more than 10.
     # pod-policies.kyverno.io/autogen-controllers: None

--- a/other/restrict_service_account.yaml
+++ b/other/restrict_service_account.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict Service Account
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.5
     policies.kyverno.io/description: >-
       Restrict Pod resources to use a known service account can be useful to
       ensure workload identity. This policy uses a ConfigMap resource as an

--- a/pod-security/default/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
+++ b/pod-security/default/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict AppArmor
     policies.kyverno.io/category: Pod Security Standards (Default)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/description: >-
       On supported hosts, the 'runtime/default' AppArmor profile is applied by default. 
       The default policy should prevent overriding or disabling the policy, or restrict 


### PR DESCRIPTION
Adds a new annotation to relevant policies called `policies.kyverno.io/minversion` which notes the minimum version of Kyverno needed to implement the policy. This will get complimented by the `render` program in the kyverno/website repo so the annotation is scraped and presented as a filter category on the /policies page.