### PR TITLE
remove patch for validationFailureAction

### DIFF
--- a/pod-security/baseline/kustomization.yaml
+++ b/pod-security/baseline/kustomization.yaml
@@ -10,11 +10,4 @@ resources:
   - restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
   - restrict-seccomp/restrict-seccomp.yaml
   - restrict-sysctls/restrict-sysctls.yaml
-
-patches:
-  - patch: |-
-      - op: replace
-        path: /spec/validationFailureAction
-        value: enforce
-    target:
-      kind: ClusterPolicy
+  


### PR DESCRIPTION
Signed-off-by: Jim Bugwadia <jim@nirmata.com>

## Related Issue(s)

n/a

## Description

Remove Kustomization so pod security policies are installed with a default validationFailureAction of audit. 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
