### PR TITLE
Update lifetime policy to remove deprecated Duration* operator

### DIFF
--- a/other/pod_lifetime_annotation/enforce_pod_duration.yaml
+++ b/other/pod_lifetime_annotation/enforce_pod_duration.yaml
@@ -25,5 +25,5 @@ spec:
       deny:
         conditions:
         - key: "{{ request.object.metadata.annotations.\"pod.kubernetes.io/lifetime\" }}"
-          operator: DurationGreaterThan
+          operator: GreaterThan
           value: "8h"


### PR DESCRIPTION
Signed-off-by: Trey Dockendorf <tdockendorf@osc.edu>

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
> /kind bug

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->

Noticed these warnings when running tests from Kyverno:

```
Executing pod-lifetime...
applying 1 policy to 2 resources... 
I1103 15:52:36.821740    3439 operator.go:70] EngineValidate "msg"="DEPRECATED: The Duration* operators have been replaced with the other existing operators that now also support duration values" "kind"="Pod" "name"="test-lifetime-pass" "namespace"="test" "policy"="pod-lifetime" "rule"="pods-lifetime" "operator"="durationgreaterthan"
I1103 15:52:36.822442    3439 operator.go:70] EngineValidate "msg"="DEPRECATED: The Duration* operators have been replaced with the other existing operators that now also support duration values" "kind"="Pod" "name"="test-lifetime-fail" "namespace"="test" "policy"="pod-lifetime" "rule"="pods-lifetime" "operator"="durationgreaterthan"
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] My PR contains new or altered behavior to Kyverno and
  
  - [] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
