### PR TITLE
Fix capabilities.add of null => "null"

### DIFF
--- a/pod-security/baseline/disallow-adding-capabilities/disallow-adding-capabilities.yaml
+++ b/pod-security/baseline/disallow-adding-capabilities/disallow-adding-capabilities.yaml
@@ -28,8 +28,8 @@ spec:
             containers:
               - =(securityContext):
                   =(capabilities):
-                    X(add): null
+                    X(add): "null"
             =(initContainers):
               - =(securityContext):
                   =(capabilities):
-                    X(add): null
+                    X(add): "null"


### PR DESCRIPTION
When `add` is specified as `null` instead of `"null"` the policy is not
actually enforced.

Fixes #69