### PR TITLE
Mark net.ipv4.ip_unprivileged_port_start as safe

### DIFF
--- a/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
@@ -27,10 +27,10 @@ spec:
           Setting additional sysctls above the allowed type is disallowed.
           The field spec.securityContext.sysctls must not use any other names
           than 'kernel.shm_rmid_forced', 'net.ipv4.ip_local_port_range',
-          'net.ipv4.tcp_syncookies' and 'net.ipv4.ping_group_range'.
+          'net.ipv4.tcp_syncookies', 'net.ipv4.ping_group_range' and 'net.ipv4.ip_unprivileged_port_start'.
         pattern:
           spec:
             =(securityContext):
               =(sysctls):
-                - name: "kernel.shm_rmid_forced | net.ipv4.ip_local_port_range | net.ipv4.tcp_syncookies | net.ipv4.ping_group_range"
+                - name: "kernel.shm_rmid_forced | net.ipv4.ip_local_port_range | net.ipv4.tcp_syncookies | net.ipv4.ping_group_range | net.ipv4.ip_unprivileged_port_start"
                   value: "?*"


### PR DESCRIPTION
/kind feature

## Proposed Changes

`net.ipv4.ip_unprivileged_port_start` has been [marked as safe](https://github.com/kubernetes/kubernetes/pull/103326) in Kubernetes, so I propose to do the same.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My PR contains new or altered behavior to Kyverno and
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.

