### PR TITLE
Fix the result for restrict-image-registries

### DIFF
--- a/best-practices/restrict_image_registries/test.yaml
+++ b/best-practices/restrict_image_registries/test.yaml
@@ -7,4 +7,4 @@ results:
   - policy: restrict-image-registries
     rule: validate-registries
     resource: k8s-nginx
-    result: pass
+    result: fail


### PR DESCRIPTION
According to this policy https://github.com/kyverno/policies/blob/ef49652730b807f70d483dc74ef52fcff8a41194/best-practices/restrict_image_registries/restrict_image_registries.yaml#L31

The result should be `fail` as the image is from `ghcr.io`.