### PR TITLE
Added team namespace name validation policy

### DIFF
--- a/openshift/team-validate-ns-name/kyverno-test.yaml
+++ b/openshift/team-validate-ns-name/kyverno-test.yaml
@@ -1,0 +1,16 @@
+name: team-validate-ns-name
+policies:
+  - team-validate-ns-name.yaml
+resources:
+  - resource.yaml
+results:
+  - policy: team-validate-ns-name
+    rule: team-validate-ns-name
+    resource: team1-test
+    kind: Namespace
+    result: pass
+  - policy: team-validate-ns-name
+    rule: team-validate-ns-name
+    resource: test-namespace
+    kind: Namespace
+    result: fail

--- a/openshift/team-validate-ns-name/resource.yaml
+++ b/openshift/team-validate-ns-name/resource.yaml
@@ -1,0 +1,12 @@
+### Namespace good
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team1-test
+### Namespace bad
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace

--- a/openshift/team-validate-ns-name/team-validate-ns-name.yaml
+++ b/openshift/team-validate-ns-name/team-validate-ns-name.yaml
@@ -1,0 +1,38 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: team-validate-ns-name
+  annotations:
+    policies.kyverno.io/title: Validate Team Namespace Schema
+    policies.kyverno.io/category: OpenShift
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/subject: Namespace
+    policies.kyverno.io/description: >-
+      Denies the creation of a namespace if the name of the namespace does
+      not follow a specific naming defined by the cluster admins.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+  - name: team-validate-ns-name
+    match:
+      any:
+      - resources:
+          kinds:
+            - Namespace
+            - ProjectRequest
+            - Project
+        subjects:
+        - kind: Group
+          name: "system:authenticated"
+    validate:
+      message: The only names approved for your namespaces are the ones starting by {{request.userInfo.groups[?contains(@,':') == `false`]}}-*
+      deny:
+        conditions:
+          any:
+          - key: "{{request.object.metadata.name}}"
+            operator: AnyNotIn
+            value: "{{ request.userInfo.groups[?contains(@,':') == `false`][].join('-', [@, '*']) }}"


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

Adds a policy that validates the name of namespaces/projects created by all authenticated users and only allows namespaces names that start with one of the user's groups followed by a hyphen and something else.

This policy is also great to see how you can work with different JMESpath filters.

I added tests for the policy but I'm not completely sure those make sense since this policy is kind of dynamic in terms of validation (different for each user depending on their groups).

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
