### PR TITLE
fix #47: allow fsGroup values greater than zero

### DIFF
--- a/pod-security/restricted/require-non-root-groups/require-non-root-groups.yaml
+++ b/pod-security/restricted/require-non-root-groups/require-non-root-groups.yaml
@@ -52,9 +52,9 @@ spec:
             - Pod
       validate:
         message: >-
-          Changing of file system groups is not allowed. The field	
-          spec.securityContext.fsGroup must not be defined.
+          Changing to root group ID is disallowed. The field
+          spec.securityContext.fsGroup must be empty or greater than zero.
         pattern:
           spec:
             =(securityContext):
-              X(fsGroup): "*"
+              =(fsGroup): ">0"


### PR DESCRIPTION
change the policy require-non-root-groups to allow fsGroup values greater than zero