### PR TITLE
fix: forget to add match keyword

### DIFF
--- a/other/verify_image_gcpkms.yaml
+++ b/other/verify_image_gcpkms.yaml
@@ -1,0 +1,30 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-image-gcpkms
+  annotations:
+    policies.kyverno.io/title: Verify Image GCP KMS
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.4.2
+    policies.kyverno.io/description: >-
+      Using the Cosign project, OCI images may be signed to ensure supply chain
+      security is maintained. Those signatures can be verified before pulling into
+      a cluster. This policy checks the signature of an image repo called
+      ghcr.io/kyverno/test-verify-image to ensure it has been signed by verifying
+      its signature against the provided public key. This policy serves as an illustration for
+      how to configure a similar rule and will require replacing with your image(s) and keys.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+    - name: verify-image
+      match:
+        any:
+          resources:
+            kinds:
+            - Pod
+      verifyImages:
+        - image: "ghcr.io/kyverno/test-verify-image:*"
+          key: gcpkms://projects/someproject/locations/us-central1/keyRings/foo/cryptoKeys/bug/versions/1

--- a/other/verify_image_k8s.yaml
+++ b/other/verify_image_k8s.yaml
@@ -1,0 +1,30 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-image-k8s
+  annotations:
+    policies.kyverno.io/title: Verify Image
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.4.2
+    policies.kyverno.io/description: >-
+      Using the Cosign project, OCI images may be signed to ensure supply chain
+      security is maintained. Those signatures can be verified before pulling into
+      a cluster. This policy checks the signature of an image repo called
+      ghcr.io/kyverno/test-verify-image to ensure it has been signed by verifying
+      its signature against the provided public key. This policy serves as an illustration for
+      how to configure a similar rule and will require replacing with your image(s) and keys.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+    - name: verify-image
+      match:
+        any:
+          resources:
+            kinds:
+            - Pod
+      verifyImages:
+        - image: "ghcr.io/kyverno/test-verify-image:*"
+          key: default/cosign-keys


### PR DESCRIPTION
feat: add two new verify image policies
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

We forgot to add match: keyword.

cc: @chipzoller
<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
