### PR TITLE
fix(require-base-image): use type docker-image for buildkit

### DIFF
--- a/other/require-base-image/require-base-image.yaml
+++ b/other/require-base-image/require-base-image.yaml
@@ -44,7 +44,7 @@ spec:
             reference: "{{ element.image }}"
         - name: mobysource
           variable:
-            jmesPath: imageData.configData."moby.buildkit.buildinfo.v1" | base64_decode(@).parse_json(@) | sources[].ref | length(@)
+            jmesPath: imageData.configData."moby.buildkit.buildinfo.v1" | base64_decode(@).parse_json(@) | sources[?type == 'docker-image'].ref | length(@)
             default: 0
         - name: ocisourcelabels
           variable:


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

Fixes #341 

## Description

<!--
What does this PR do?
-->

use type docker-image for buildkit

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
