### PR TITLE
add policies.kyverno.io/subject annotation

### DIFF
--- a/best-practices/add_network_policy.yaml
+++ b/best-practices/add_network_policy.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add Network Policy
     policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/subject: NetworkPolicy
     policies.kyverno.io/description: >-
       By default, Kubernetes allows communications across all pods within a cluster. 
       Network policies and, a CNI that supports network policies, must be used to restrict 

--- a/best-practices/add_ns_quota.yaml
+++ b/best-practices/add_ns_quota.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add Quota
     policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/subject: ResourceQuota, LimitRange
     policies.kyverno.io/description: >-
       To limit the number of objects, as well as the total amount of compute that 
       may be consumed by a single namespace, create a default resource quota for 

--- a/best-practices/add_safe_to_evict.yaml
+++ b/best-practices/add_safe_to_evict.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add safe-to-evict 
     policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       The Kubernetes cluster autoscaler does not evict pods that use hostPath 
       or emptyDir volumes. To allow eviction of these pods, the annotation 

--- a/best-practices/disallow_cri_sock_mount/disallow_cri_sock_mount.yaml
+++ b/best-practices/disallow_cri_sock_mount/disallow_cri_sock_mount.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Disallow CRI socket mounts
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Container daemon socket bind mounts allows access to the container engine on the 
       node. This access can be used for privilege escalation and to manage containers 

--- a/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
+++ b/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     policies.kyverno.io/title: Disallow Default Namespace
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Kubernetes namespaces are an optional feature that provide a way to segment and 
       isolate cluster resources across multiple applications and users. As a best 

--- a/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
+++ b/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Disallow Helm Tiller
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Tiller has known security challenges. It requires administrative privileges and acts as a shared
       resource accessible to any authenticated user. Tiller can lead to privilege escalation as

--- a/best-practices/disallow_latest_tag/disallow_latest_tag.yaml
+++ b/best-practices/disallow_latest_tag/disallow_latest_tag.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Disallow Latest Tag
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       The ':latest' tag is mutable and can lead to unexpected errors if the 
       image changes. A best practice is to use an immutable tag that maps to 

--- a/best-practices/require_drop_all/require_drop_all.yaml
+++ b/best-practices/require_drop_all/require_drop_all.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Drop All Capabilities
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access. All 
       capabilities should be dropped from a pod, with only those required added back.

--- a/best-practices/require_labels/require_labels.yaml
+++ b/best-practices/require_labels/require_labels.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Require Labels
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod, Label
     policies.kyverno.io/description: >-
       Define and use labels that identify semantic attributes of your application or Deployment.
       A common set of labels allows tools to work collaboratively, describing objects in a common manner that 

--- a/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
+++ b/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Require Limits and Requests 
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       As application workloads share cluster resources, it is important to limit resources 
       requested and consumed by each pod. It is recommended to require 'resources.requests' 

--- a/best-practices/require_probes/require_probes.yaml
+++ b/best-practices/require_probes/require_probes.yaml
@@ -7,6 +7,7 @@ metadata:
     policies.kyverno.io/title: Require Pod Probes
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Liveness and readiness probes need to be configured to correctly manage a pods 
       lifecycle during deployments, restarts, and upgrades. For each pod, a periodic 

--- a/best-practices/require_ro_rootfs/require_ro_rootfs.yaml
+++ b/best-practices/require_ro_rootfs/require_ro_rootfs.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Require Read-Only Root Filesystem
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       A read-only root file system helps to enforce an immutable infrastructure strategy; 
       the container only needs to write on the mounted volume that persists the state. 

--- a/best-practices/restrict-service-external-ips/restrict-service-external-ips.yaml
+++ b/best-practices/restrict-service-external-ips/restrict-service-external-ips.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict External IPs
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
       Service externalIPs can be used for a MITM attack (CVE-2020-8554).
       Restrict externalIPs or limit to a known set of addresses.

--- a/best-practices/restrict_image_registries/restrict_image_registries.yaml
+++ b/best-practices/restrict_image_registries/restrict_image_registries.yaml
@@ -7,6 +7,7 @@ metadata:
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
     policies.kyverno.io/minversion: 1.3.0
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Images from unknown registries may not be scanned and secured. 
       Requiring use of known registries helps reduce threat exposure.

--- a/best-practices/restrict_node_port/restrict_node_port.yaml
+++ b/best-practices/restrict_node_port/restrict_node_port.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Disallow NodePort
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
       A Kubernetes service of type NodePort uses a host port to receive traffic from 
       any source. A 'NetworkPolicy' resource cannot be used to control traffic to host ports. 

--- a/other/add_labels.yaml
+++ b/other/add_labels.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Add Labels
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Label
     policies.kyverno.io/description: >-
       Simple mutation which adds a label `foo=bar` to different resource kinds.
 spec:

--- a/other/add_nodeSelector.yaml
+++ b/other/add_nodeSelector.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add nodeSelector
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Adds the nodeSelector field to a Pod spec.
 spec:

--- a/other/add_volume_deployment.yaml
+++ b/other/add_volume_deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add Volume to Deployment
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Deployment, Volume
     policies.kyverno.io/description: >-
       Sample policy to add a volume and volumeMount to a Deployment resource. This checks for the presence of an annotation called
       "vault.k8s.corp.net/inject=enabled" and adds an emptyDir volume using the memory medium.

--- a/other/block_updates_deletes.yaml
+++ b/other/block_updates_deletes.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Block Updates and Deletes
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: RBAC
     policies.kyverno.io/description: >-
       Kubernetes RBAC allows for controls on kinds of resources or those
       with specific names. This policy restricts updates and deletes to any

--- a/other/create_pod_antiaffinity.yaml
+++ b/other/create_pod_antiaffinity.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Add Pod Anti-Affinity
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Deployment, Pod
     policies.kyverno.io/description: >-
       Sample policy to add Pod anti-affinity
 spec:

--- a/other/disallow_localhost_services.yaml
+++ b/other/disallow_localhost_services.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Disallow Localhost ExternalName Services
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
       A Service of type ExternalName which points back to localhost can potentially be used to exploit
       vulnerabilities in some Ingress controllers. This sample policy blocks Services of type ExternalName

--- a/other/disallow_secrets_from_env_vars.yaml
+++ b/other/disallow_secrets_from_env_vars.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Disallow Secrets from Env Vars
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod, Secret
     policies.kyverno.io/description: >-
       Sample policy to disallow using secrets from environment variables 
       which are visible in resource definitions. 

--- a/other/ensure_probes_different.yaml
+++ b/other/ensure_probes_different.yaml
@@ -8,6 +8,7 @@ metadata:
     policies.kyverno.io/title: Validate Probes
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Sample policy to check that liveness and readiness probes are not set to the same values.
 spec:

--- a/other/exclude_namespaces_dynamically.yaml
+++ b/other/exclude_namespaces_dynamically.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Exclude Namespaces Dynamically
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Namespace, Pod
     policies.kyverno.io/description: >-
       Policy which illustrates how to dynamically look up an allow list of Namespaces from a ConfigMap
       where the ConfigMap stores an array of strings. This policy validates that any Pods created

--- a/other/imagepullpolicy-always.yaml
+++ b/other/imagepullpolicy-always.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Set imagePullPolicy
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Sample policy that sets imagePullPolicy to "Always" when the "latest" tag is used.
 spec:

--- a/other/inject_sidecar_deployment.yaml
+++ b/other/inject_sidecar_deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Inject Sidecar Container
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Sample policy that injects a sidecar container into Pods that match an annotation.  
 spec:

--- a/other/require_deployments_have_multiple_replicas.yaml
+++ b/other/require_deployments_have_multiple_replicas.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Require Multiple Replicas
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Deployment
     policies.kyverno.io/description: >-
       Sample policy that requires more than one replica for deployments.    
 spec:

--- a/other/require_image_checksum.yaml
+++ b/other/require_image_checksum.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Require Images Use Checksums
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Use of a SHA checksum when pulling an image is often preferable because tags
       are mutable and can be overwritten. This policy checks to ensure that all images

--- a/other/restrict_annotations.yaml
+++ b/other/restrict_annotations.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict Annotations
     policies.kyverno.io/category: Sample
     policies.kyverno.io/minversion: 1.3.0
+    policies.kyverno.io/subject: Pod, Annotation
     policies.kyverno.io/description: >-
       This example policy prevents the use of an annotation beginning with a common
       key name (in this case "fluxcd.io/"). This can be useful to ensure users either

--- a/other/restrict_automount_sa_token.yaml
+++ b/other/restrict_automount_sa_token.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict Auto-Mount of Service Account Tokens
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Kubernetes automatically mounts service account credentials in each pod. 
       The service account may be assigned roles allowing pods to access API resources. 

--- a/other/restrict_controlplane_scheduling.yaml
+++ b/other/restrict_controlplane_scheduling.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict control plane scheduling
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       This policy prevents users from setting a toleration
       in a Pod spec which allows running on control plane nodes

--- a/other/restrict_ingress_classes.yaml
+++ b/other/restrict_ingress_classes.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict Ingress Classes
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Ingress
     policies.kyverno.io/description: >-
       It can be useful to restrict Ingress resources to a set of known ingress classes 
       that are allowed in the cluster. You can customize this policy to allow ingress 

--- a/other/restrict_ingress_host.yaml
+++ b/other/restrict_ingress_host.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Unique Ingress Host
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Ingress
     policies.kyverno.io/minversion: 1.3.2
     policies.kyverno.io/description: >-
       Checks an incoming Ingress resource to ensure its hosts are unique to the cluster.

--- a/other/restrict_loadbalancer.yaml
+++ b/other/restrict_loadbalancer.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Disallow Service Type LoadBalancer
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
       Sample policy to restrict use of Service type LoadBalancer.
 spec:

--- a/other/restrict_node_label_changes.yaml
+++ b/other/restrict_node_label_changes.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict node label changes
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Node, Label
     policies.kyverno.io/description: >-
       This policy prevents changes or deletions to label called `foo` on
       cluster nodes. Use of this policy requires removal of the Node resource filter

--- a/other/restrict_node_selection.yaml
+++ b/other/restrict_node_selection.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Restrict node selection
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       This policy prevents users from targeting specific nodes
       for scheduling of Pods by prohibiting the use of the `nodeSelector`

--- a/other/restrict_pod_count_per_node.yaml
+++ b/other/restrict_pod_count_per_node.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict Pod Count per Node
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.3.2
     policies.kyverno.io/description: >-
       Sample policy to restrict pod count on node 'minikube' to be no more than 10.

--- a/other/restrict_service_account.yaml
+++ b/other/restrict_service_account.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict Service Account
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.3.5
     policies.kyverno.io/description: >-
       Restrict Pod resources to use a known service account can be useful to

--- a/other/restrict_usergroup_fsgroup_id.yaml
+++ b/other/restrict_usergroup_fsgroup_id.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Validate User ID, Group ID, and FS Group 
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       All processes inside the pod can be made to run with specific user and groupID 
       by setting 'runAsUser' and 'runAsGroup' respectively. 'fsGroup' can be specified 

--- a/other/spread_pods_across_topology.yaml
+++ b/other/spread_pods_across_topology.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Spread Pods Across Nodes 
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Deployment, Pod
     policies.kyverno.io/description: >-
       Sample policy to spread pods matching a label across nodes.
 spec:

--- a/other/sync_secrets.yaml
+++ b/other/sync_secrets.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/title: Sync Secrets 
     policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Secret
     policies.kyverno.io/description: >-
       Secrets like registry credentials often need to exist in multiple
       namespaces so pods there have access. This sample policy will copy a

--- a/pod-security/baseline/disallow-adding-capabilities/disallow-adding-capabilities.yaml
+++ b/pod-security/baseline/disallow-adding-capabilities/disallow-adding-capabilities.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access.
       Adding capabilities beyond the default set must not be allowed.

--- a/pod-security/baseline/disallow-host-ipc/disallow-host-ipc.yaml
+++ b/pod-security/baseline/disallow-host-ipc/disallow-host-ipc.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description:
       Sharing the host's PID namespace allows visibility of process
       on the host, potentially exposing process information. Sharing the host's IPC namespace allows

--- a/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
+++ b/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Host namespaces (Process ID namespace, Inter-Process Communication namespace, and
       network namespace) allow access to shared information and can be used to elevate

--- a/pod-security/baseline/disallow-host-path/disallow-host-path.yaml
+++ b/pod-security/baseline/disallow-host-path/disallow-host-path.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       HostPath volumes let pods use host directories and volumes in containers.
       Using host resources can be used to access shared data or escalate privileges

--- a/pod-security/baseline/disallow-host-ports/disallow-host-ports.yaml
+++ b/pod-security/baseline/disallow-host-ports/disallow-host-ports.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Access to host ports allows potential snooping of network traffic and should not be
       allowed, or at minimum restricted to a known list.

--- a/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
+++ b/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Privileged mode disables most security mechanisms and must not be allowed.
 spec:

--- a/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.yaml
+++ b/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       The default /proc masks are set up to reduce attack surface and should be required.
 spec:

--- a/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Disallow SELinux
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       SELinux options can be used to escalate privileges and should not be allowed.
 spec:

--- a/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict AppArmor
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod, Annotation
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/description: >-
       On supported hosts, the 'runtime/default' AppArmor profile is applied by default. 

--- a/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Baseline)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Sysctls can disable security mechanisms or affect all containers on a
       host, and should be disallowed except for an allowed "safe" subset. A

--- a/pod-security/restricted/deny-privilege-escalation/deny-privilege-escalation.yaml
+++ b/pod-security/restricted/deny-privilege-escalation/deny-privilege-escalation.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
 spec:

--- a/pod-security/restricted/require-non-root-groups/require-non-root-groups.yaml
+++ b/pod-security/restricted/require-non-root-groups/require-non-root-groups.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Containers should be forbidden from running with a root primary or supplementary GID.
 spec:

--- a/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: Containers must be required to run as non-root users.
 spec:
   background: true

--- a/pod-security/restricted/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security/restricted/restrict-seccomp/restrict-seccomp.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Restrict Seccomp
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       The runtime default seccomp profile must be required, or only specific
       additional profiles should be allowed.

--- a/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       In addition to restricting HostPath volumes, the restricted pod security profile
       limits usage of non-core volume types to those defined through PersistentVolumes.


### PR DESCRIPTION
Signed-off-by: Chip Zoller <chipzoller@gmail.com>

This PR adds a new annotation to all policies called `policies.kyverno.io/subject` the value of which describes the "focus" or "subject" of the policy. This will be scraped by the `render` utility on kyverno/website to build Markdown files of these policies which will then allow the values to be exposed as additional filters on the [policies page](https://kyverno.io/policies/).