### PR TITLE
initial commit for certificate max duration

### DIFF
--- a/cert-manager/limit-duration/limit-duration.yaml
+++ b/cert-manager/limit-duration/limit-duration.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cert-manager-limit-duration
+  annotations:
+    policies.kyverno.io/title: Certificate max duration 100 days
+    policies.kyverno.io/category: Cert-Manager
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.3.6
+    policies.kyverno.io/subject: Certificate
+    policies.kyverno.io/description: k8s managed non-letsencrypt certificates have to be renewed in every 100day
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: certificate-duration-max-100days 
+    match:
+      resources:
+        kinds:
+        - Certificate
+    preconditions:
+      all:
+      - key: "{{ contains(request.object.spec.issuerRef.name, 'letsencrypt') }}"
+        operator: Equals
+        value: False
+      - key: "{{ request.object.spec.duration }}"
+        operator: NotEquals
+        value: ""
+    validate:
+      message: "certificate duration must be < than 2400h (100 days)"
+      deny:
+        conditions:
+        - key: "{{ max( [ to_number(regex_replace_all('h.*',request.object.spec.duration,'')), to_number('2400') ] ) }}"
+          operator: NotEquals
+          value: 2400

--- a/cert-manager/limit-duration/resource.yaml
+++ b/cert-manager/limit-duration/resource.yaml
@@ -1,0 +1,56 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: acme-crt-short
+spec:
+  secretName: acme-crt-secret
+  dnsNames:
+  - example.com
+  issuerRef:
+    name: acme-prod
+    kind: Issuer
+    group: cert-manager.io
+  duration: 2160h0m0s
+  renewBefore: 360h0m0s
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: acme-crt-long
+spec:
+  secretName: acme-crt-secret
+  dnsNames:
+  - example.com
+  issuerRef:
+    name: acme-prod
+    kind: Issuer
+    group: cert-manager.io
+  duration: 3400h0m0s
+  renewBefore: 360h0m0s
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: letsencrypt-crt
+spec:
+  secretName: letsencrypt-crt-secret
+  dnsNames:
+  - example.com
+  - foo.example.com
+  issuerRef:
+    name: letsencrypt-prod
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: acme-crt
+spec:
+  secretName: acme-crt-secret
+  dnsNames:
+  - example.com
+  issuerRef:
+    name: acme-prod
+    kind: Issuer
+    group: cert-manager.io

--- a/cert-manager/limit-duration/test.yaml
+++ b/cert-manager/limit-duration/test.yaml
@@ -1,0 +1,21 @@
+name: limit-duration
+policies:
+  -  limit-duration.yaml
+resources:
+  -  resource.yaml
+results:
+  - policy: cert-manager-limit-duration
+    rule: certificate-duration-max-100days 
+    resource: letsencrypt-crt
+    kind: Certificate
+    result: pass
+  - policy: cert-manager-restrict-issuer
+    rule: certificate-duration-max-100days 
+    resource: acme-crt-short
+    kind: Certificate
+    result: pass
+  - policy: cert-manager-restrict-issuer
+    rule: certificate-duration-max-100days 
+    resource: acme-crt-long
+    kind: Certificate
+    result: fail


### PR DESCRIPTION
## Related issue

n/a

## Milestone of this PR

n/a 

## What type of PR is this

/kind feature

## Proposed Changes

This policy can limit max duration for a Certificate resource created on the cluster. Useful if you cannot control in your CA the certificate duration, or you want to implement finer control.

### Proof Manifests

In resource.yaml

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My PR contains new or altered behavior to Kyverno and
- [x] I have read the [PR documentation guide]

## Further Comments

For some reason tests don't work, but applying the policy provides proper result.

![image](https://user-images.githubusercontent.com/786044/136345665-aa06a359-cd78-4ce7-a490-4683eb86aeb9.png)

Maybe I need some guidance how to handle properly missing request.object.spec.duration variable.