### PR TITLE
applying fix to check-deprecated-apis policy

### DIFF
--- a/best-practices/check_deprecated_apis.yaml
+++ b/best-practices/check_deprecated_apis.yaml
@@ -6,6 +6,7 @@ metadata:
     policies.kyverno.io/title: Check deprecated APIs
     policies.kyverno.io/category: Best Practices
     policies.kyverno.io/subject: Kubernetes APIs
+    policies.kyverno.io/minversion: 1.6.2
     policies.kyverno.io/description: >-
       Kubernetes APIs are sometimes deprecated and removed after a few releases.
       As a best practice, older API versions should be replaced with newer versions.
@@ -13,7 +14,7 @@ metadata:
       Note that checking for some of these resources may require modifying the Kyverno
       ConfigMap to remove filters.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-v1-22-removals

--- a/best-practices/check_deprecated_apis.yaml
+++ b/best-practices/check_deprecated_apis.yaml
@@ -13,41 +13,52 @@ metadata:
       Note that checking for some of these resources may require modifying the Kyverno
       ConfigMap to remove filters.
 spec:
-  validationFailureAction: audit
-  background: false
+  validationFailureAction: enforce
+  background: true
   rules:
   - name: validate-v1-22-removals
     match:
       resources:
         kinds:
-        - "*"
+        - admissionregistration.k8s.io/*/ValidatingWebhookConfiguration
+        - admissionregistration.k8s.io/*/MutatingWebhookConfiguration
+        - apiextensions.k8s.io/*/CustomResourceDefinition
+        - apiregistration.k8s.io/*/APIService
+        - authentication.k8s.io/*/TokenReview
+        - authorization.k8s.io/*/SubjectAccessReview
+        - authorization.k8s.io/*/LocalSubjectAccessReview
+        - authorization.k8s.io/*/SelfSubjectAccessReview
+        - certificates.k8s.io/*/CertificateSigningRequest
+        - coordination.k8s.io/*/Lease
+        - extensions/*/Ingress
+        - networking.k8s.io/*/Ingress
+        - networking.k8s.io/*/IngressClass
+        - rbac.authorization.k8s.io/*/ClusterRole
+        - rbac.authorization.k8s.io/*/ClusterRoleBinding
+        - rbac.authorization.k8s.io/*/Role
+        - rbac.authorization.k8s.io/*/RoleBinding
+        - scheduling.k8s.io/*/PriorityClass
+        - storage.k8s.io/*/CSIDriver
+        - storage.k8s.io/*/CSINode
+        - storage.k8s.io/*/StorageClass
+        - storage.k8s.io/*/VolumeAttachment
     preconditions:
       all:
       - key: "{{request.object.apiVersion}}"
-        operator: In
+        operator: AnyIn
         value:
-        - admissionregistration.k8s.io/v1beta1/ValidatingWebhookConfiguration
-        - admissionregistration.k8s.io/v1beta1/MutatingWebhookConfiguration
-        - apiextensions.k8s.io/v1beta1/CustomResourceDefinition
-        - apiregistration.k8s.io/v1beta1/APIService
-        - authentication.k8s.io/v1beta1/TokenReview
-        - authorization.k8s.io/v1beta1/SubjectAccessReview
-        - authorization.k8s.io/v1beta1/LocalSubjectAccessReview
-        - authorization.k8s.io/v1beta1/SelfSubjectAccessReview
-        - certificates.k8s.io/v1beta1/CertificateSigningRequest
-        - coordination.k8s.io/v1beta1/Lease
-        - extensions/v1beta1/Ingress
-        - networking.k8s.io/v1beta1/Ingress
-        - networking.k8s.io/v1beta1/IngressClass
-        - rbac.authorization.k8s.io/v1beta1/ClusterRole
-        - rbac.authorization.k8s.io/v1beta1/ClusterRoleBinding
-        - rbac.authorization.k8s.io/v1beta1/Role
-        - rbac.authorization.k8s.io/v1beta1/RoleBinding
-        - scheduling.k8s.io/v1beta1/PriorityClass
-        - storage.k8s.io/v1beta1/CSIDriver
-        - storage.k8s.io/v1beta1/CSINode
-        - storage.k8s.io/v1beta1/StorageClass
-        - storage.k8s.io/v1beta1/VolumeAttachment
+        - admissionregistration.k8s.io/v1beta1
+        - apiextensions.k8s.io/v1beta1
+        - apiregistration.k8s.io/v1beta1
+        - authentication.k8s.io/v1beta1
+        - authorization.k8s.io/v1beta1
+        - certificates.k8s.io/v1beta1
+        - coordination.k8s.io/v1beta1
+        - extensions/v1beta1
+        - networking.k8s.io/v1beta1
+        - rbac.authorization.k8s.io/v1beta1
+        - scheduling.k8s.io/v1beta1
+        - storage.k8s.io/v1beta1
     validate:
       message: >-
         {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated and will be removed in v1.22.
@@ -57,18 +68,22 @@ spec:
     match:
       resources:
         kinds:
-        - "*"
+        - batch/*/CronJob
+        - discovery.k8s.io/*/EndpointSlice
+        - events.k8s.io/*/Event
+        - policy/*/PodDisruptionBudget
+        - policy/*/PodSecurityPolicy
+        - node.k8s.io/*/RuntimeClass
     preconditions:
       all:
       - key: "{{request.object.apiVersion}}"
-        operator: In
+        operator: AnyIn
         value:
-        - batch/v1beta1/CronJob
-        - discovery.k8s.io/v1beta1/EndpointSlice
-        - events.k8s.io/v1beta1/Event
-        - policy/v1beta1/PodDisruptionBudget
-        - policy/v1beta1/PodSecurityPolicy
-        - node.k8s.io/v1beta1/RuntimeClass
+        - batch/v1beta1
+        - discovery.k8s.io/v1beta1
+        - events.k8s.io/v1beta1
+        - policy/v1beta1
+        - node.k8s.io/v1beta1
     validate:
       message: >-
         {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated and will be removed in v1.25.


### PR DESCRIPTION
## Related Issue(s)

[3988](https://github.com/kyverno/kyverno/issues/3988)

Closes #331

## Description

Fix for `check-deprecated-apis` policy, which causes kyverno to utilise high amount of memory/cpu.

Using wildcard to match `kind` is not necessary and using it on the `apiVersion` much more optimal.. also the pre-conditions had an error which I didn't pick up until i deployed 1.7.0-rc1 but need to remove the `kind` as it should only contain `group` and `apiVersion`.


## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
