### PR TITLE
Error unknown field "message"

### DIFF
--- a/best-practices/nginx-custom-snippets/disallow-custom-snippets.yaml
+++ b/best-practices/nginx-custom-snippets/disallow-custom-snippets.yaml
@@ -17,22 +17,22 @@ spec:
   validationFailureAction: enforce
   rules:
     - name: check-config-map
-      message: "ingress-nginx allow-snippet-annotations must be set to false"
       match:
         resources:
           kinds:
             - ConfigMap      
       validate:
+        message: "ingress-nginx allow-snippet-annotations must be set to false"
         pattern:
           data:
             =(allow-snippet-annotations) : "false"
     - name: check-ingress-annotations
-      message: "ingress-nginx custom snippets are not allowed"
       match:
         resources:
           kinds:
             - Ingress      
       validate:
+        message: "ingress-nginx custom snippets are not allowed"
         pattern:
           metadata:
             =(annotations):


### PR DESCRIPTION
Resolve the error 
error validating data: ValidationError(ClusterPolicy.spec.rules[0]): unknown field "message" in io.kyverno.v1.ClusterPolicy.spec.rules; if you choose to ignore these errors, turn validation off with --validate=false

/kind bug

