### PR TITLE
update check-deprecated-apis policy to use wildcard kind + preconditi…

### DIFF
--- a/best-practices/check_deprecated_apis.yaml
+++ b/best-practices/check_deprecated_apis.yaml
@@ -14,12 +14,18 @@ metadata:
       ConfigMap to remove filters.
 spec:
   validationFailureAction: audit
-  background: true
+  background: false
   rules:
   - name: validate-v1-22-removals
     match:
       resources:
         kinds:
+        - "*"
+    preconditions:
+      all:
+      - key: "{{request.object.apiVersion}}"
+        operator: In
+        value:
         - admissionregistration.k8s.io/v1beta1/ValidatingWebhookConfiguration
         - admissionregistration.k8s.io/v1beta1/MutatingWebhookConfiguration
         - apiextensions.k8s.io/v1beta1/CustomResourceDefinition
@@ -51,6 +57,12 @@ spec:
     match:
       resources:
         kinds:
+        - "*"
+    preconditions:
+      all:
+      - key: "{{request.object.apiVersion}}"
+        operator: In
+        value:
         - batch/v1beta1/CronJob
         - discovery.k8s.io/v1beta1/EndpointSlice
         - events.k8s.io/v1beta1/Event


### PR DESCRIPTION
## Related Issue(s)

[https://github.com/kyverno/policies/issues/312](https://github.com/kyverno/policies/issues/312)

## Description

This pr is intended to make the `check-deprecated-apis` policy more user friendly/passive by allowing it to work on a k8s versions that no longer has the api's. For example this ClusterPolicy would fail to apply on k8s > v1.22.x as the apis no longer exist which then causes other issues and other policies not being applied.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
