### PR TITLE
[HOLD] safe to evict policy fails on generated items without volumes

### DIFF
--- a/best-practices/add_safe_to_evict.yaml
+++ b/best-practices/add_safe_to_evict.yaml
@@ -23,7 +23,7 @@ spec:
           annotations:
             +(cluster-autoscaler.kubernetes.io/safe-to-evict): "true"
         spec:          
-          volumes: 
+          (volumes): 
           - (emptyDir): {}
   - name: annotate-host-path
     match: 
@@ -36,6 +36,6 @@ spec:
           annotations:
             +(cluster-autoscaler.kubernetes.io/safe-to-evict): "true"
         spec:          
-          volumes: 
+          (volumes): 
           - (hostPath):
               path: "*"


### PR DESCRIPTION
Signed-off-by: Jon Leemon <jon.leemon@invitae.com>

The policy throws an error when it meets a cronjob that does not have any volumes:

```
E0514 12:31:24.087776   57635 strategicMergePatch.go:69] EngineMutate "msg"="failed to apply patchStrategicMerge" "error"="failed to preProcess rule: wrong Node Kind for  expected: SequenceNode was MappingNode: value: {{\"containers\": [{\"envFrom\": [{\"configMapRef\": {\"name\": \"myconfigmap\"}}], \"image\": \"myimage\", \"imagePullPolicy\": \"Always\", \"name\": \"mycronjob\", \"resources\": {\"limits\": {\"cpu\": \"100m\", \"memory\": \"128Mi\"}, \"requests\": {\"cpu\": \"50m\", \"memory\": \"64Mi\"}}}], \"restartPolicy\": \"OnFailure\"}}" "kind"="CronJob" "name"="mycronjob" "namespace"="default" "policy"="add-safe-to-evict" "rule"="autogen-cronjob-annotate-empty-dir"
E0514 12:31:24.088916   57635 strategicMergePatch.go:69] EngineMutate "msg"="failed to apply patchStrategicMerge" "error"="failed to preProcess rule: wrong Node Kind for  expected: SequenceNode was MappingNode: value: {{\"containers\": [{\"envFrom\": [{\"configMapRef\": {\"name\": \"myconfigmap\"}}], \"image\": \"myimage\", \"imagePullPolicy\": \"Always\", \"name\": \"mycronjob\", \"resources\": {\"limits\": {\"cpu\": \"100m\", \"memory\": \"128Mi\"}, \"requests\": {\"cpu\": \"50m\", \"memory\": \"64Mi\"}}}], \"restartPolicy\": \"OnFailure\"}}" "kind"="CronJob" "name"="mycronjob" "namespace"="default" "policy"="add-safe-to-evict" "rule"="autogen-cronjob-annotate-host-path"
```