### PR TITLE
Added result in the test.yaml file for rule validate-crio-sock-mount

### DIFF
--- a/best-practices/disallow_cri_sock_mount/test.yaml
+++ b/best-practices/disallow_cri_sock_mount/test.yaml
@@ -12,3 +12,7 @@ results:
     rule: validate-containerd-sock-mount
     resource: pod-with-docker-sock-mount
     status: pass
+  - policy: disallow-container-sock-mounts
+    rule: validate-crio-sock-mount
+    resource: pod-with-docker-sock-mount
+    status: pass


### PR DESCRIPTION
Signed-off-by: viveksahu26 <vivekkumarsahu650@gmail.com>

Description

In this [policy](https://github.com/kyverno/policies/blob/main/best-practices/disallow_cri_sock_mount/disallow_cri_sock_mount.yaml) 3 rules are present i.e `validate-docker-sock-mount`, `validate-containerd-sock-mount` and `validate-crio-sock-mount`. Since, the policy validates for 3 rules against the [resource](https://github.com/kyverno/policies/blob/main/best-practices/disallow_cri_sock_mount/resource.yaml). So, there should be 3 result present in the [test.yaml](https://github.com/kyverno/policies/blob/main/best-practices/disallow_cri_sock_mount/test.yaml). But in the test.yaml file result of only 2 rules are present.

Solution:-
We also need to add result for 3rd rule in the test.yaml file. 