### PR TITLE
update seccomp to match PSS

### DIFF
--- a/pod-security/restricted/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security/restricted/restrict-seccomp/restrict-seccomp.yaml
@@ -8,10 +8,9 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      The runtime default seccomp profile must be required, or only specific
-      additional profiles should be allowed. This policy, requiring Kubernetes
-      v1.19 or later, ensures that only the `RuntimeDefault` or `Localhost` is
-      used as a `type` and that it is not unset.
+      The seccomp profile must not be explicitly set to Unconfined. This policy, 
+      requiring Kubernetes v1.19 or later, ensures that seccomp is not set or 
+      set to `RuntimeDefault` or `Localhost`.
 spec:
   background: true
   validationFailureAction: enforce
@@ -25,38 +24,24 @@ spec:
       message: >-
         Use of custom Seccomp profiles is disallowed. The fields
         spec.securityContext.seccompProfile.type,
-        spec.containers[*].securityContext.seccompProfile.type, and
-        spec.initContainers[*].securityContext.seccompProfile.type
-        must be set to `RuntimeDefault` or `Localhost`.
-      anyPattern:
-      - spec:
-          securityContext:
-            seccompProfile:
+        spec.containers[*].securityContext.seccompProfile.type,
+        spec.initContainers[*].securityContext.seccompProfile.type, and
+        spec.ephemeralContainers[*].securityContext.seccompProfile.type
+        must not be set, or set to `RuntimeDefault` or `Localhost`.
+      pattern:
+       spec:
+        =(securityContext):
+          =(seccompProfile):
+            type: "RuntimeDefault | Localhost"      
+        containers:
+        - =(securityContext):
+            =(seccompProfile):
               type: "RuntimeDefault | Localhost"
-      - spec:
-          containers:
-          - securityContext:
-              seccompProfile:
-                type: "RuntimeDefault | Localhost"
-  - name: restrict-seccomp-initcontainers
-    match:
-      resources:
-        kinds:
-        - Pod
-    validate:
-      message: >-
-        Use of custom Seccomp profiles is disallowed. The fields
-        spec.securityContext.seccompProfile.type,
-        spec.containers[*].securityContext.seccompProfile.type, and
-        spec.initContainers[*].securityContext.seccompProfile.type
-        must be set to `RuntimeDefault` or `Localhost`.
-      anyPattern:
-      - spec:
-          securityContext:
-            seccompProfile:
+        =(initContainers):
+        - =(securityContext):
+            =(seccompProfile):
               type: "RuntimeDefault | Localhost"
-      - spec:
-          =(initContainers):
-          - securityContext:
-              seccompProfile:
-                type: "RuntimeDefault | Localhost"
+        =(ephemeralContainers):
+        - =(securityContext):
+            =(seccompProfile):
+              type: "RuntimeDefault | Localhost"

--- a/pod-security/restricted/restrict-seccomp/test.yaml
+++ b/pod-security/restricted/restrict-seccomp/test.yaml
@@ -8,7 +8,7 @@ results:
     rule: restrict-seccomp
     resource: seccomp-pod-spec-undefined
     kind: Pod
-    result: fail
+    result: pass
   - policy:  restrict-seccomp
     rule: restrict-seccomp
     resource: seccomp-pod-spec-unconfined
@@ -28,14 +28,14 @@ results:
     rule: restrict-seccomp
     resource: seccomp-pod-cont2-inconsistent1
     kind: Pod
-    result: fail
+    result: pass
   - policy:  restrict-seccomp
-    rule: restrict-seccomp-initcontainers
+    rule: restrict-seccomp
     resource: seccomp-pod-initcont-undefined
     kind: Pod
-    result: fail
+    result: pass
   - policy:  restrict-seccomp
-    rule: restrict-seccomp-initcontainers
+    rule: restrict-seccomp
     resource: seccomp-pod-initcont-unconfined
     kind: Pod
     result: fail
@@ -60,12 +60,12 @@ results:
     kind: Pod
     result: pass
   - policy:  restrict-seccomp
-    rule: restrict-seccomp-initcontainers
+    rule: restrict-seccomp
     resource: seccomp-good-pod-initcont
     kind: Pod
     result: pass
   - policy:  restrict-seccomp
-    rule: restrict-seccomp-initcontainers
+    rule: restrict-seccomp
     resource: seccomp-good-pod-initcont1
     kind: Pod
     result: pass


### PR DESCRIPTION
Signed-off-by: Jim Bugwadia <jim@nirmata.com>

The seccomp checks did not match the PSS definiton: https://kubernetes.io/docs/concepts/security/pod-security-standards/


```
Seccomp profile must not be explicitly set to Unconfined.

Restricted Fields

spec.securityContext.seccompProfile.type
spec.containers[*].securityContext.seccompProfile.type
spec.initContainers[*].securityContext.seccompProfile.type
spec.ephemeralContainers[*].securityContext.seccompProfile.type

Allowed Values
- Undefined/nil
- RuntimeDefault
- Localhost

```