### PR TITLE
feat: add runAsNonRoot:true to default

### DIFF
--- a/other/add-default-securitycontext/add-default-securitycontext.yaml
+++ b/other/add-default-securitycontext/add-default-securitycontext.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/description: >-
       A Pod securityContext entry defines fields such as the user and group which should be used to run the Pod.
       Sometimes choosing default values for users rather than blocking is a better alternative to not impede
-      such Pod definitions. This policy will mutate a Pod to set `runAsUser`, `runAsGroup`, and `fsGroup` fields
+      such Pod definitions. This policy will mutate a Pod to set `runAsNonRoot`, runAsUser`, `runAsGroup`, and `fsGroup` fields
       within the Pod securityContext if they are not already set.
 spec:
   rules:
@@ -22,6 +22,7 @@ spec:
       patchStrategicMerge:
         spec:
           securityContext:
+            +(runAsNonRoot): true
             +(runAsUser): 1000
             +(runAsGroup): 3000
             +(fsGroup): 2000

--- a/other/add-default-securitycontext/patchedResource.yaml
+++ b/other/add-default-securitycontext/patchedResource.yaml
@@ -9,6 +9,7 @@ spec:
   - name: nginx
     image: nginx:latest
   securityContext:
+    runAsNonRoot: true
     runAsUser: 1000
     runAsGroup: 3000
     fsGroup: 2000


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

<!--
What does this PR do?
-->

I noticed that we have a check for runAsNonRoot in validation rules but we don't have any mutation for that.

This PR will fix that.

kindly ping @chipzoller

Does it make sense? 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
