### PR TITLE
Add other/restrict-ingress-defaultbackend policy 

### DIFF
--- a/other/restrict_ingress_defaultbackend/kyverno-test.yaml
+++ b/other/restrict_ingress_defaultbackend/kyverno-test.yaml
@@ -1,0 +1,18 @@
+name: restrict-node-defaultbackend
+policies:
+  -  restrict_ingress_defaultbackend.yaml
+resources:
+  -  resource.yaml
+results:
+  - policy: restrict-ingress-defaultbackend
+    rule: restrict-ingress-defaultbackend
+    resource: sample-app-1
+    kind: Ingress
+    namespace: default
+    result: fail  
+  - policy: restrict-ingress-defaultbackend
+    rule: restrict-ingress-defaultbackend
+    resource: sample-app-2
+    kind: Ingress
+    namespace: default
+    result: pass

--- a/other/restrict_ingress_defaultbackend/resource.yaml
+++ b/other/restrict_ingress_defaultbackend/resource.yaml
@@ -1,0 +1,62 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sample-app-1
+  namespace: default
+spec:
+  defaultBackend:
+    service:
+      name: sample-backend
+      port:
+        number: 80
+  rules:
+  - host: sample-frontend.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: sample-frontend
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - sample-frontend.example.com
+    secretName: sample-frontend-tls
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sample-app-2
+  namespace: default
+spec:
+  rules:
+  - host: sample-backend.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: sample-backend
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific
+  - host: sample-frontend.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: sample-frontend
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - sample-backend.example.com
+    secretName: sample-backend-tls
+  - hosts:
+    - sample-frontend.example.com
+    secretName: sample-frontend-tls

--- a/other/restrict_ingress_defaultbackend/restrict_ingress_defaultbackend.yaml
+++ b/other/restrict_ingress_defaultbackend/restrict_ingress_defaultbackend.yaml
@@ -24,7 +24,7 @@ spec:
   - name: restrict-ingress-defaultbackend
     match:
       any:
-        resources:
+      - resources:
           kinds:
           - Ingress
     validate:

--- a/other/restrict_ingress_defaultbackend/restrict_ingress_defaultbackend.yaml
+++ b/other/restrict_ingress_defaultbackend/restrict_ingress_defaultbackend.yaml
@@ -1,0 +1,34 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-ingress-defaultbackend
+  annotations:
+    policies.kyverno.io/title: Restrict Ingress defaultBackend
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: high
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.19-1.24"
+    policies.kyverno.io/subject: Ingress
+    policies.kyverno.io/description: >-
+      An Ingress with no rules sends all traffic to a single default backend. The defaultBackend
+      is conventionally a configuration option of the Ingress controller and is not specified in
+      your Ingress resources. If none of the hosts or paths match the HTTP request in the Ingress
+      objects, the traffic is routed to your default backend. In a multi-tenant environment, you
+      want users to use explicit hosts, they should not be able to overwrite the global default backend
+      service.
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+  - name: restrict-ingress-defaultbackend
+    match:
+      any:
+        resources:
+          kinds:
+          - Ingress
+    validate:
+      message: Setting the defaultBackend field is prohibited.
+      pattern:
+        spec:
+          X(defaultBackend): "null"

--- a/other/restrict_ingress_defaultbackend/restrict_ingress_defaultbackend.yaml
+++ b/other/restrict_ingress_defaultbackend/restrict_ingress_defaultbackend.yaml
@@ -16,7 +16,7 @@ metadata:
       your Ingress resources. If none of the hosts or paths match the HTTP request in the Ingress
       objects, the traffic is routed to your default backend. In a multi-tenant environment, you
       want users to use explicit hosts, they should not be able to overwrite the global default backend
-      service.
+      service. This policy prohibits the use of the defaultBackend field.
 spec:
   validationFailureAction: audit
   background: true


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->
Fixes https://github.com/kyverno/policies/issues/322

## Description

<!--
What does this PR do?
-->
Create a sample policy to prevent usage of the Ingress defaultBackend field.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
