### PR TITLE
Test policy in pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: Policy Test
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - name: Get Kyverno
+        run: |
+          curl -sL `
+            curl -sL https://api.github.com/repos/kyverno/kyverno/releases/latest \
+            | jq -r '.assets[].browser_download_url' \
+            | grep linux_x86_64 \
+          ` | tar xvz -C /usr/local/bin
+
+      - name: Kyverno test
+        run: kyverno test .
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,12 @@ name: Policy Test
 on:
   push:
     branches:
-      - 'main'
+      - main
+      - release*
   pull_request:
     branches:
-      - 'main'
+      - main
+      - release*
 
 jobs:
   build:


### PR DESCRIPTION
## Related issue
n/a

## Milestone of this PR
n/a
## What type of PR is this

> /kind feature

## Proposed Changes

Use github actions to test the policies (also use dependabot to keep actions up to date)

Note this did reveal that one of the policies doesn't pass against the current release cli, it does pass in v1.5.2-rc1 though.
I could make this pull the latest pre-release if one exists, but that feels a bit fragile, ideally the policies repo should match what the current release can do?

### Proof Manifests

n/a

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
  
  - [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

## Further Comments