### PR TITLE
Exclude Policy Reporter from 'restrict-automount-sa-token' Policy

### DIFF
--- a/other/restrict_automount_sa_token/kyverno-test.yaml
+++ b/other/restrict_automount_sa_token/kyverno-test.yaml
@@ -14,3 +14,13 @@ results:
     resource: mydeploy
     kind: Deployment
     result: fail
+  - policy: restrict-automount-sa-token
+    rule: validate-automountServiceAccountToken
+    resource: policy-reporter
+    kind: Pod
+    result: skip
+  - policy: restrict-automount-sa-token
+    rule: validate-automountServiceAccountToken
+    resource: deploy-policy-reporter
+    kind: Deployment
+    result: skip

--- a/other/restrict_automount_sa_token/resource.yaml
+++ b/other/restrict_automount_sa_token/resource.yaml
@@ -31,3 +31,42 @@ spec:
         ports:
         - containerPort: 80
       automountServiceAccountToken: true
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: policy-reporter
+  labels:
+    app.kubernetes.io/part-of: policy-reporter
+spec:
+  containers:
+  - name: policy-reporter
+    image: policy-reporter
+    ports:
+    - containerPort: 8080
+  automountServiceAccountToken: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy-policy-reporter
+  labels:
+    app.kubernetes.io/part-of: policy-reporter
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+      automountServiceAccountToken: true
+

--- a/other/restrict_automount_sa_token/restrict_automount_sa_token.yaml
+++ b/other/restrict_automount_sa_token/restrict_automount_sa_token.yaml
@@ -22,6 +22,11 @@ spec:
       resources:
         kinds:
         - Pod
+    preconditions:
+      all:
+      - key: "{{ request.\"object\".metadata.labels.\"app.kubernetes.io/part-of\" || '' }}"
+        operator: NotEquals
+        value: policy-reporter
     validate:
       message: "Auto-mounting of Service Account tokens is not allowed."
       pattern:


### PR DESCRIPTION
Signed-off-by: Frank Jogeleit <frank.jogeleit@web.de>

## Related Issue(s)

[kyverno/policy-reporter#](https://github.com/kyverno/policy-reporter/issues/155)

## Description

Exclude Policy Reporter from Restrict SA automount policy.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
