### PR TITLE
[HOLD FOR v1.4.2] Pod exec samples; mutation for imagePullSecrets

### DIFF
--- a/best-practices/add_network_policy.yaml
+++ b/best-practices/add_network_policy.yaml
@@ -7,12 +7,13 @@ metadata:
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/subject: NetworkPolicy
     policies.kyverno.io/description: >-
-      By default, Kubernetes allows communications across all pods within a cluster. 
-      Network policies and, a CNI that supports network policies, must be used to restrict 
-      communications. A default NetworkPolicy should be configured for each namespace to 
-      default deny all ingress and egress traffic to the pods in the namespace. Application 
+      By default, Kubernetes allows communications across all Pods within a cluster. 
+      The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict 
+      communications. A default NetworkPolicy should be configured for each Namespace to 
+      default deny all ingress and egress traffic to the Pods in the Namespace. Application 
       teams can then configure additional NetworkPolicy resources to allow desired traffic 
-      to application pods from select sources.
+      to application Pods from select sources. This sample will create a new NetworkPolicy resource
+      named `default-deny` which will deny all traffic anytime a new Namespace is created.
 spec:
   validationFailureAction: audit
   rules:

--- a/best-practices/add_network_policy.yaml
+++ b/best-practices/add_network_policy.yaml
@@ -12,7 +12,7 @@ metadata:
       communications. A default NetworkPolicy should be configured for each Namespace to 
       default deny all ingress and egress traffic to the Pods in the Namespace. Application 
       teams can then configure additional NetworkPolicy resources to allow desired traffic 
-      to application Pods from select sources. This sample will create a new NetworkPolicy resource
+      to application Pods from select sources. This policy will create a new NetworkPolicy resource
       named `default-deny` which will deny all traffic anytime a new Namespace is created.
 spec:
   validationFailureAction: audit

--- a/best-practices/add_ns_quota.yaml
+++ b/best-practices/add_ns_quota.yaml
@@ -7,9 +7,12 @@ metadata:
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/subject: ResourceQuota, LimitRange
     policies.kyverno.io/description: >-
-      To limit the number of objects, as well as the total amount of compute that 
-      may be consumed by a single namespace, create a default resource quota for 
-      each namespace.
+      In order to better control the number of resources that can be created in a
+      given Namespace as well as to provide some default resource consumption limits for
+      Pods in that Namespace, a ResourceQuota and LimitRange resources can be created.
+      This sample, upon seeing the creation of a new Namespace, will generate a
+      ResourceQuota and LimitRange resource configuring them according to the `spec` objects
+      shown in the below rules.
 spec:
   rules:
   - name: generate-resourcequota

--- a/best-practices/add_ns_quota.yaml
+++ b/best-practices/add_ns_quota.yaml
@@ -10,7 +10,7 @@ metadata:
       To better control the number of resources that can be created in a given 
       Namespace and provide default resource consumption limits for Pods,
       ResourceQuota and LimitRange resources are recommended.
-      This sample will generate ResourceQuota and LimitRange resources when
+      This policy will generate ResourceQuota and LimitRange resources when
       a new Namespace is created.
 spec:
   rules:

--- a/best-practices/add_ns_quota.yaml
+++ b/best-practices/add_ns_quota.yaml
@@ -7,12 +7,11 @@ metadata:
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/subject: ResourceQuota, LimitRange
     policies.kyverno.io/description: >-
-      In order to better control the number of resources that can be created in a
-      given Namespace as well as to provide some default resource consumption limits for
-      Pods in that Namespace, a ResourceQuota and LimitRange resources can be created.
-      This sample, upon seeing the creation of a new Namespace, will generate a
-      ResourceQuota and LimitRange resource configuring them according to the `spec` objects
-      shown in the below rules.
+      To better control the number of resources that can be created in a given 
+      Namespace and provide default resource consumption limits for Pods,
+      ResourceQuota and LimitRange resources are recommended.
+      This sample will generate ResourceQuota and LimitRange resources when
+      a new Namespace is created.
 spec:
   rules:
   - name: generate-resourcequota

--- a/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
+++ b/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
@@ -12,7 +12,7 @@ metadata:
       Kubernetes Namespaces are an optional feature that provide a way to segment and 
       isolate cluster resources across multiple applications and users. As a best 
       practice, workloads should be isolated with Namespaces. Namespaces should be required 
-      and the default (empty) namespace should not be used. This sample validates that Pods
+      and the default (empty) namespace should not be used. This policy validates that Pods
       specify a Namespace name other than `default`.
 spec:
   validationFailureAction: audit

--- a/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
+++ b/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
@@ -9,10 +9,11 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Kubernetes namespaces are an optional feature that provide a way to segment and 
+      Kubernetes Namespaces are an optional feature that provide a way to segment and 
       isolate cluster resources across multiple applications and users. As a best 
-      practice, workloads should be isolated with namespaces. Namespaces should be required 
-      and the default (empty) namespace should not be used.
+      practice, workloads should be isolated with Namespaces. Namespaces should be required 
+      and the default (empty) namespace should not be used. This sample validates that Pods
+      specify a Namespace name other than `default`.
 spec:
   validationFailureAction: audit
   rules:

--- a/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
+++ b/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
@@ -8,9 +8,11 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Tiller has known security challenges. It requires administrative privileges and acts as a shared
+      Tiller, found in Helm v2, has known security challenges. It requires administrative privileges and acts as a shared
       resource accessible to any authenticated user. Tiller can lead to privilege escalation as
-      restricted users can impact other users.
+      restricted users can impact other users. It is recommend to use Helm v3+ which does not contain
+      Tiller for these reasons. This sample validates that there is not an image
+      containing the name `tiller`.
 spec:
   validationFailureAction: audit
   rules:

--- a/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
+++ b/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
@@ -11,7 +11,7 @@ metadata:
       Tiller, found in Helm v2, has known security challenges. It requires administrative privileges and acts as a shared
       resource accessible to any authenticated user. Tiller can lead to privilege escalation as
       restricted users can impact other users. It is recommend to use Helm v3+ which does not contain
-      Tiller for these reasons. This sample validates that there is not an image
+      Tiller for these reasons. This policy validates that there is not an image
       containing the name `tiller`.
 spec:
   validationFailureAction: audit

--- a/best-practices/disallow_latest_tag/disallow_latest_tag.yaml
+++ b/best-practices/disallow_latest_tag/disallow_latest_tag.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       The ':latest' tag is mutable and can lead to unexpected errors if the 
       image changes. A best practice is to use an immutable tag that maps to 
-      a specific version of an application Pod. This sample validates that the image
+      a specific version of an application Pod. This policy validates that the image
       specifies a tag and that it is not called `latest`.
 spec:
   validationFailureAction: audit

--- a/best-practices/disallow_latest_tag/disallow_latest_tag.yaml
+++ b/best-practices/disallow_latest_tag/disallow_latest_tag.yaml
@@ -10,7 +10,8 @@ metadata:
     policies.kyverno.io/description: >-
       The ':latest' tag is mutable and can lead to unexpected errors if the 
       image changes. A best practice is to use an immutable tag that maps to 
-      a specific version of an application pod.
+      a specific version of an application Pod. This sample validates that the image
+      specifies a tag and that it is not called `latest`.
 spec:
   validationFailureAction: audit
   rules:

--- a/best-practices/require_drop_all/require_drop_all.yaml
+++ b/best-practices/require_drop_all/require_drop_all.yaml
@@ -29,6 +29,6 @@ spec:
               capabilities:
                 drop: ["ALL"]
           =(initContainers):
-          - =(securityContext):
-              (capabilities):
+          - securityContext:
+              capabilities:
                 drop: ["ALL"]

--- a/best-practices/require_drop_all/require_drop_all.yaml
+++ b/best-practices/require_drop_all/require_drop_all.yaml
@@ -9,7 +9,9 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access. All 
-      capabilities should be dropped from a pod, with only those required added back.
+      capabilities should be dropped from a Pod, with only those required added back.
+      This sample ensures that all containers explicitly specify the `drop: ["ALL"]`
+      ability.
 spec:
   validationFailureAction: audit
   rules:

--- a/best-practices/require_drop_all/require_drop_all.yaml
+++ b/best-practices/require_drop_all/require_drop_all.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access. All 
       capabilities should be dropped from a Pod, with only those required added back.
-      This sample ensures that all containers explicitly specify the `drop: ["ALL"]`
+      This policy ensures that all containers explicitly specify the `drop: ["ALL"]`
       ability.
 spec:
   validationFailureAction: audit

--- a/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
+++ b/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
@@ -11,7 +11,7 @@ metadata:
       Capabilities permit privileged actions without giving full root access. The
       CAP_NET_RAW capability, enabled by default, allows processes in a container to
       forge packets and bind to any interface potentially leading to MitM attacks.
-      This sample ensures that all containers explicitly drop the CAP_NET_RAW
+      This policy ensures that all containers explicitly drop the CAP_NET_RAW
       ability.
 spec:
   validationFailureAction: audit

--- a/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
+++ b/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: drop-cap-net-raw
+  annotations:
+    policies.kyverno.io/title: Drop CAP_NET_RAW
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Capabilities permit privileged actions without giving full root access. The
+      CAP_NET_RAW capability, enabled by default, allows processes in a container to
+      forge packets and bind to any interface potentially leading to MitM attacks.
+      This sample ensures that all containers explicitly drop the CAP_NET_RAW
+      ability.
+spec:
+  validationFailureAction: audit
+  rules:
+  - name: drop-cap-net-raw
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "The capability CAP_NET_RAW must be explicitly dropped."
+      pattern:
+        spec:
+          containers:
+          - securityContext:
+              capabilities:
+                drop: ["CAP_NET_RAW"]
+          =(initContainers):
+          - securityContext:
+              capabilities:
+                drop: ["CAP_NET_RAW"]

--- a/best-practices/require_drop_cap_net_raw/resource.yaml
+++ b/best-practices/require_drop_cap_net_raw/resource.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: add-capabilities
+spec:
+  containers:
+  - name: add-capabilities
+    image: gcr.io/google-samples/node-hello:1.0
+    securityContext:
+      capabilities:
+        add: ["SYS_TIME"]

--- a/best-practices/require_drop_cap_net_raw/test.yaml
+++ b/best-practices/require_drop_cap_net_raw/test.yaml
@@ -1,0 +1,10 @@
+name: drop-cap-net-raw
+policies:
+  -  require_drop_cap_net_raw.yaml
+resources:
+  -  resource.yaml
+results:
+  - policy: drop-cap-net-raw
+    rule: drop-cap-net-raw
+    resource:  add-capabilities
+    status: fail

--- a/best-practices/require_labels/require_labels.yaml
+++ b/best-practices/require_labels/require_labels.yaml
@@ -11,7 +11,7 @@ metadata:
       Define and use labels that identify semantic attributes of your application or Deployment.
       A common set of labels allows tools to work collaboratively, describing objects in a common manner that 
       all tools can understand. The recommended labels describe applications in a way that can be 
-      queried. This sample validates that the label `app.kubernetes.io/name` is specified with some value.
+      queried. This policy validates that the label `app.kubernetes.io/name` is specified with some value.
 spec:
   validationFailureAction: audit
   rules:

--- a/best-practices/require_labels/require_labels.yaml
+++ b/best-practices/require_labels/require_labels.yaml
@@ -11,7 +11,7 @@ metadata:
       Define and use labels that identify semantic attributes of your application or Deployment.
       A common set of labels allows tools to work collaboratively, describing objects in a common manner that 
       all tools can understand. The recommended labels describe applications in a way that can be 
-      queried. 
+      queried. This sample validates that the label `app.kubernetes.io/name` is specified with some value.
 spec:
   validationFailureAction: audit
   rules:

--- a/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
+++ b/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
@@ -12,7 +12,7 @@ metadata:
       requested and consumed by each Pod. It is recommended to require resource requests and
       limits per Pod, especially for memory and CPU. If a Namespace level request or limit is specified, 
       defaults will automatically be applied to each Pod based on the 'LimitRange' configuration.
-      This sample validates that all containers have something specified for memory and cpu
+      This policy validates that all containers have something specified for memory and cpu
       requests and memory limits.
 spec:
   validationFailureAction: audit

--- a/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
+++ b/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
@@ -9,8 +9,8 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       As application workloads share cluster resources, it is important to limit resources 
-      requested and consumed by each Pod. It is recommended to require 'resources.requests' 
-      and 'resources.limits.memory' per Pod. If a Namespace level request or limit is specified, 
+      requested and consumed by each Pod. It is recommended to require resource requests and
+      limits per Pod, especially for memory and CPU. If a Namespace level request or limit is specified, 
       defaults will automatically be applied to each Pod based on the 'LimitRange' configuration.
       This sample validates that all containers have something specified for memory and cpu
       requests and memory limits.

--- a/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
+++ b/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
@@ -9,9 +9,11 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       As application workloads share cluster resources, it is important to limit resources 
-      requested and consumed by each pod. It is recommended to require 'resources.requests' 
-      and 'resources.limits.memory' per pod. If a namespace level request or limit is specified, 
-      defaults will automatically be applied to each pod based on the 'LimitRange' configuration.
+      requested and consumed by each Pod. It is recommended to require 'resources.requests' 
+      and 'resources.limits.memory' per Pod. If a Namespace level request or limit is specified, 
+      defaults will automatically be applied to each Pod based on the 'LimitRange' configuration.
+      This sample validates that all containers have something specified for memory and cpu
+      requests and memory limits.
 spec:
   validationFailureAction: audit
   rules:

--- a/best-practices/require_probes/require_probes.yaml
+++ b/best-practices/require_probes/require_probes.yaml
@@ -9,11 +9,13 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Liveness and readiness probes need to be configured to correctly manage a pods 
-      lifecycle during deployments, restarts, and upgrades. For each pod, a periodic 
-      `livenessProbe` is performed by the kubelet to determine if the pod's containers 
-      are running or need to be restarted. A `readinessProbe` is used by services 
-      and deployments to determine if the pod is ready to receive network traffic.
+      Liveness and readiness probes need to be configured to correctly manage a Pod's 
+      lifecycle during deployments, restarts, and upgrades. For each Pod, a periodic 
+      `livenessProbe` is performed by the kubelet to determine if the Pod's containers 
+      are running or need to be restarted. A `readinessProbe` is used by Services 
+      and Deployments to determine if the Pod is ready to receive network traffic.
+      This sample validates that all containers have liveness and readiness probes by
+      ensuring the `periodSeconds` field is greater than zero.
 spec:
   validationFailureAction: audit
   rules:

--- a/best-practices/require_probes/require_probes.yaml
+++ b/best-practices/require_probes/require_probes.yaml
@@ -14,7 +14,7 @@ metadata:
       `livenessProbe` is performed by the kubelet to determine if the Pod's containers 
       are running or need to be restarted. A `readinessProbe` is used by Services 
       and Deployments to determine if the Pod is ready to receive network traffic.
-      This sample validates that all containers have liveness and readiness probes by
+      This policy validates that all containers have liveness and readiness probes by
       ensuring the `periodSeconds` field is greater than zero.
 spec:
   validationFailureAction: audit

--- a/best-practices/require_ro_rootfs/require_ro_rootfs.yaml
+++ b/best-practices/require_ro_rootfs/require_ro_rootfs.yaml
@@ -11,7 +11,7 @@ metadata:
       A read-only root file system helps to enforce an immutable infrastructure strategy; 
       the container only needs to write on the mounted volume that persists the state. 
       An immutable root filesystem can also prevent malicious binaries from writing to the 
-      host system. This sample validates that containers define a securityContext
+      host system. This policy validates that containers define a securityContext
       with `readOnlyRootFilesystem: true`.
 spec:
   validationFailureAction: audit

--- a/best-practices/require_ro_rootfs/require_ro_rootfs.yaml
+++ b/best-practices/require_ro_rootfs/require_ro_rootfs.yaml
@@ -11,7 +11,8 @@ metadata:
       A read-only root file system helps to enforce an immutable infrastructure strategy; 
       the container only needs to write on the mounted volume that persists the state. 
       An immutable root filesystem can also prevent malicious binaries from writing to the 
-      host system.
+      host system. This sample validates that containers define a securityContext
+      with `readOnlyRootFilesystem: true`.
 spec:
   validationFailureAction: audit
   rules:

--- a/best-practices/restrict-service-external-ips/restrict-service-external-ips.yaml
+++ b/best-practices/restrict-service-external-ips/restrict-service-external-ips.yaml
@@ -10,7 +10,8 @@ metadata:
     policies.kyverno.io/description: >-
       Service externalIPs can be used for a MITM attack (CVE-2020-8554).
       Restrict externalIPs or limit to a known set of addresses.
-      See: https://github.com/kyverno/kyverno/issues/1367.
+      See: https://github.com/kyverno/kyverno/issues/1367. This sample validates
+      that the `externalIPs` field is not set on a Service.
 spec:
   validationFailureAction: audit
   rules:

--- a/best-practices/restrict-service-external-ips/restrict-service-external-ips.yaml
+++ b/best-practices/restrict-service-external-ips/restrict-service-external-ips.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       Service externalIPs can be used for a MITM attack (CVE-2020-8554).
       Restrict externalIPs or limit to a known set of addresses.
-      See: https://github.com/kyverno/kyverno/issues/1367. This sample validates
+      See: https://github.com/kyverno/kyverno/issues/1367. This policy validates
       that the `externalIPs` field is not set on a Service.
 spec:
   validationFailureAction: audit

--- a/best-practices/restrict_image_registries/restrict_image_registries.yaml
+++ b/best-practices/restrict_image_registries/restrict_image_registries.yaml
@@ -13,7 +13,7 @@ metadata:
       Requiring use of known registries helps reduce threat exposure.
 spec:
   background: false
-  validationFailureAction: enforce
+  validationFailureAction: audit
   rules:
   - name: validate-registries
     match:

--- a/best-practices/restrict_image_registries/restrict_image_registries.yaml
+++ b/best-practices/restrict_image_registries/restrict_image_registries.yaml
@@ -10,10 +10,10 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Images from unknown, public registries can be of dubious quality and may not be
-      scanned and secured, representing some degree of risk. Requiring use of known, approved
+      scanned and secured, representing a high degree of risk. Requiring use of known, approved
       registries helps reduce threat exposure by ensuring image pulls only come from them. This
-      sample validates that container images only originate from the registry `k8s.gcr.io` or
-      `gcr.io`.
+      sample validates that container images only originate from the registry `eu.foo.io` or
+      `bar.io`.
 spec:
   background: false
   validationFailureAction: audit
@@ -28,4 +28,4 @@ spec:
       pattern:
         spec:
           containers:
-          - image: "k8s.gcr.io/* | gcr.io/*"
+          - image: "eu.foo.io/* | bar.io/*"

--- a/best-practices/restrict_image_registries/restrict_image_registries.yaml
+++ b/best-practices/restrict_image_registries/restrict_image_registries.yaml
@@ -9,8 +9,11 @@ metadata:
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Images from unknown registries may not be scanned and secured. 
-      Requiring use of known registries helps reduce threat exposure.
+      Images from unknown, public registries can be of dubious quality and may not be
+      scanned and secured, representing some degree of risk. Requiring use of known, approved
+      registries helps reduce threat exposure by ensuring image pulls only come from them. This
+      sample validates that container images only originate from the registry `k8s.gcr.io` or
+      `gcr.io`.
 spec:
   background: false
   validationFailureAction: audit

--- a/best-practices/restrict_node_port/restrict_node_port.yaml
+++ b/best-practices/restrict_node_port/restrict_node_port.yaml
@@ -11,7 +11,7 @@ metadata:
       A Kubernetes Service of type NodePort uses a host port to receive traffic from 
       any source. A NetworkPolicy cannot be used to control traffic to host ports. 
       Although NodePort Services can be useful, their use must be limited to Services 
-      with additional upstream security checks. This sample validates that any new Services
+      with additional upstream security checks. This policy validates that any new Services
       do not use the `NodePort` type.
 spec:
   rules:

--- a/best-practices/restrict_node_port/restrict_node_port.yaml
+++ b/best-practices/restrict_node_port/restrict_node_port.yaml
@@ -8,10 +8,11 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
-      A Kubernetes service of type NodePort uses a host port to receive traffic from 
-      any source. A 'NetworkPolicy' resource cannot be used to control traffic to host ports. 
-      Although 'NodePort' services can be useful, their use must be limited to services 
-      with additional upstream security checks.
+      A Kubernetes Service of type NodePort uses a host port to receive traffic from 
+      any source. A NetworkPolicy cannot be used to control traffic to host ports. 
+      Although NodePort Services can be useful, their use must be limited to Services 
+      with additional upstream security checks. This sample validates that any new Services
+      do not use the `NodePort` type.
 spec:
   rules:
   - name: validate-nodeport

--- a/cert-manager/limit-dnsnames.yaml
+++ b/cert-manager/limit-dnsnames.yaml
@@ -9,7 +9,10 @@ metadata:
     policies.kyverno.io/minversion: 1.3.6
     policies.kyverno.io/subject: Certificate
     policies.kyverno.io/description: >-
-      Ensures that each certificate request contains only one DNS name entry.
+      Some applications will not accept certificates containing more than a single name.
+      Additionally, having a single certificate name multiple potentially increases
+      overhead and complexity. This sample ensures that each certificate request contains
+      only one DNS name entry.
 spec:
   validationFailureAction: audit
   background: false

--- a/cert-manager/limit-dnsnames.yaml
+++ b/cert-manager/limit-dnsnames.yaml
@@ -11,7 +11,7 @@ metadata:
     policies.kyverno.io/description: >-
       Some applications will not accept certificates containing more than a single name.
       Additionally, having a single certificate name multiple potentially increases
-      overhead and complexity. This sample ensures that each certificate request contains
+      overhead and complexity. This policy ensures that each certificate request contains
       only one DNS name entry.
 spec:
   validationFailureAction: audit

--- a/cert-manager/restrict-issuer.yaml
+++ b/cert-manager/restrict-issuer.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       Certificates for trusted domains should always be steered to a controlled issuer to
       ensure the chain of trust is appropriate for that application. Users may otherwise be
-      able to create their own issuers and sign certificates for other domains. This sample
+      able to create their own issuers and sign certificates for other domains. This policy
       ensures that a certificate request for a specific domain uses a designated ClusterIssuer.
 spec:
   validationFailureAction: audit

--- a/cert-manager/restrict-issuer.yaml
+++ b/cert-manager/restrict-issuer.yaml
@@ -8,7 +8,10 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Certificate
     policies.kyverno.io/description: >-
-      Ensures that a certificate request for a specific domain uses a designated ClusterIssuer.
+      Certificates for trusted domains should always be steered to a controlled issuer to
+      ensure the chain of trust is appropriate for that application. Users may otherwise be
+      able to create their own issuers and sign certificates for other domains. This sample
+      ensures that a certificate request for a specific domain uses a designated ClusterIssuer.
 spec:
   validationFailureAction: audit
   background: false

--- a/other/add-default-securitycontext.yaml
+++ b/other/add-default-securitycontext.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-default-securitycontext
+  annotations:
+    policies.kyverno.io/title: Add Default securityContext
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      A Pod securityContext entry defines fields such as the user and group should be used to run the Pod.
+      Sometimes choosing default values for users rather than blocking is a better alternative to not impede
+      such Pod definitions. This sample will mutate a Pod to set `runAsUser`, `runAsGroup`, and `fsGroup` fields
+      within the Pod securityContext if they are not present.
+spec:
+  background: false
+  rules:
+  - name: add-default-securitycontext
+    match:
+      resources:
+        kinds:
+        - Pod
+    mutate:
+      patchStrategicMerge:
+        spec:
+          securityContext:
+            +(runAsUser): 1000
+            +(runAsGroup): 3000
+            +(fsGroup): 2000

--- a/other/add-default-securitycontext.yaml
+++ b/other/add-default-securitycontext.yaml
@@ -7,10 +7,10 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      A Pod securityContext entry defines fields such as the user and group should be used to run the Pod.
+      A Pod securityContext entry defines fields such as the user and group which should be used to run the Pod.
       Sometimes choosing default values for users rather than blocking is a better alternative to not impede
       such Pod definitions. This sample will mutate a Pod to set `runAsUser`, `runAsGroup`, and `fsGroup` fields
-      within the Pod securityContext if they are not present.
+      within the Pod securityContext if they are not already set.
 spec:
   background: false
   rules:

--- a/other/add-default-securitycontext.yaml
+++ b/other/add-default-securitycontext.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       A Pod securityContext entry defines fields such as the user and group which should be used to run the Pod.
       Sometimes choosing default values for users rather than blocking is a better alternative to not impede
-      such Pod definitions. This sample will mutate a Pod to set `runAsUser`, `runAsGroup`, and `fsGroup` fields
+      such Pod definitions. This policy will mutate a Pod to set `runAsUser`, `runAsGroup`, and `fsGroup` fields
       within the Pod securityContext if they are not already set.
 spec:
   background: false

--- a/other/add-imagepullsecrets.yaml
+++ b/other/add-imagepullsecrets.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       Images coming from certain registries require authentication in order to pull them,
       and a Kubernetes imagePullSecret is mounted into a Pod to supply those credentials.
-      This sample searches for images coming from a registry called `corp.reg.com` and,
+      This policy searches for images coming from a registry called `corp.reg.com` and,
       if found, will mutate the Pod to add an imagePullSecret called `my-secret`.
 spec:
   background: false

--- a/other/add-imagepullsecrets.yaml
+++ b/other/add-imagepullsecrets.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-imagepullsecrets
+  annotations:
+    policies.kyverno.io/title: Add imagePullSecrets
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Images coming from certain registries require authentication in order to pull them,
+      and a Kubernetes imagePullSecret is mounted into a Pod to supply those credentials.
+      This sample policy searches for images coming from a registry called `corp.reg.com` and,
+      if found, will mutate the Pod to add an imagePullSecret called `my-secret`.
+spec:
+  background: false
+  rules:
+  - name: add-imagepullsecret
+    match:
+      resources:
+        kinds:
+        - Pod
+    mutate:
+      patchStrategicMerge:
+        spec:
+          containers:
+          - (image): "corp.reg.com/*"
+          imagePullSecrets:
+          - name: my-secret

--- a/other/add-imagepullsecrets.yaml
+++ b/other/add-imagepullsecrets.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       Images coming from certain registries require authentication in order to pull them,
       and a Kubernetes imagePullSecret is mounted into a Pod to supply those credentials.
-      This sample policy searches for images coming from a registry called `corp.reg.com` and,
+      This sample searches for images coming from a registry called `corp.reg.com` and,
       if found, will mutate the Pod to add an imagePullSecret called `my-secret`.
 spec:
   background: false

--- a/other/add-pod-proxies.yaml
+++ b/other/add-pod-proxies.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       In restricted environments, Pods may not be allowed to egress directly to all destinations
       and some overrides to specific addresses may need to go through a corporate proxy.
-      This sample adds proxy information to Pods in the form of environment variables.
+      This policy adds proxy information to Pods in the form of environment variables.
       It will add the `env` array if not present. If any Pods have any of these
       env vars, they will be overwritten with the value(s) in this policy.
 spec:

--- a/other/add-pod-proxies.yaml
+++ b/other/add-pod-proxies.yaml
@@ -7,8 +7,10 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/category: Sample
     policies.kyverno.io/description: >-
-      Adds proxy information to Pods in the form of environment variables.
-      Will add the `env` array if not present. If any Pods have any of these
+      In restricted environments, Pods may not be allowed to egress directly to all destinations
+      and some overrides to specific addresses may need to go through a corporate proxy.
+      This sample adds proxy information to Pods in the form of environment variables.
+      It will add the `env` array if not present. If any Pods have any of these
       env vars, they will be overwritten with the value(s) in this policy.
 spec:
   background: false

--- a/other/add_labels.yaml
+++ b/other/add_labels.yaml
@@ -8,19 +8,22 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Label
     policies.kyverno.io/description: >-
-      Simple mutation which adds a label `foo=bar` to different resource kinds.
+      Labels are used as an important source of metadata describing objects in various ways
+      or triggering other functionality. Labels are also a very basic concept and should be
+      used throughout Kubernetes. This sample performs a simple mutation which adds a label
+      `foo=bar` to Pods, Services, ConfigMaps, and Secrets.
 spec:
-    rules:
-    - name: add-labels
-      match:
-        resources:
-          kinds:
-          - Pod
-          - Service
-          - ConfigMap
-          - Secret
-      mutate:
-        patchStrategicMerge:
-          metadata:
-            labels:
-              foo: bar
+  rules:
+  - name: add-labels
+    match:
+      resources:
+        kinds:
+        - Pod
+        - Service
+        - ConfigMap
+        - Secret
+    mutate:
+      patchStrategicMerge:
+        metadata:
+          labels:
+            foo: bar

--- a/other/add_labels.yaml
+++ b/other/add_labels.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       Labels are used as an important source of metadata describing objects in various ways
       or triggering other functionality. Labels are also a very basic concept and should be
-      used throughout Kubernetes. This sample performs a simple mutation which adds a label
+      used throughout Kubernetes. This policy performs a simple mutation which adds a label
       `foo=bar` to Pods, Services, ConfigMaps, and Secrets.
 spec:
   rules:

--- a/other/add_ndots.yaml
+++ b/other/add_ndots.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       The ndots value controls where DNS lookups are first performed in a cluster
       and needs to be set to a lower value than the default of 5 in some cases.
-      This policy policy mutates all Pods to add the ndots option with a value of 1.
+      This policy mutates all Pods to add the ndots option with a value of 1.
 spec:
   background: false
   rules:

--- a/other/add_ndots.yaml
+++ b/other/add_ndots.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       The ndots value controls where DNS lookups are first performed in a cluster
       and needs to be set to a lower value than the default of 5 in some cases.
-      This sample policy mutates all Pods to add the ndots option with a value of 1.
+      This policy policy mutates all Pods to add the ndots option with a value of 1.
 spec:
   background: false
   rules:

--- a/other/add_nodeSelector.yaml
+++ b/other/add_nodeSelector.yaml
@@ -7,7 +7,9 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Adds the nodeSelector field to a Pod spec.
+      The nodeSelector field uses labels to select the node which node a Pod can be scheduled on.
+      This can be useful when Pods have specific needs that only certain nodes in a cluster can provide.
+      This sample adds the nodeSelector field to a Pod spec and configures it with two labels as shown below.
 spec:
   background: false
   rules:

--- a/other/add_nodeSelector.yaml
+++ b/other/add_nodeSelector.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       The nodeSelector field uses labels to select the node which node a Pod can be scheduled on.
       This can be useful when Pods have specific needs that only certain nodes in a cluster can provide.
-      This sample adds the nodeSelector field to a Pod spec and configures it with two labels as shown below.
+      This policy adds the nodeSelector field to a Pod spec and configures it with two labels as shown below.
 spec:
   background: false
   rules:

--- a/other/add_volume_deployment.yaml
+++ b/other/add_volume_deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       Some Kubernetes applications like HashiCorp Vault must perform some modifications
       to resources in order to invoke their specific functionality. Often times, that functionality
-      is controlled by the presence of a label or specific annotation. This sample, based on HashiCorp
+      is controlled by the presence of a label or specific annotation. This policy, based on HashiCorp
       Vault, adds a volume and volumeMount to a Deployment if there is an annotation called
       "vault.k8s.corp.net/inject=enabled" present.
 spec:

--- a/other/add_volume_deployment.yaml
+++ b/other/add_volume_deployment.yaml
@@ -7,8 +7,11 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/subject: Deployment, Volume
     policies.kyverno.io/description: >-
-      Sample policy to add a volume and volumeMount to a Deployment resource. This checks for the presence of an annotation called
-      "vault.k8s.corp.net/inject=enabled" and adds an emptyDir volume using the memory medium.
+      Some Kubernetes applications like HashiCorp Vault must perform some modifications
+      to resources in order to invoke their specific functionality. Often times, that functionality
+      is controlled by the presence of a label or specific annotation. This sample, based on HashiCorp
+      Vault, adds a volume and volumeMount to a Deployment if there is an annotation called
+      "vault.k8s.corp.net/inject=enabled" present.
 spec:
   background: false
   rules:

--- a/other/allowed_pod_priorities.yaml
+++ b/other/allowed_pod_priorities.yaml
@@ -15,7 +15,7 @@ metadata:
       PriorityClasses for the given Namespace stored in a ConfigMap. If the `priorityClassName` is not
       among them, the Pod is blocked.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: validate-pod-priority

--- a/other/allowed_pod_priorities.yaml
+++ b/other/allowed_pod_priorities.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       A Pod PriorityClass is used to provide a guarantee on the scheduling of a Pod relative to others.
       In certain cases where not all users in a cluster are trusted, a malicious user could create Pods
-      at the highest possible priorities, causing other Pods to be evicted/not get scheduled. This sample
+      at the highest possible priorities, causing other Pods to be evicted/not get scheduled. This policy
       checks the defined `priorityClassName` in a Pod spec to a dictionary of allowable
       PriorityClasses for the given Namespace stored in a ConfigMap. If the `priorityClassName` is not
       among them, the Pod is blocked.

--- a/other/always-pull-images.yaml
+++ b/other/always-pull-images.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       By default, images that have already been pulled can be accessed by other
       Pods without re-pulling them if the name and tag are known. In multi-tenant scenarios,
-      this may be undesirable. This sample mutates all incoming Pods to set their
+      this may be undesirable. This policy mutates all incoming Pods to set their
       imagePullPolicy to Always. An alternative to the Kubernetes admission controller
       AlwaysPullImages.
 spec:

--- a/other/always-pull-images.yaml
+++ b/other/always-pull-images.yaml
@@ -1,0 +1,29 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: always-pull-images
+  annotations:
+    policies.kyverno.io/title: Always Pull Images
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      By default, images that have already been pulled can be accessed by other
+      Pods without re-pulling them if the name and tag are known. In multi-tenant scenarios,
+      this may be undesirable. This sample mutates all incoming Pods to set their
+      imagePullPolicy to Always. An alternative to the Kubernetes admission controller
+      AlwaysPullImages.
+spec:
+  background: false
+  rules:
+  - name: always-pull-images
+    match:
+      resources:
+        kinds:
+        - Pod
+    mutate:
+      patchStrategicMerge:
+        spec:
+          containers:
+          - (name): "?*"
+            imagePullPolicy: Always

--- a/other/block-pod-exec-by-namespace-label.yaml
+++ b/other/block-pod-exec-by-namespace-label.yaml
@@ -12,7 +12,7 @@ metadata:
       be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
       This policy blocks Pod exec commands based upon a Namespace label `exec=false`.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: deny-exec-by-ns-label

--- a/other/block-pod-exec-by-namespace-label.yaml
+++ b/other/block-pod-exec-by-namespace-label.yaml
@@ -30,7 +30,7 @@ spec:
       operator: Equals
       value: CONNECT
     validate:
-      message: Exec'ing into Pods into Namespaces protected with the label `exec=false` is forbidden.
+      message: Executing a command in a container is forbidden for Pods running in Namespaces protected with the label "exec=false".
       deny:
         conditions:
           - key: "{{ nslabelexec }}"

--- a/other/block-pod-exec-by-namespace-label.yaml
+++ b/other/block-pod-exec-by-namespace-label.yaml
@@ -1,0 +1,38 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-exec-by-namespace-label
+  annotations:
+    policies.kyverno.io/title: Block Pod Exec by Namespace Label
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.4.2
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The `exec` command may be used to gain shell access to a given Pod. While this can
+      be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
+      This policy blocks Pod exec commands based upon a Namespace label `exec=false`.
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: deny-exec-by-ns-label
+    match:
+      resources:
+        kinds:
+        - PodExecOptions
+    context:
+    - name: nslabelexec
+      apiCall:
+        urlPath: "/api/v1/namespaces/{{request.namespace}}"
+        jmesPath: "metadata.labels.exec"   
+    preconditions:
+    - key: "{{ request.operation }}"
+      operator: Equals
+      value: CONNECT
+    validate:
+      message: Exec'ing into Pods into Namespaces protected with the label `exec=false` is forbidden.
+      deny:
+        conditions:
+          - key: "{{ nslabelexec }}"
+            operator: Equals
+            value: "false"

--- a/other/block-pod-exec-by-namespace.yaml
+++ b/other/block-pod-exec-by-namespace.yaml
@@ -12,7 +12,7 @@ metadata:
       be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
       This policy blocks Pod exec commands to Pods in a Namespace called `pci`.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: deny-exec-ns-pci

--- a/other/block-pod-exec-by-namespace.yaml
+++ b/other/block-pod-exec-by-namespace.yaml
@@ -8,7 +8,7 @@ metadata:
     policies.kyverno.io/minversion: 1.4.2
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      The `exec` command may be used to gain shell access to a given Pod. While this can
+      The "exec" command may be used to gain shell access, or run other commands, in a Pod's container. While this can
       be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
       This policy blocks Pod exec commands to Pods in a Namespace called `pci`.
 spec:

--- a/other/block-pod-exec-by-namespace.yaml
+++ b/other/block-pod-exec-by-namespace.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-exec-by-namespace-name
+  annotations:
+    policies.kyverno.io/title: Block Pod Exec by Namespace Name
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.4.2
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The `exec` command may be used to gain shell access to a given Pod. While this can
+      be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
+      This policy blocks Pod exec commands to Pods in a Namespace called `pci`.
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: deny-exec-ns-pci
+    match:
+      resources:
+        kinds:
+        - PodExecOptions
+    preconditions:
+    - key: "{{ request.operation }}"
+      operator: Equals
+      value: CONNECT
+    validate:
+      message: Pods in this namespace may not be exec'd into.
+      deny:
+        conditions:
+          - key: "{{ request.namespace }}"
+            operator: Equals
+            value: pci

--- a/other/block-pod-exec-by-pod-and-container.yaml
+++ b/other/block-pod-exec-by-pod-and-container.yaml
@@ -1,0 +1,38 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-exec-by-pod-and-container
+  annotations:
+    policies.kyverno.io/title: Block Pod Exec by Pod and Container
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.4.2
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The `exec` command may be used to gain shell access to a given Pod. While this can
+      be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
+      This policy blocks Pod exec commands to containers named `nginx` in Pods starting
+      with name `myapp-maintenance`.
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: deny-nginx-exec-in-myapp-maintenance
+    match:
+      resources:
+        kinds:
+        - PodExecOptions
+    preconditions:
+      all:
+      - key: "{{ request.operation }}"
+        operator: Equals
+        value: CONNECT
+      - key: "{{ request.name }}"
+        operator: Equals
+        value: myapp-maintenance*
+    validate:
+      message: Nginx containers inside myapp-maintanence Pods may not be exec'd into.
+      deny:
+        conditions:
+          - key: "{{ request.object.container }}"
+            operator: Equals
+            value: nginx

--- a/other/block-pod-exec-by-pod-and-container.yaml
+++ b/other/block-pod-exec-by-pod-and-container.yaml
@@ -13,7 +13,7 @@ metadata:
       This policy blocks Pod exec commands to containers named `nginx` in Pods starting
       with name `myapp-maintenance`.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: deny-nginx-exec-in-myapp-maintenance

--- a/other/block-pod-exec-by-pod-label.yaml
+++ b/other/block-pod-exec-by-pod-label.yaml
@@ -12,7 +12,7 @@ metadata:
       be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
       This policy blocks Pod exec commands to Pods having the label `exec=false`.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: deny-exec-by-label

--- a/other/block-pod-exec-by-pod-label.yaml
+++ b/other/block-pod-exec-by-pod-label.yaml
@@ -1,0 +1,38 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-exec-by-pod-label
+  annotations:
+    policies.kyverno.io/title: Block Pod Exec by Pod Label
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.4.2
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The `exec` command may be used to gain shell access to a given Pod. While this can
+      be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
+      This policy blocks Pod exec commands to Pods having the label `exec=false`.
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: deny-exec-by-label
+    match:
+      resources:
+        kinds:
+        - PodExecOptions
+    context:
+    - name: podexeclabel
+      apiCall:
+        urlPath: "/api/v1/namespaces/{{request.namespace}}/pods/{{request.name}}"
+        jmesPath: "metadata.labels.exec"   
+    preconditions:
+    - key: "{{ request.operation }}"
+      operator: Equals
+      value: CONNECT
+    validate:
+      message: Exec'ing into Pods protected with the label `exec=false` is forbidden.
+      deny:
+        conditions:
+          - key: "{{ podexeclabel }}"
+            operator: Equals
+            value: "false"

--- a/other/block-pod-exec-by-pod-name.yaml
+++ b/other/block-pod-exec-by-pod-name.yaml
@@ -1,0 +1,34 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-exec-by-pod-name
+  annotations:
+    policies.kyverno.io/title: Block Pod Exec by Pod Name
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.4.2
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The `exec` command may be used to gain shell access to a given Pod. While this can
+      be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
+      This policy blocks Pod exec commands to Pods beginning with the name
+      `myapp-maintenance-`.
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: deny-exec-myapp-maintenance
+    match:
+      resources:
+        kinds:
+        - PodExecOptions
+    preconditions:
+    - key: "{{ request.operation }}"
+      operator: Equals
+      value: CONNECT
+    validate:
+      message: Exec'ing into Pods called "myapp-maintenance" is not allowed.
+      deny:
+        conditions:
+          - key: "{{ request.name }}"
+            operator: Equals
+            value: myapp-maintenance-*

--- a/other/block-pod-exec-by-pod-name.yaml
+++ b/other/block-pod-exec-by-pod-name.yaml
@@ -13,7 +13,7 @@ metadata:
       This policy blocks Pod exec commands to Pods beginning with the name
       `myapp-maintenance-`.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: deny-exec-myapp-maintenance

--- a/other/block_updates_deletes.yaml
+++ b/other/block_updates_deletes.yaml
@@ -8,10 +8,10 @@ metadata:
     policies.kyverno.io/subject: RBAC
     policies.kyverno.io/description: >-
       Kubernetes RBAC allows for controls on kinds of resources or those
-      with specific names. This policy restricts updates and deletes to any
-      Service resource that contains the label `protected="true"` unless by
-      a cluster-admin and thus functions as a more granular option to
-      Kubernetes RBAC. 
+      with specific names. But it does not have the type of granularity often
+      required in more complex environments. This sample restricts updates and deletes to any
+      Service resource that contains the label `protected=true` unless by
+      a cluster-admin.
 spec:
   validationFailureAction: audit
   background: false

--- a/other/block_updates_deletes.yaml
+++ b/other/block_updates_deletes.yaml
@@ -13,7 +13,7 @@ metadata:
       Service resource that contains the label `protected=true` unless by
       a cluster-admin.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: enforce
   background: false
   rules:
   - name: block-updates-deletes

--- a/other/block_updates_deletes.yaml
+++ b/other/block_updates_deletes.yaml
@@ -13,7 +13,7 @@ metadata:
       a cluster-admin and thus functions as a more granular option to
       Kubernetes RBAC. 
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: block-updates-deletes

--- a/other/block_updates_deletes.yaml
+++ b/other/block_updates_deletes.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       Kubernetes RBAC allows for controls on kinds of resources or those
       with specific names. But it does not have the type of granularity often
-      required in more complex environments. This sample restricts updates and deletes to any
+      required in more complex environments. This policy restricts updates and deletes to any
       Service resource that contains the label `protected=true` unless by
       a cluster-admin.
 spec:

--- a/other/create_pod_antiaffinity.yaml
+++ b/other/create_pod_antiaffinity.yaml
@@ -41,4 +41,4 @@ spec:
                             - key: app
                               operator: In
                               values:
-                              - "{{request.object.metadata.labels.app}}"
+                              - "{{request.object.spec.template.metadata.labels.app}}"

--- a/other/create_pod_antiaffinity.yaml
+++ b/other/create_pod_antiaffinity.yaml
@@ -8,7 +8,7 @@ metadata:
     policies.kyverno.io/subject: Deployment, Pod
     policies.kyverno.io/description: >-
       Applications may involve multiple replicas of the same Pod for availability as well as scale
-      purposes, yet Kubernetes does not by default provide a solution for availability. This sample
+      purposes, yet Kubernetes does not by default provide a solution for availability. This policy
       sets a Pod anti-affinity configuration on Deployments which contain an `app` label if it is
       not already present.
 spec:

--- a/other/create_pod_antiaffinity.yaml
+++ b/other/create_pod_antiaffinity.yaml
@@ -7,7 +7,10 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/subject: Deployment, Pod
     policies.kyverno.io/description: >-
-      Sample policy to add Pod anti-affinity
+      Applications may involve multiple replicas of the same Pod for availability as well as scale
+      purposes, yet Kubernetes does not by default provide a solution for availability. This sample
+      sets a Pod anti-affinity configuration on Deployments which contain an `app` label if it is
+      not already present.
 spec:
   rules:
     - name: insert-pod-antiaffinity

--- a/other/disallow_localhost_services/disallow_localhost_services.yaml
+++ b/other/disallow_localhost_services/disallow_localhost_services.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
       A Service of type ExternalName which points back to localhost can potentially be used to exploit
-      vulnerabilities in some Ingress controllers. This sample audits Services of type ExternalName
+      vulnerabilities in some Ingress controllers. This policy audits Services of type ExternalName
       if the externalName field refers to localhost.
 spec:
   validationFailureAction: audit

--- a/other/disallow_localhost_services/disallow_localhost_services.yaml
+++ b/other/disallow_localhost_services/disallow_localhost_services.yaml
@@ -12,7 +12,7 @@ metadata:
       vulnerabilities in some Ingress controllers. This sample policy blocks Services of type ExternalName
       if the externalName field refers to localhost.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   rules:
   - name: no-localhost-service
     match:

--- a/other/disallow_localhost_services/disallow_localhost_services.yaml
+++ b/other/disallow_localhost_services/disallow_localhost_services.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
       A Service of type ExternalName which points back to localhost can potentially be used to exploit
-      vulnerabilities in some Ingress controllers. This sample policy blocks Services of type ExternalName
+      vulnerabilities in some Ingress controllers. This sample blocks Services of type ExternalName
       if the externalName field refers to localhost.
 spec:
   validationFailureAction: audit

--- a/other/disallow_localhost_services/disallow_localhost_services.yaml
+++ b/other/disallow_localhost_services/disallow_localhost_services.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
       A Service of type ExternalName which points back to localhost can potentially be used to exploit
-      vulnerabilities in some Ingress controllers. This sample blocks Services of type ExternalName
+      vulnerabilities in some Ingress controllers. This sample audits Services of type ExternalName
       if the externalName field refers to localhost.
 spec:
   validationFailureAction: audit

--- a/other/disallow_secrets_from_env_vars.yaml
+++ b/other/disallow_secrets_from_env_vars.yaml
@@ -8,8 +8,9 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod, Secret
     policies.kyverno.io/description: >-
-      Sample policy to disallow using secrets from environment variables 
-      which are visible in resource definitions. 
+      Secrets used as environment variables containing sensitive information may, if not carefully controlled, 
+      be printed in log output which could be visible to unauthorized people and captured in forwarding
+      applications. This sample disallows using Secrets as environment variables.
 spec:
   validationFailureAction: audit
   rules:

--- a/other/disallow_secrets_from_env_vars.yaml
+++ b/other/disallow_secrets_from_env_vars.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       Secrets used as environment variables containing sensitive information may, if not carefully controlled, 
       be printed in log output which could be visible to unauthorized people and captured in forwarding
-      applications. This sample disallows using Secrets as environment variables.
+      applications. This policy disallows using Secrets as environment variables.
 spec:
   validationFailureAction: audit
   rules:

--- a/other/ensure_probes_different.yaml
+++ b/other/ensure_probes_different.yaml
@@ -11,7 +11,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Liveness and readiness probes accomplish different goals, and setting both to the same
-      is an anti-pattern and often results in app problems in the future. This sample
+      is an anti-pattern and often results in app problems in the future. This policy
       checks that liveness and readiness probes are not equal.
 spec:
   validationFailureAction: audit

--- a/other/ensure_probes_different.yaml
+++ b/other/ensure_probes_different.yaml
@@ -12,7 +12,7 @@ metadata:
     policies.kyverno.io/description: >-
       Sample policy to check that liveness and readiness probes are not equal.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
     - name: validate-probes

--- a/other/ensure_probes_different.yaml
+++ b/other/ensure_probes_different.yaml
@@ -10,7 +10,9 @@ metadata:
     policies.kyverno.io/minversion: 1.3.6
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Sample policy to check that liveness and readiness probes are not equal.
+      Liveness and readiness probes accomplish different goals, and setting both to the same
+      is an anti-pattern and often results in app problems in the future. This sample
+      checks that liveness and readiness probes are not equal.
 spec:
   validationFailureAction: audit
   background: false

--- a/other/exclude_namespaces_dynamically.yaml
+++ b/other/exclude_namespaces_dynamically.yaml
@@ -12,7 +12,7 @@ metadata:
       where the ConfigMap stores an array of strings. This policy validates that any Pods created
       outside of the list of Namespaces have the label `foo` applied.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: exclude-namespaces-dynamically

--- a/other/exclude_namespaces_dynamically.yaml
+++ b/other/exclude_namespaces_dynamically.yaml
@@ -8,7 +8,8 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Namespace, Pod
     policies.kyverno.io/description: >-
-      Policy which illustrates how to dynamically look up an allow list of Namespaces from a ConfigMap
+      It's common where policy lookups need to consider a mapping to many possible values rather than a
+      static mapping. This is a sample which demonstrates how to dynamically look up an allow list of Namespaces from a ConfigMap
       where the ConfigMap stores an array of strings. This policy validates that any Pods created
       outside of the list of Namespaces have the label `foo` applied.
 spec:

--- a/other/imagepullpolicy-always.yaml
+++ b/other/imagepullpolicy-always.yaml
@@ -8,7 +8,10 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Sample policy that sets imagePullPolicy to "Always" when the "latest" tag is used.
+      If the `latest` tag is allowed for images, it is often recommended to set the
+      imagePullPolicy field to `Always` to ensure should that tag be overwritten that future
+      pulls will get the updated image. This sample sets imagePullPolicy to `Always`
+      when the `latest` tag is specified explicitly or where a tag is not defined at all.
 spec:
   validationFailureAction: audit
   background: false

--- a/other/imagepullpolicy-always.yaml
+++ b/other/imagepullpolicy-always.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       If the `latest` tag is allowed for images, it is a good idea to have the
       imagePullPolicy field set to `Always` to ensure should that tag be overwritten that future
-      pulls will get the updated image. This sample validates the imagePullPolicy is set to `Always`
+      pulls will get the updated image. This policy validates the imagePullPolicy is set to `Always`
       when the `latest` tag is specified explicitly or where a tag is not defined at all.
 spec:
   validationFailureAction: audit

--- a/other/imagepullpolicy-always.yaml
+++ b/other/imagepullpolicy-always.yaml
@@ -3,14 +3,14 @@ kind: ClusterPolicy
 metadata:
   name: imagepullpolicy-always
   annotations:
-    policies.kyverno.io/title: Set imagePullPolicy
+    policies.kyverno.io/title: Require imagePullPolicy Always
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      If the `latest` tag is allowed for images, it is often recommended to set the
-      imagePullPolicy field to `Always` to ensure should that tag be overwritten that future
-      pulls will get the updated image. This sample sets imagePullPolicy to `Always`
+      If the `latest` tag is allowed for images, it is a good idea to have the
+      imagePullPolicy field set to `Always` to ensure should that tag be overwritten that future
+      pulls will get the updated image. This sample validates the imagePullPolicy is set to `Always`
       when the `latest` tag is specified explicitly or where a tag is not defined at all.
 spec:
   validationFailureAction: audit

--- a/other/inject_sidecar_deployment.yaml
+++ b/other/inject_sidecar_deployment.yaml
@@ -10,7 +10,7 @@ metadata:
       The sidecar pattern is very common in Kubernetes whereby other applications can
       insert components via tacit modification of a submitted resource. This is, for example,
       often how service meshes and secrets applications are able to function transparently.
-      This sample injects a sidecar container, initContainer, and volume into Pods that match
+      This policy injects a sidecar container, initContainer, and volume into Pods that match
       an annotation called `vault.hashicorp.com/agent-inject: true`. 
 spec:
   background: false

--- a/other/inject_sidecar_deployment.yaml
+++ b/other/inject_sidecar_deployment.yaml
@@ -7,7 +7,11 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Sample policy that injects a sidecar container into Pods that match an annotation.  
+      The sidecar pattern is very common in Kubernetes whereby other applications can
+      insert components via tacit modification of a submitted resource. This is, for example,
+      often how service meshes and secrets applications are able to function transparently.
+      This sample injects a sidecar container, initContainer, and volume into Pods that match
+      an annotation called `vault.hashicorp.com/agent-inject: true`. 
 spec:
   background: false
   rules:

--- a/other/limit_containers_per_pod.yaml
+++ b/other/limit_containers_per_pod.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Pods can have many different containers which
-      are tightly coupled. It may be desired to limit the amount of containers that
+      are tightly coupled. It may be desirable to limit the amount of containers that
       can be in a single Pod to control best practice application or so policy can
       be applied consistently. This sample checks all Pods to ensure they have
       no more than four containers.

--- a/other/limit_containers_per_pod.yaml
+++ b/other/limit_containers_per_pod.yaml
@@ -15,7 +15,7 @@ metadata:
       no more than four containers.
 spec:
   background: false
-  validationFailureAction: enforce
+  validationFailureAction: audit
   rules:
   - name: limit-containers-per-pod-controllers
     match:

--- a/other/limit_containers_per_pod.yaml
+++ b/other/limit_containers_per_pod.yaml
@@ -11,7 +11,7 @@ metadata:
       Pods can have many different containers which
       are tightly coupled. It may be desirable to limit the amount of containers that
       can be in a single Pod to control best practice application or so policy can
-      be applied consistently. This sample checks all Pods to ensure they have
+      be applied consistently. This policy checks all Pods to ensure they have
       no more than four containers.
 spec:
   background: false

--- a/other/limit_containers_per_pod.yaml
+++ b/other/limit_containers_per_pod.yaml
@@ -8,7 +8,7 @@ metadata:
     policies.kyverno.io/minversion: 1.3.6
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Pods can have between one and a number of different containers included which
+      Pods can have many different containers which
       are tightly coupled. It may be desired to limit the amount of containers that
       can be in a single Pod to control best practice application or so policy can
       be applied consistently. This sample checks all Pods to ensure they have

--- a/other/memory-requests-equal-limits.yaml
+++ b/other/memory-requests-equal-limits.yaml
@@ -10,7 +10,9 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.3.6
     policies.kyverno.io/description: >-
-      Checks that all containers in a given Pod have memory requests equal to limits.
+      Pods which have memory limits equal to requests are given a QoS class of Guaranteed
+      which is the highest schedulable class. This sample checks that all containers in
+      a given Pod have memory requests equal to limits.
 spec:
   validationFailureAction: audit
   background: false

--- a/other/memory-requests-equal-limits.yaml
+++ b/other/memory-requests-equal-limits.yaml
@@ -11,7 +11,7 @@ metadata:
     policies.kyverno.io/minversion: 1.3.6
     policies.kyverno.io/description: >-
       Pods which have memory limits equal to requests are given a QoS class of Guaranteed
-      which is the highest schedulable class. This sample checks that all containers in
+      which is the highest schedulable class. This policy checks that all containers in
       a given Pod have memory requests equal to limits.
 spec:
   validationFailureAction: audit

--- a/other/replace_image_registry.yaml
+++ b/other/replace_image_registry.yaml
@@ -11,7 +11,9 @@ metadata:
     policies.kyverno.io/description: >-
       Rather than blocking Pods which come from outside registries,
       it is also possible to mutate them so the pulls are directed to
-      approved registries. This sample policy mutates all images either
+      approved registries. In some cases, those registries may function as
+      pull-through proxies and can fetch the image if not cached.
+      This sample policy mutates all images either
       in the form 'image:tag' or 'registry.corp.com/image:tag' to be prefaced
       with `myregistry.corp.com/`.
 spec:

--- a/other/replace_image_registry.yaml
+++ b/other/replace_image_registry.yaml
@@ -13,7 +13,7 @@ metadata:
       it is also possible to mutate them so the pulls are directed to
       approved registries. In some cases, those registries may function as
       pull-through proxies and can fetch the image if not cached.
-      This sample policy mutates all images either
+      This policy policy mutates all images either
       in the form 'image:tag' or 'registry.corp.com/image:tag' to be prefaced
       with `myregistry.corp.com/`.
 spec:

--- a/other/replace_image_registry.yaml
+++ b/other/replace_image_registry.yaml
@@ -30,4 +30,4 @@ spec:
             containers:
             - (name): "*"
               image: |-
-                {{ regex_replace_all('(.*)\/', '{{@}}', 'myregistry.corp.com/') }}
+                {{ regex_replace_all('^[^/]+', '{{@}}', 'myregistry.corp.com') }}

--- a/other/require_deployments_have_multiple_replicas.yaml
+++ b/other/require_deployments_have_multiple_replicas.yaml
@@ -8,7 +8,9 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Deployment
     policies.kyverno.io/description: >-
-      Sample policy that requires more than one replica for deployments.    
+      Deployments with a single replica cannot be highly available and thus the application
+      may suffer downtime if that one replica goes down. This sample validates that Deployments
+      have more than one replica.    
 spec:
   validationFailureAction: audit
   rules:

--- a/other/require_deployments_have_multiple_replicas.yaml
+++ b/other/require_deployments_have_multiple_replicas.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Deployment
     policies.kyverno.io/description: >-
       Deployments with a single replica cannot be highly available and thus the application
-      may suffer downtime if that one replica goes down. This sample validates that Deployments
+      may suffer downtime if that one replica goes down. This policy validates that Deployments
       have more than one replica.    
 spec:
   validationFailureAction: audit

--- a/other/require_image_checksum.yaml
+++ b/other/require_image_checksum.yaml
@@ -12,7 +12,7 @@ metadata:
       are mutable and can be overwritten. This policy checks to ensure that all images
       use SHA checksums rather than tags.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: true
   rules:
   - name: require-image-checksum

--- a/other/require_imagepullsecrets.yaml
+++ b/other/require_imagepullsecrets.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Some registries, both public and private, require credentials in order to pull images
-      from them. This sample policy checks those images and if they come from a registry
+      from them. This sample checks those images and if they come from a registry
       other than ghcr.io or quay.io an `imagePullSecret` is required.
 spec:
   validationFailureAction: audit

--- a/other/require_imagepullsecrets.yaml
+++ b/other/require_imagepullsecrets.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Some registries, both public and private, require credentials in order to pull images
-      from them. This sample checks those images and if they come from a registry
+      from them. This policy checks those images and if they come from a registry
       other than ghcr.io or quay.io an `imagePullSecret` is required.
 spec:
   validationFailureAction: audit

--- a/other/require_imagepullsecrets.yaml
+++ b/other/require_imagepullsecrets.yaml
@@ -12,7 +12,7 @@ metadata:
       from them. This sample policy checks those images and if they come from a registry
       other than ghcr.io or quay.io an `imagePullSecret` is required.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   rules:
   - name: check-for-image-pull-secrets
     match:

--- a/other/require_netpol.yaml
+++ b/other/require_netpol.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       NetworkPolicy is used to control Pod-to-Pod communication
       and is a good practice to ensure only authorized Pods can send/receive
-      traffic. This sample checks incoming Deployments to ensure
+      traffic. This policy checks incoming Deployments to ensure
       they have a matching, preexisting NetworkPolicy.
 spec:
   validationFailureAction: audit

--- a/other/require_netpol.yaml
+++ b/other/require_netpol.yaml
@@ -8,9 +8,9 @@ metadata:
     policies.kyverno.io/minversion: 1.3.6
     policies.kyverno.io/subject: Deployment, NetworkPolicy
     policies.kyverno.io/description: >-
-      NetworkPolicy resources are used to control pod-to-pod communication
-      and are good practices to ensure only authorized pods can send/receive
-      traffic. This sample policy checks incoming Deployments to ensure
+      NetworkPolicy is used to control Pod-to-Pod communication
+      and is a good practice to ensure only authorized Pods can send/receive
+      traffic. This sample checks incoming Deployments to ensure
       they have a matching, preexisting NetworkPolicy.
 spec:
   validationFailureAction: audit

--- a/other/require_pdb.yaml
+++ b/other/require_pdb.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Deployment, PodDisruptionBudget
     policies.kyverno.io/description: >-
       PodDisruptionBudget resources are useful to ensuring minimum availability
-      is maintained at all times. This sample policy checks all incoming Deployments
+      is maintained at all times. This sample checks all incoming Deployments
       to ensure they have a matching, preexisting PodDisruptionBudget.
 spec:
   validationFailureAction: audit

--- a/other/require_pdb.yaml
+++ b/other/require_pdb.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Deployment, PodDisruptionBudget
     policies.kyverno.io/description: >-
       PodDisruptionBudget resources are useful to ensuring minimum availability
-      is maintained at all times. This sample checks all incoming Deployments
+      is maintained at all times. This policy checks all incoming Deployments
       to ensure they have a matching, preexisting PodDisruptionBudget.
 spec:
   validationFailureAction: audit

--- a/other/restrict_annotations.yaml
+++ b/other/restrict_annotations.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Pod, Annotation
     policies.kyverno.io/description: >-
       Some annotations control functionality driven by other cluster-wide tools and are not
-      normally set by some class of users. This sample prevents the use of an annotation beginning
+      normally set by some class of users. This policy prevents the use of an annotation beginning
       with `fluxcd.io/`. This can be useful to ensure users either
       don't set reserved annotations or to force them to use a newer version of an annotation.
     pod-policies.kyverno.io/autogen-controllers: None

--- a/other/restrict_annotations.yaml
+++ b/other/restrict_annotations.yaml
@@ -14,7 +14,7 @@ metadata:
       use a newer version of an annotation.
     pod-policies.kyverno.io/autogen-controllers: None
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: block-flux-v1

--- a/other/restrict_annotations.yaml
+++ b/other/restrict_annotations.yaml
@@ -8,10 +8,10 @@ metadata:
     policies.kyverno.io/minversion: 1.3.0
     policies.kyverno.io/subject: Pod, Annotation
     policies.kyverno.io/description: >-
-      This example policy prevents the use of an annotation beginning with a common
-      key name (in this case "fluxcd.io/"). This can be useful to ensure users either
-      don't set reserved annotations or to force them to
-      use a newer version of an annotation.
+      Some annotations control functionality driven by other cluster-wide tools and are not
+      normally set by some class of users. This sample prevents the use of an annotation beginning
+      with `fluxcd.io/`. This can be useful to ensure users either
+      don't set reserved annotations or to force them to use a newer version of an annotation.
     pod-policies.kyverno.io/autogen-controllers: None
 spec:
   validationFailureAction: audit

--- a/other/restrict_automount_sa_token.yaml
+++ b/other/restrict_automount_sa_token.yaml
@@ -12,7 +12,7 @@ metadata:
       The ServiceAccount may be assigned roles allowing Pods to access API resources.
       Blocking this ability is an extension of the least privilege best practice and should
       be followed if Pods do not need to speak to the API server to function. 
-      This sample ensures that mounting of these ServiceAccount tokens is blocked.
+      This policy ensures that mounting of these ServiceAccount tokens is blocked.
 spec:
   rules:
   - name: validate-automountServiceAccountToken

--- a/other/restrict_automount_sa_token.yaml
+++ b/other/restrict_automount_sa_token.yaml
@@ -8,10 +8,11 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Kubernetes automatically mounts service account credentials in each pod. 
-      The service account may be assigned roles allowing pods to access API resources. 
-      To restrict access, opt out of auto-mounting tokens by setting 
-      automountServiceAccountToken to false.
+      Kubernetes automatically mounts ServiceAccount credentials in each Pod. 
+      The ServiceAccount may be assigned roles allowing Pods to access API resources.
+      Blocking this ability is an extension of the least privilege best practice and should
+      be followed if Pods do not need to speak to the API server to function. 
+      This sample ensures that mounting of these ServiceAccount tokens is blocked.
 spec:
   rules:
   - name: validate-automountServiceAccountToken

--- a/other/restrict_controlplane_scheduling.yaml
+++ b/other/restrict_controlplane_scheduling.yaml
@@ -7,9 +7,11 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      This policy prevents users from setting a toleration
+      Scheduling non-system Pods to control plane nodes (which run kubelet) is often undesirable
+      because it takes away resources from the control plane components and can represent
+      a possible security threat vector. This sample prevents users from setting a toleration
       in a Pod spec which allows running on control plane nodes
-      with the taint key "node-role.kubernetes.io/master".   
+      with the taint key `node-role.kubernetes.io/master`.   
 spec:
   validationFailureAction: audit
   background: false

--- a/other/restrict_controlplane_scheduling.yaml
+++ b/other/restrict_controlplane_scheduling.yaml
@@ -11,7 +11,7 @@ metadata:
       in a Pod spec which allows running on control plane nodes
       with the taint key "node-role.kubernetes.io/master".   
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: restrict-controlplane-scheduling-master

--- a/other/restrict_controlplane_scheduling.yaml
+++ b/other/restrict_controlplane_scheduling.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       Scheduling non-system Pods to control plane nodes (which run kubelet) is often undesirable
       because it takes away resources from the control plane components and can represent
-      a possible security threat vector. This sample prevents users from setting a toleration
+      a possible security threat vector. This policy prevents users from setting a toleration
       in a Pod spec which allows running on control plane nodes
       with the taint key `node-role.kubernetes.io/master`.   
 spec:

--- a/other/restrict_ingress_classes.yaml
+++ b/other/restrict_ingress_classes.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       Ingress classes should only be allowed which match up to deployed Ingress controllers
       in the cluster. Allowing users to define classes which cannot be satisfied by a deployed
-      Ingress controller can result in either no or undesired functionality. This sample checks
+      Ingress controller can result in either no or undesired functionality. This policy checks
       Ingress resources and only allows those which define `HAProxy` or `nginx` in the respective
       annotation. This annotation has largely been replaced as of Kubernetes 1.18 with the IngressClass
       resource.

--- a/other/restrict_ingress_classes.yaml
+++ b/other/restrict_ingress_classes.yaml
@@ -8,9 +8,12 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Ingress
     policies.kyverno.io/description: >-
-      It can be useful to restrict Ingress resources to a set of known ingress classes 
-      that are allowed in the cluster. You can customize this policy to allow ingress 
-      classes that are configured in the cluster.
+      Ingress classes should only be allowed which match up to deployed Ingress controllers
+      in the cluster. Allowing users to define classes which cannot be satisfied by a deployed
+      Ingress controller can result in either no or undesired functionality. This sample checks
+      Ingress resources and only allows those which define `HAProxy` or `nginx` in the respective
+      annotation. This annotation has largely been replaced as of Kubernetes 1.18 with the IngressClass
+      resource.
 spec:
   rules:
   - name: validate-ingress

--- a/other/restrict_ingress_host.yaml
+++ b/other/restrict_ingress_host.yaml
@@ -11,7 +11,7 @@ metadata:
     policies.kyverno.io/description: >-
       An Ingress host is a URL at which services may be made available externally. In most cases,
       these hosts should be unique across the cluster to ensure no routing conflicts occur.
-      This sample checks an incoming Ingress resource to ensure its hosts are unique to the cluster.
+      This policy checks an incoming Ingress resource to ensure its hosts are unique to the cluster.
 spec:
   validationFailureAction: audit
   background: false

--- a/other/restrict_ingress_host.yaml
+++ b/other/restrict_ingress_host.yaml
@@ -11,7 +11,7 @@ metadata:
     policies.kyverno.io/description: >-
       Checks an incoming Ingress resource to ensure its hosts are unique to the cluster.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
     - name: check-host

--- a/other/restrict_ingress_host.yaml
+++ b/other/restrict_ingress_host.yaml
@@ -24,16 +24,20 @@ spec:
       context:
         - name: hosts
           apiCall:
-            urlPath: "/apis/networking.k8s.io/v1beta1/ingresses"
+            urlPath: "/apis/networking.k8s.io/v1/ingresses"
             jmesPath: "items[].spec.rules[].host"
       preconditions:
+        all:
         - key: "{{ request.operation }}"
           operator: Equals
-          value: "CREATE"
+          value: CREATE
+        any:
+        - key: "{{ request.object.spec.rules[].host }}"
+          operator: In
+          value: "{{ hosts }}"
+        - key: "{{ request.object.spec.rules[].host }}"
+          operator: NotIn
+          value: "{{ hosts }}"
       validate:
         message: "The Ingress host name must be unique."
-        deny:
-          conditions:
-            - key: "{{ request.object.spec.rules[].host }}"
-              operator: In
-              value: "{{ hosts }}"
+        deny: {}

--- a/other/restrict_ingress_host.yaml
+++ b/other/restrict_ingress_host.yaml
@@ -9,7 +9,9 @@ metadata:
     policies.kyverno.io/subject: Ingress
     policies.kyverno.io/minversion: 1.3.2
     policies.kyverno.io/description: >-
-      Checks an incoming Ingress resource to ensure its hosts are unique to the cluster.
+      An Ingress host is a URL at which services may be made available externally. In most cases,
+      these hosts should be unique across the cluster to ensure no routing conflicts occur.
+      This sample checks an incoming Ingress resource to ensure its hosts are unique to the cluster.
 spec:
   validationFailureAction: audit
   background: false

--- a/other/restrict_loadbalancer.yaml
+++ b/other/restrict_loadbalancer.yaml
@@ -8,7 +8,11 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Service
     policies.kyverno.io/description: >-
-      Sample policy to restrict use of Service type LoadBalancer.
+      Especially in cloud provider environments, a Service having type LoadBalancer will cause the
+      provider to respond by creating a load balancer somewhere in the customer account. This adds
+      cost and complexity to a deployment. Without restricting this ability, users may easily
+      overrun established budgets and security practices set by the organization. This sample restricts
+      use of the Service type LoadBalancer.
 spec:
   validationFailureAction: audit
   rules:

--- a/other/restrict_loadbalancer.yaml
+++ b/other/restrict_loadbalancer.yaml
@@ -11,7 +11,7 @@ metadata:
       Especially in cloud provider environments, a Service having type LoadBalancer will cause the
       provider to respond by creating a load balancer somewhere in the customer account. This adds
       cost and complexity to a deployment. Without restricting this ability, users may easily
-      overrun established budgets and security practices set by the organization. This sample restricts
+      overrun established budgets and security practices set by the organization. This policy restricts
       use of the Service type LoadBalancer.
 spec:
   validationFailureAction: audit

--- a/other/restrict_node_label_changes.yaml
+++ b/other/restrict_node_label_changes.yaml
@@ -13,7 +13,7 @@ metadata:
       requires, at minimum, one of the following versions of Kubernetes:
       v1.18.18, v1.19.10, v1.20.6, or v1.21.0.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: prevent-label-value-changes

--- a/other/restrict_node_label_changes.yaml
+++ b/other/restrict_node_label_changes.yaml
@@ -7,8 +7,10 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/subject: Node, Label
     policies.kyverno.io/description: >-
-      This policy prevents changes or deletions to label called `foo` on
-      cluster nodes. Use of this policy requires removal of the Node resource filter
+      Node labels are critical pieces of metadata upon which many other applications and
+      logic may depend and should not be altered or removed by regular users.
+      This policy prevents changes or deletions to a label called `foo` on
+      cluster Nodes. Use of this policy requires removal of the Node resource filter
       in the Kyverno ConfigMap ([Node,*,*]). Due to Kubernetes CVE-2021-25735, this policy
       requires, at minimum, one of the following versions of Kubernetes:
       v1.18.18, v1.19.10, v1.20.6, or v1.21.0.

--- a/other/restrict_node_label_creation.yaml
+++ b/other/restrict_node_label_creation.yaml
@@ -1,0 +1,36 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-node-label-creation
+  annotations:
+    policies.kyverno.io/title: Restrict node label creation
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: Node, Label
+    policies.kyverno.io/description: >-
+      Node labels are critical pieces of metadata upon which many other applications and
+      logic may depend and should not be altered or removed by regular users. Many cloud
+      providers also use Node labels to signal specific functions to applications.
+      This policy prevents setting of a new label called `foo` on
+      cluster Nodes. Use of this policy requires removal of the Node resource filter
+      in the Kyverno ConfigMap ([Node,*,*]). Due to Kubernetes CVE-2021-25735, this policy
+      requires, at minimum, one of the following versions of Kubernetes:
+      v1.18.18, v1.19.10, v1.20.6, or v1.21.0.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+  - name: prevent-label-set
+    match:
+      resources:
+        kinds:
+        - Node
+    preconditions:
+    - key: "{{request.operation}}"
+      operator: Equals
+      value: UPDATE
+    - key: "{{request.object.metadata.labels.foo}}"
+      operator: Equals
+      value: "*"
+    validate:
+      message: "Setting the `foo` label on a Node is not allowed."
+      deny: {}

--- a/other/restrict_node_selection.yaml
+++ b/other/restrict_node_selection.yaml
@@ -7,9 +7,11 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      This policy prevents users from targeting specific nodes
-      for scheduling of Pods by prohibiting the use of the `nodeSelector`
-      and `nodeName` fields in a Pod spec.     
+      The Kubernetes scheduler uses complex logic to determine the optimal placement
+      for new Pods. Users who have access to set certain fields in a Pod spec
+      may sidestep this logic which in many cases is undesirable. This policy
+      prevents users from targeting specific Nodes for scheduling of Pods by
+      prohibiting the use of the `nodeSelector` and `nodeName` fields.     
 spec:
   validationFailureAction: audit
   background: false

--- a/other/restrict_node_selection.yaml
+++ b/other/restrict_node_selection.yaml
@@ -11,7 +11,7 @@ metadata:
       for scheduling of Pods by prohibiting the use of the `nodeSelector`
       and `nodeName` fields in a Pod spec.     
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: false
   rules:
   - name: restrict-nodeselector

--- a/other/restrict_pod_count_per_node.yaml
+++ b/other/restrict_pod_count_per_node.yaml
@@ -9,7 +9,9 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.3.2
     policies.kyverno.io/description: >-
-      Sample policy to restrict pod count on node 'minikube' to be no more than 10.
+      Sometimes Kubernetes Nodes may have a maximum number of Pods they can accommodate due to
+      resources outside CPU and memory such as licensing, or in some
+      development cases. This sample restricts Pod count on a Node named `minikube` to be no more than 10.
     # pod-policies.kyverno.io/autogen-controllers: None
 spec:
   validationFailureAction: audit
@@ -30,9 +32,9 @@ spec:
           operator: Equals
           value: "CREATE"
       validate:
-        message: "restrict pod counts to be no more than 12 on node minikube"
+        message: "A maximum of 10 Pods are allowed on the Node `minikube`"
         deny:
           conditions:
             - key: "{{ podcounts }}"
-              operator: GreaterThanOrEquals
+              operator: GreaterThan
               value: 10

--- a/other/restrict_pod_count_per_node.yaml
+++ b/other/restrict_pod_count_per_node.yaml
@@ -11,7 +11,7 @@ metadata:
     policies.kyverno.io/description: >-
       Sometimes Kubernetes Nodes may have a maximum number of Pods they can accommodate due to
       resources outside CPU and memory such as licensing, or in some
-      development cases. This sample restricts Pod count on a Node named `minikube` to be no more than 10.
+      development cases. This policy restricts Pod count on a Node named `minikube` to be no more than 10.
     # pod-policies.kyverno.io/autogen-controllers: None
 spec:
   validationFailureAction: audit

--- a/other/restrict_service_account.yaml
+++ b/other/restrict_service_account.yaml
@@ -15,7 +15,7 @@ metadata:
       Example: 'sa-name: ["registry/image-name"]'
 spec:
   background: false
-  validationFailureAction: enforce
+  validationFailureAction: audit
   rules:
   - name: validate-service-account
     context:

--- a/other/restrict_service_account.yaml
+++ b/other/restrict_service_account.yaml
@@ -9,10 +9,12 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.3.5
     policies.kyverno.io/description: >-
-      Restrict Pod resources to use a known service account can be useful to
-      ensure workload identity. This policy uses a ConfigMap resource as an
-      external data source to map service accounts to images.
-      Example: 'sa-name: ["registry/image-name"]'
+      Users may be able to specify any ServiceAccount which exists in their Namespace without
+      restrictions. Confining Pods to a list of authorized ServiceAccounts can be useful to
+      ensure applications in those Pods do not have more privileges than they should.
+      This policy verifies that in the `staging` Namespace the ServiceAccount being
+      specified is matched based on the image and name of the container. For example: 
+      'sa-name: ["registry/image-name"]'
 spec:
   background: false
   validationFailureAction: audit

--- a/other/restrict_usergroup_fsgroup_id.yaml
+++ b/other/restrict_usergroup_fsgroup_id.yaml
@@ -11,7 +11,7 @@ metadata:
       All processes inside a Pod can be made to run with specific user and groupID 
       by setting 'runAsUser' and 'runAsGroup' respectively. 'fsGroup' can be specified 
       to make sure any file created in the volume will have the specified groupID. 
-      This sample validates that these fields are set to the defined values.
+      This policy validates that these fields are set to the defined values.
 spec:
   rules:
   - name: validate-userid

--- a/other/restrict_usergroup_fsgroup_id.yaml
+++ b/other/restrict_usergroup_fsgroup_id.yaml
@@ -8,10 +8,10 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      All processes inside the pod can be made to run with specific user and groupID 
+      All processes inside a Pod can be made to run with specific user and groupID 
       by setting 'runAsUser' and 'runAsGroup' respectively. 'fsGroup' can be specified 
-      to make sure any file created in the volume with have the specified groupID. 
-      These options can be used to validate the IDs used for user and group.
+      to make sure any file created in the volume will have the specified groupID. 
+      This sample validates that these fields are set to the defined values.
 spec:
   rules:
   - name: validate-userid

--- a/other/spread_pods_across_topology.yaml
+++ b/other/spread_pods_across_topology.yaml
@@ -7,7 +7,10 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/subject: Deployment, Pod
     policies.kyverno.io/description: >-
-      Sample policy to spread pods matching a label across nodes.
+      Deployments to a Kubernetes cluster with multiple availability zones often need to
+      distribute those replicas to align with those zones to ensure site-level failures
+      do not impact availability. This sample policy matches Deployments with the label
+      `distributed=required` and mutates them to spread Pods across zones.
 spec:
   rules:
     - name: spread-pods-across-nodes

--- a/other/spread_pods_across_topology.yaml
+++ b/other/spread_pods_across_topology.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       Deployments to a Kubernetes cluster with multiple availability zones often need to
       distribute those replicas to align with those zones to ensure site-level failures
-      do not impact availability. This sample policy matches Deployments with the label
+      do not impact availability. This policy policy matches Deployments with the label
       `distributed=required` and mutates them to spread Pods across zones.
 spec:
   rules:

--- a/other/sync_secrets.yaml
+++ b/other/sync_secrets.yaml
@@ -8,10 +8,11 @@ metadata:
     policies.kyverno.io/subject: Secret
     policies.kyverno.io/description: >-
       Secrets like registry credentials often need to exist in multiple
-      namespaces so pods there have access. This sample policy will copy a
-      secret called "regcred" which exists in the default namespace to
-      new namespaces when they are created. It will also push updates to
-      the copied secrets should the source secret be changed.
+      Namespaces so Pods there have access. Manually duplicating those Secrets
+      is time consuming and error prone. This sample will copy a
+      Secret called `regcred` which exists in the `default` Namespace to
+      new Namespaces when they are created. It will also push updates to
+      the copied Secrets should the source Secret be changed.
 spec:
   background: false
   rules:

--- a/other/sync_secrets.yaml
+++ b/other/sync_secrets.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       Secrets like registry credentials often need to exist in multiple
       Namespaces so Pods there have access. Manually duplicating those Secrets
-      is time consuming and error prone. This sample will copy a
+      is time consuming and error prone. This policy will copy a
       Secret called `regcred` which exists in the `default` Namespace to
       new Namespaces when they are created. It will also push updates to
       the copied Secrets should the source Secret be changed.

--- a/other/unique-ingress-paths.yaml
+++ b/other/unique-ingress-paths.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/minversion: 1.3.6
     policies.kyverno.io/description: >-
       Just like the need to ensure uniqueness among Ingress hosts, there is a need to have the paths
-      be unique as well. This sample checks an incoming Ingress to ensure its root path does not conflict with another
+      be unique as well. This policy checks an incoming Ingress to ensure its root path does not conflict with another
       root path in a different Namespace. It requires that incoming Ingress resources have a single
       rule with a single path only and assumes the root path is specified explicitly in an
       existing Ingress rule (ex., when blocking /foo/bar /foo must exist by itself and not part of

--- a/other/unique-ingress-paths.yaml
+++ b/other/unique-ingress-paths.yaml
@@ -9,9 +9,10 @@ metadata:
     policies.kyverno.io/subject: Ingress
     policies.kyverno.io/minversion: 1.3.6
     policies.kyverno.io/description: >-
-      Checks an incoming Ingress resource to ensure its root path does not conflict with another
-      root path in a different Namespace. Requires that incoming Ingress resources have a single
-      rule with a single path only. Also assumes that the root path is specified explicitly in an
+      Just like the need to ensure uniqueness among Ingress hosts, there is a need to have the paths
+      be unique as well. This sample checks an incoming Ingress to ensure its root path does not conflict with another
+      root path in a different Namespace. It requires that incoming Ingress resources have a single
+      rule with a single path only and assumes the root path is specified explicitly in an
       existing Ingress rule (ex., when blocking /foo/bar /foo must exist by itself and not part of
       /foo/baz).
 spec:

--- a/other/verify_image.yaml
+++ b/other/verify_image.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-image
+  annotations:
+    policies.kyverno.io/title: Verify Image
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.4.2
+    policies.kyverno.io/description: >-
+      Using the Cosign project, OCI images may be signed to ensure supply chain
+      security is maintained. Those signatures can be verified before pulling into
+      a cluster. This policy checks the signature of an image repo called
+      ghcr.io/kyverno/test-image-verify to ensure it has been signed by verifying
+      its signature against the provided public key. This policy serves as an illustration for
+      how to configure a similar rule and will require replacing with your image(s) and keys.
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+    - name: verify-image
+      match:
+        resources:
+          kinds:
+            - Pod
+      verifyImages:
+      - image: "ghcr.io/kyverno/test-image-verify:*"
+        key: |-
+          -----BEGIN PUBLIC KEY-----
+          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
+          5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
+          -----END PUBLIC KEY-----

--- a/pod-security/baseline/disallow-adding-capabilities/disallow-adding-capabilities.yaml
+++ b/pod-security/baseline/disallow-adding-capabilities/disallow-adding-capabilities.yaml
@@ -8,7 +8,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access.
-      Adding capabilities beyond the default set must not be allowed. This sample
+      Adding capabilities beyond the default set must not be allowed. This policy
       ensures users cannot add any additional capabilities to a Pod.
 spec:
   validationFailureAction: audit

--- a/pod-security/baseline/disallow-adding-capabilities/disallow-adding-capabilities.yaml
+++ b/pod-security/baseline/disallow-adding-capabilities/disallow-adding-capabilities.yaml
@@ -8,7 +8,8 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access.
-      Adding capabilities beyond the default set must not be allowed.
+      Adding capabilities beyond the default set must not be allowed. This sample
+      ensures users cannot add any additional capabilities to a Pod.
 spec:
   validationFailureAction: audit
   background: true

--- a/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
+++ b/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       Host namespaces (Process ID namespace, Inter-Process Communication namespace, and
       network namespace) allow access to shared information and can be used to elevate
-      privileges. Pods should not be allowed access to host namespaces. This sample ensures
+      privileges. Pods should not be allowed access to host namespaces. This policy ensures
       fields which make use of these host namespaces are set to `false`.
 spec:
   validationFailureAction: audit

--- a/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
+++ b/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
@@ -9,7 +9,8 @@ metadata:
     policies.kyverno.io/description: >-
       Host namespaces (Process ID namespace, Inter-Process Communication namespace, and
       network namespace) allow access to shared information and can be used to elevate
-      privileges. Pods should not be allowed access to host namespaces.
+      privileges. Pods should not be allowed access to host namespaces. This sample ensures
+      fields which make use of these host namespaces are set to `false`.
 spec:
   validationFailureAction: audit
   background: true

--- a/pod-security/baseline/disallow-host-path/disallow-host-path.yaml
+++ b/pod-security/baseline/disallow-host-path/disallow-host-path.yaml
@@ -7,9 +7,9 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      HostPath volumes let pods use host directories and volumes in containers.
+      HostPath volumes let Pods use host directories and volumes in containers.
       Using host resources can be used to access shared data or escalate privileges
-      and should not be allowed.
+      and should not be allowed. This sample ensures no hostPath volumes are in use.
 spec:
   validationFailureAction: audit
   background: true

--- a/pod-security/baseline/disallow-host-path/disallow-host-path.yaml
+++ b/pod-security/baseline/disallow-host-path/disallow-host-path.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       HostPath volumes let Pods use host directories and volumes in containers.
       Using host resources can be used to access shared data or escalate privileges
-      and should not be allowed. This sample ensures no hostPath volumes are in use.
+      and should not be allowed. This policy ensures no hostPath volumes are in use.
 spec:
   validationFailureAction: audit
   background: true

--- a/pod-security/baseline/disallow-host-ports/disallow-host-ports.yaml
+++ b/pod-security/baseline/disallow-host-ports/disallow-host-ports.yaml
@@ -8,7 +8,8 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Access to host ports allows potential snooping of network traffic and should not be
-      allowed, or at minimum restricted to a known list.
+      allowed, or at minimum restricted to a known list. This sample ensures the `hostPort`
+      fields are empty.
 spec:
   validationFailureAction: audit
   background: true

--- a/pod-security/baseline/disallow-host-ports/disallow-host-ports.yaml
+++ b/pod-security/baseline/disallow-host-ports/disallow-host-ports.yaml
@@ -8,7 +8,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Access to host ports allows potential snooping of network traffic and should not be
-      allowed, or at minimum restricted to a known list. This sample ensures the `hostPort`
+      allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
       fields are empty.
 spec:
   validationFailureAction: audit

--- a/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
+++ b/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
@@ -7,7 +7,8 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Privileged mode disables most security mechanisms and must not be allowed.
+      Privileged mode disables most security mechanisms and must not be allowed. This sample
+      ensures Pods do not call for privileged mode.
 spec:
   validationFailureAction: audit
   background: true

--- a/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
+++ b/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
@@ -7,7 +7,7 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Privileged mode disables most security mechanisms and must not be allowed. This sample
+      Privileged mode disables most security mechanisms and must not be allowed. This policy
       ensures Pods do not call for privileged mode.
 spec:
   validationFailureAction: audit

--- a/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.yaml
+++ b/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.yaml
@@ -7,7 +7,7 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      The default /proc masks are set up to reduce attack surface and should be required. This sample
+      The default /proc masks are set up to reduce attack surface and should be required. This policy
       ensures nothing but the default procMount can be specified.
 spec:
   validationFailureAction: audit

--- a/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.yaml
+++ b/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.yaml
@@ -7,7 +7,8 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      The default /proc masks are set up to reduce attack surface and should be required.
+      The default /proc masks are set up to reduce attack surface and should be required. This sample
+      ensures nothing but the default procMount can be specified.
 spec:
   validationFailureAction: audit
   background: true

--- a/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
@@ -8,7 +8,7 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      SELinux options can be used to escalate privileges and should not be allowed. This sample
+      SELinux options can be used to escalate privileges and should not be allowed. This policy
       ensures that the `seLinuxOptions` field is undefined.
 spec:
   validationFailureAction: audit

--- a/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
@@ -8,7 +8,8 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      SELinux options can be used to escalate privileges and should not be allowed.
+      SELinux options can be used to escalate privileges and should not be allowed. This sample
+      ensures that the `seLinuxOptions` field is undefined.
 spec:
   validationFailureAction: audit
   background: true

--- a/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
@@ -11,7 +11,7 @@ metadata:
     policies.kyverno.io/description: >-
       On supported hosts, the 'runtime/default' AppArmor profile is applied by default. 
       The default policy should prevent overriding or disabling the policy, or restrict 
-      overrides to an allowed set of profiles. This sample ensures Pods do not
+      overrides to an allowed set of profiles. This policy ensures Pods do not
       specify any other AppArmor profiles than `runtime/default`.
 spec:
   validationFailureAction: audit

--- a/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
@@ -11,7 +11,8 @@ metadata:
     policies.kyverno.io/description: >-
       On supported hosts, the 'runtime/default' AppArmor profile is applied by default. 
       The default policy should prevent overriding or disabling the policy, or restrict 
-      overrides to an allowed set of profiles.
+      overrides to an allowed set of profiles. This sample ensures Pods do not
+      specify any other AppArmor profiles than `runtime/default`.
 spec:
   validationFailureAction: audit
   background: true

--- a/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
@@ -11,7 +11,7 @@ metadata:
       host, and should be disallowed except for an allowed "safe" subset. A
       sysctl is considered safe if it is namespaced in the container or the
       Pod, and it is isolated from other Pods or processes on the same Node.
-      This sample ensures that only those "safe" subsets can be specified in
+      This policy ensures that only those "safe" subsets can be specified in
       a Pod.
 spec:
   validationFailureAction: audit

--- a/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
@@ -11,6 +11,8 @@ metadata:
       host, and should be disallowed except for an allowed "safe" subset. A
       sysctl is considered safe if it is namespaced in the container or the
       Pod, and it is isolated from other Pods or processes on the same Node.
+      This sample ensures that only those "safe" subsets can be specified in
+      a Pod.
 spec:
   validationFailureAction: audit
   background: true

--- a/pod-security/restricted/deny-privilege-escalation/deny-privilege-escalation.yaml
+++ b/pod-security/restricted/deny-privilege-escalation/deny-privilege-escalation.yaml
@@ -8,7 +8,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
-      This sample ensures the `allowPrivilegeEscalation` fields are either undefined
+      This policy ensures the `allowPrivilegeEscalation` fields are either undefined
       or set to `false`.
 spec:
   background: true

--- a/pod-security/restricted/deny-privilege-escalation/deny-privilege-escalation.yaml
+++ b/pod-security/restricted/deny-privilege-escalation/deny-privilege-escalation.yaml
@@ -8,6 +8,8 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
+      This sample ensures the `allowPrivilegeEscalation` fields are either undefined
+      or set to `false`.
 spec:
   background: true
   validationFailureAction: audit

--- a/pod-security/restricted/require-non-root-groups/require-non-root-groups.yaml
+++ b/pod-security/restricted/require-non-root-groups/require-non-root-groups.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Containers should be forbidden from running with a root primary or supplementary GID.
-      This sample ensures the `runAsGroup`, `supplementalGroups`, and `fsGroup` fields are set to a number
+      This policy ensures the `runAsGroup`, `supplementalGroups`, and `fsGroup` fields are set to a number
       greater than zero (i.e., non root).
 spec:
   background: true

--- a/pod-security/restricted/require-non-root-groups/require-non-root-groups.yaml
+++ b/pod-security/restricted/require-non-root-groups/require-non-root-groups.yaml
@@ -9,6 +9,8 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Containers should be forbidden from running with a root primary or supplementary GID.
+      This sample ensures the `runAsGroup`, `supplementalGroups`, and `fsGroup` fields are set to a number
+      greater than zero (i.e., non root).
 spec:
   background: true
   validationFailureAction: audit

--- a/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -6,7 +6,9 @@ metadata:
     policies.kyverno.io/category: Pod Security Standards (Restricted)
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-    policies.kyverno.io/description: Containers must be required to run as non-root users.
+    policies.kyverno.io/description: >-
+      Containers must be required to run as non-root users. This sample ensures
+      `runAsNonRoot` is set to `true`.
 spec:
   background: true
   validationFailureAction: audit

--- a/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -7,7 +7,7 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Containers must be required to run as non-root users. This sample ensures
+      Containers must be required to run as non-root users. This policy ensures
       `runAsNonRoot` is set to `true`.
 spec:
   background: true

--- a/pod-security/restricted/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security/restricted/restrict-seccomp/restrict-seccomp.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       The runtime default seccomp profile must be required, or only specific
-      additional profiles should be allowed. This sample ensures that only the
+      additional profiles should be allowed. This policy ensures that only the
       `runtime/default` is used as a `type`.
 spec:
   background: true

--- a/pod-security/restricted/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security/restricted/restrict-seccomp/restrict-seccomp.yaml
@@ -9,7 +9,8 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       The runtime default seccomp profile must be required, or only specific
-      additional profiles should be allowed.
+      additional profiles should be allowed. This sample ensures that only the
+      `runtime/default` is used as a `type`.
 spec:
   background: true
   validationFailureAction: audit

--- a/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       In addition to restricting HostPath volumes, the restricted pod security profile
       limits usage of non-core volume types to those defined through PersistentVolumes.
-      This sample blocks a number of different non-core volume types as named.
+      This policy blocks a number of different non-core volume types as named.
 spec:
   background: true
   validationFailureAction: audit

--- a/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -9,6 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       In addition to restricting HostPath volumes, the restricted pod security profile
       limits usage of non-core volume types to those defined through PersistentVolumes.
+      This sample blocks a number of different non-core volume types as named.
 spec:
   background: true
   validationFailureAction: audit


### PR DESCRIPTION
Closes https://github.com/kyverno/kyverno/issues/2151
Closes https://github.com/kyverno/kyverno/issues/1069
Closes #64 
Closes #78 
Closes #79 
Closes https://github.com/kyverno/kyverno/issues/2189
Closes https://github.com/kyverno/kyverno/issues/2239

Adds:

* Pod mutation policy to add imagePullSecrets
* Pod mutation policy to add imagePullPolicy=Always
* Node label creation restriction
* 5 policies to deny Pod exec operations based on the CONNECT option in Kyverno v1.4.2
* Image verification policy for Cosign in Kyverno v1.4.2
* Validate policy to drop `CAP_NET_RAW`

Changes:

* Updated descriptions for all policies.
* Fixes a policy name to be accurate
* Alters the "drop all" policy to bring into alignment with drop cap_net_raw in initContainers
* Addresses updated policy in https://github.com/kyverno/kyverno/issues/2028#issuecomment-883882285
* Updates restrict_ingress_host for latest Ingress API version and supports resources with multiple rules