### PR TITLE
Adds policy that only allows cluster-unique UIDs per Workload

### DIFF
--- a/other/require_unique_uid_per_workload/require_unique_uid_per_workload.yaml
+++ b/other/require_unique_uid_per_workload/require_unique_uid_per_workload.yaml
@@ -1,0 +1,48 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-unique-uid-per-workload
+  annotations:
+    policies.kyverno.io/category: other
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Two distinct workloads should not share a UID so that in a multitenant environment, applications 
+      from different projects never run as the same user ID. When using persistent storage, 
+      any files created by applications will also have different ownership in the file system.
+
+      Running processes for applications as different user IDs means that if a security 
+      vulnerability were ever discovered in the underlying container runtime, and an application 
+      were able to break out of the container to the host, they would not be able to interact 
+      with processes owned by other users, or from other applications, in other projects.
+    kyverno.io/kyverno-version: v1.4.3
+    kyverno.io/kubernetes-version: v1.20
+spec:
+  background: false
+  validationFailureAction: audit
+  rules:
+  - name: require-unique-uid
+    match:
+      resources:
+        kinds:
+        - Pod
+    context:
+      - name: uidsAllPodsExceptSameOwnerAsRequestObject
+        apiCall:
+          urlPath: "/api/v1/pods"
+          # Gets UIDs of all Pods, excluding those of pods whos ownerReference
+          # references the same owner as the policy subject (request.object)
+          # UIDs need to be strings, because the "In" operator (see below in the conditions Block) only works on lists of strings.
+          # see https://github.com/kyverno/website/blob/b08d6d8356bd46b8d55ab52324a9cfa243399b01/content/en/docs/Writing%20policies/preconditions.md?plain=1#L154
+          jmesPath: "items[?@.metadata.ownerReferences == false || metadata.ownerReferences[?uid != '{{ request.object.metadata.keys(@).contains(@, 'ownerReferences') && request.object.metadata.ownerReferences[0].uid }}']].spec.containers[].securityContext.to_string(runAsUser)"
+    preconditions:
+    - key: "{{ request.operation }}"
+      operator: Equals
+      value: "CREATE"
+    validate:
+      message: "Only cluster-unique UIDs are allowed"
+      deny:
+        conditions:
+        # this checks uids for ALL containers in any pod of the workload
+        - key: "{{ request.object.spec.containers[].securityContext.to_string(runAsUser) }}"
+          operator: In
+          value: "{{ uidsAllPodsExceptSameOwnerAsRequestObject }}"


### PR DESCRIPTION
Hi all 👋,

I've been trying to write a policy that only allows cluster-unique UIDs per Workload. More details below:


## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
-->
/kind feature


## Proposed Changes
Add a policy that only allows cluster-unique UIDs per workload.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:
-->

### Example 1: Two Deployments want to use the same UID
Apply the Policy (set on enforce):
```
$ kubectl create -f require_unique_uid_per_workload.yaml
```

Create a deployment which shall `runAsUser` 1337
```
$ cat << 'EOF' | kubectl create -f - 
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: server-1
  name: server-1
spec:
  replicas: 1
  selector:
    matchLabels:
      app: server-1
  template:
    metadata:
      labels:
        app: server-1
    spec:
      containers:
      - image: nginxinc/nginx-unprivileged
        name: hello-1
        securityContext:
          runAsUser: 1337
        resources: {}
EOF
```
Observe that a pod can be created.

Create another deployment `server-2` which shall `runAsUser` 1337.
```
$ cat << 'EOF' | kubectl create -f - 
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: server-2
  name: server-2
spec:
  replicas: 1
  selector:
    matchLabels:
      app: server-2
  template:
    metadata:
      labels:
        app: server-2
    spec:
      containers:
      - image: nginxinc/nginx-unprivileged
        name: hello-2
        securityContext:
          runAsUser: 1337
        resources: {}
EOF
```
Observe that a pod can not be created by `server-2` because the UID `1337` is already in use in your cluster by `server-1`. 

However, you can still increase the number of replicas on `server-1`!
```
$ kubectl scale --replicas=3 deployment/server-1
```

### Example 2: Pod wants to use UID already in use by a deployment
Apply the Policy (set on enforce):
```
$ kubectl create -f require_unique_uid_per_workload.yaml
```

Create another deployment `server-3` which shall `runAsUser` 42.
```
$ cat << 'EOF' | kubectl create -f - 
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: server-3
  name: server-3
spec:
  replicas: 1
  selector:
    matchLabels:
      app: server-3
  template:
    metadata:
      labels:
        app: server-3
    spec:
      containers:
      - image: nginxinc/nginx-unprivileged
        name: hello-3
        securityContext:
          runAsUser: 42
        resources: {}
EOF
```
Observe, that a pod can be created, as the UID 42 is currently not used.

Create a Pod which shall `runAsUser` 42
```
$ cat << 'EOF' | kubectl create -f - 
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: server
  name: hello-no-owner
spec:
  containers:
  - image: nginxinc/nginx-unprivileged
    name: hello-no-owner
    securityContext:
      runAsUser: 42
EOF
```
Observe that this pod cannot be created.

````
Error from server: error when creating "STDIN": admission webhook "validate.kyverno.svc" denied the request: 

resource Pod/kyverno-example-namespace/hello-no-owner was blocked due to the following policies

require-unique-uid-per-workload:
  require-unique-uid: Only cluster-unique UIDs are allowed
````
🎉 You made it. Don't forget to clean up ;) 
```
k delete clusterpolicy require-unique-uid-per-workload
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Further Comments

Why? I've borrowed [this explanation](https://github.com/openshift-evangelists/openshift-cookbook/blob/099cdc56dd339b78993c7ca84d5f75fa5a2c7b51/users-and-role-based-access-control/why-do-my-applications-run-as-a-random-user-id.md?plain=1#L18-L20):

> Running processes for applications as different user IDs means that if a security vulnerability were ever discovered in the underlying container runtime, and an application were able to break out of the container to the host, they would not be able to interact with processes owned by other users, or from other applications, in other projects.

> When using persistent storage, any files created by applications will also have different ownership in the file system.

I'm also planning to write a mutating policy to accompany this one. The mutating policy will assign new workloads a cluster-unique UID.

What do you think about this in general and specifically about my implementation:
- Is there an easier way to do this than with my [JEMSPath of doom](https://github.com/kyverno/policies/pull/176/files#diff-48a7b08113fbf248aba682162b123168ecbf2853108dedc23c0e74314d2fea30R36)?
- Will this kind of policy make my API unresponsive (as it often queries all pods)?
- While testing, I've found that when creating two Deployments with pods that use the same uid one after the other the policy works as intended. The creation of pods by the second deployment is denied by the policy. However, when applying two deployments which want to use the same value for runAsUser at once the policy does not work (i guess this is a timing issue...). Any ideas how could I mitigate this issue?
