### PR TITLE
policy to check CM and Ingress for nginx custom snippets

### DIFF
--- a/best-practices/nginx-custom-snippets/disallow-custom-snippets.yaml
+++ b/best-practices/nginx-custom-snippets/disallow-custom-snippets.yaml
@@ -1,0 +1,40 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-ingress-nginx-custom-snippets
+  annotations:
+    policies.kyverno.io/title: Disallow Custom Snippets
+    policies.kyverno.io/category: Best Practice
+    policies.kyverno.io/subject: ConfigMap, Ingress
+    policies.kyverno.io/minversion: 1.4.3
+    policies.kyverno.io/description: >-
+      Users that can create or update ingress objects can use the custom snippets 
+      feature to obtain all secrets in the cluster (CVE-2021-25742). This policy 
+      disables allow-snippet-annotations in the ingress-nginx configuration and 
+      blocks *-snippet annotations on an Ingress.
+      See: https://github.com/kubernetes/ingress-nginx/issues/7837
+spec:
+  validationFailureAction: enforce
+  rules:
+    - name: check-config-map
+      message: "ingress-nginx allow-snippet-annotations must be set to false"
+      match:
+        resources:
+          kinds:
+            - ConfigMap      
+      validate:
+        pattern:
+          data:
+            =(allow-snippet-annotations) : "false"
+    - name: check-ingress-annotations
+      message: "ingress-nginx custom snippets are not allowed"
+      match:
+        resources:
+          kinds:
+            - Ingress      
+      validate:
+        pattern:
+          metadata:
+            =(annotations):
+              X(*-snippets): "?*"
+

--- a/best-practices/nginx-custom-snippets/resources.yaml
+++ b/best-practices/nginx-custom-snippets/resources.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+data:
+  allow-snippet-annotations: "false"
+kind: ConfigMap
+metadata:
+  name: config-map-false
+---
+apiVersion: v1
+data:
+  allow-snippet-annotations: "true"
+kind: ConfigMap
+metadata:
+  name: config-map-true
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cafe-ingress-with-snippets
+  annotations:
+    nginx.org/server-snippets: |
+      location / {
+          return 302 /coffee;
+      }      
+    nginx.org/location-snippets: |
+            add_header my-test-header test-value;
+spec:
+  rules:
+  - host: cafe.example.com
+    http:
+      paths:
+      - path: /tea
+        pathType: Prefix
+        backend:
+          service:
+            name: tea-svc
+            port:
+              number: 80
+      - path: /coffee
+        pathType: Prefix
+        backend:
+          service:
+            name: coffee-svc
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cafe-ingress
+spec:
+  rules:
+  - host: cafe.example.com
+    http:
+      paths:
+      - path: /tea
+        pathType: Prefix
+        backend:
+          service:
+            name: tea-svc
+            port:
+              number: 80
+      - path: /coffee
+        pathType: Prefix
+        backend:
+          service:
+            name: coffee-svc
+            port:
+              number: 80              

--- a/best-practices/nginx-custom-snippets/test.yaml
+++ b/best-practices/nginx-custom-snippets/test.yaml
@@ -1,0 +1,26 @@
+name: disallow_nginx_custom_snippets
+policies:
+  -  disallow-custom-snippets.yaml
+resources:
+  -  resources.yaml
+results:
+  - policy: disallow-ingress-nginx-custom-snippets
+    rule: check-config-map
+    resource: config-map-true
+    kind: ConfigMap
+    result: fail
+  - policy: disallow-ingress-nginx-custom-snippets
+    rule: check-config-map
+    resource: config-map-false
+    kind: ConfigMap
+    result: pass
+  - policy: disallow-ingress-nginx-custom-snippets
+    rule: check-ingress-annotations
+    resource: cafe-ingress-with-snippets
+    kind: Ingress
+    result: fail
+  - policy: disallow-ingress-nginx-custom-snippets
+    rule: check-ingress-annotations
+    resource: cafe-ingress
+    kind: Ingress
+    result: pass


### PR DESCRIPTION
Signed-off-by: Jim Bugwadia <jim@nirmata.com>

Policies for CVE-2021-25742:

https://github.com/kubernetes/kubernetes/issues/126811

https://discuss.kubernetes.io/t/security-advisory-cve-2021-25742-ingress-nginx-custom-snippets-allows-retrieval-of-ingress-nginx-serviceaccount-token-and-secrets-across-all-namespaces/17860