### PR TITLE
Use actions/checkout to clone Kyverno

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,12 @@ jobs:
           path: policies
 
       - name: Clone Kyverno
-        run: |
-          if [[ ${{ github.event_name }} == "push" ]]
-          then
-            GIT_BRANCH=${GITHUB_REF##*/}
-          elif [[ ${{ github.event_name }} == "pull_request" ]]
-          then
-            GIT_BRANCH=${{ github.event.pull_request.base.ref }}
-          fi
-
-          git clone https://github.com/kyverno/kyverno --branch $GIT_BRANCH
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          repository: kyverno/kyverno
+          path: kyverno
+          # The target branch of a pull request or the branch/tag of a push
+          ref: ${{ github.base_ref || github.ref_name }}
 
       - name: Set up Go 
         uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923
@@ -37,6 +33,5 @@ jobs:
           go-version: 1.17
 
       - name: Test Policy
-        run: |
-          cd kyverno
-          go run cmd/cli/kubectl-kyverno/main.go test ../policies
+        run: go run cmd/cli/kubectl-kyverno/main.go test ../policies
+        working-directory: kyverno

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
           go-version: 1.17
 
       - name: Test Policy
-        run: go run cmd/cli/kubectl-kyverno/main.go test ../policies
+        run: go run ./cmd/cli/kubectl-kyverno test ../policies
         working-directory: kyverno


### PR DESCRIPTION
## Related Issue(s)

Related to #243 

## Description

Replace the parsing of environment variables and `git clone` with arguments to the `actions/checkout` action.

The action logs the commit hash as its final output. The last group in the log can be expanded to see the referenced branch. For example, a run on a push to the `release-1.7` branch shows:

```
Checking out the ref
  /usr/bin/git checkout --progress --force -B release-1.7 refs/remotes/origin/release-1.7
  Switched to a new branch 'release-1.7'
  branch 'release-1.7' set up to track 'origin/release-1.7'.

/usr/bin/git log -1 --format='%H'
'db440c1b10d91c29d0e28f279705d248ced5c4a7'
```

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
