### PR TITLE
add openshift unique route policy

### DIFF
--- a/openshift/unique-routes/kyverno-test.yaml
+++ b/openshift/unique-routes/kyverno-test.yaml
@@ -1,0 +1,18 @@
+---
+name: unique-routes-tests
+policies:
+  - unique-routes.yaml
+resources:
+  - resources.yaml
+variables: mock.yaml
+results:
+  - policy: unique-routes
+    rule: require-unique-routes
+    resource: hello-openshift-good
+    kind: Route
+    result: pass
+  - policy: unique-routes
+    rule: require-unique-routes
+    resource: hello-openshift-bad
+    kind: Route
+    result: fail

--- a/openshift/unique-routes/mock.yaml
+++ b/openshift/unique-routes/mock.yaml
@@ -1,0 +1,8 @@
+---
+# this will mock the apiCall
+policies:
+  - name: unique-routes
+    rules:
+      - name: require-unique-routes
+        values:
+          hosts: "[\"hello-openshift-bad.mydomain\"]"

--- a/openshift/unique-routes/resources.yaml
+++ b/openshift/unique-routes/resources.yaml
@@ -1,0 +1,23 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hello-openshift-good
+spec:
+  host: hello-openshift-good.mydomain
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: hello-openshift
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hello-openshift-bad
+spec:
+  host: hello-openshift-bad.mydomain
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: hello-openshift

--- a/openshift/unique-routes/unique-routes.yaml
+++ b/openshift/unique-routes/unique-routes.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: unique-routes
+  annotations:
+    policies.kyverno.io/title: Require unique host names in OpenShift routes
+    policies.kyverno.io/category: OpenShift
+    policies.kyverno.io/severity: high
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.20"
+    policies.kyverno.io/subject: Route
+    policies.kyverno.io/description: |-
+      An Route host is a URL at which services may be made available externally. In most cases,
+      these hosts should be unique across the cluster to ensure no routing conflicts occur.
+      This policy checks an incoming Route resource to ensure its hosts are unique to the cluster.
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+    - name: require-unique-routes
+      match:
+        any:
+          - resources:
+              kinds:
+                - route.openshift.io/v1/Route
+      context:
+        - name: hosts
+          apiCall:
+            urlPath: "/apis/route.openshift.io/v1/Routes"
+            jmesPath: "items[].spec.host"
+      preconditions:
+        all:
+          - key: "{{ request.operation }}"
+            operator: NotEquals
+            value: "DELETE"
+      validate:
+        message: >-
+          The Route host name must be unique.
+        deny:
+          conditions:
+            all:
+              - key: "{{ request.object.spec.host }}"
+                operator: In
+                value: "{{ hosts }}"

--- a/openshift/unique-routes/unique-routes.yaml
+++ b/openshift/unique-routes/unique-routes.yaml
@@ -42,5 +42,5 @@ spec:
           conditions:
             all:
               - key: "{{ request.object.spec.host }}"
-                operator: In
+                operator: AnyIn
                 value: "{{ hosts }}"


### PR DESCRIPTION
## Description

Just as the unique Ingress policy, there should also be the openshift equivalent for route hosts.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
