### PR TITLE
updated status/result from skip to error for non-assigned variables

### DIFF
--- a/cert-manager/limit-duration/kyverno-test.yaml
+++ b/cert-manager/limit-duration/kyverno-test.yaml
@@ -8,7 +8,18 @@ results:
     rule: certificate-duration-max-100days 
     resource: letsencrypt-crt
     kind: Certificate
+    result: error
+    # duration field absent in resource, therefore request.object.spec.duration = nil.
+    # policy throws an error, as nil value assigned to variable.
+    # status/result --> error
+
+  - policy: cert-manager-limit-duration
+    rule: certificate-duration-max-100days 
+    resource: acme-crt
+    kind: Certificate
     result: skip
+    # Status/result = skip, because preconditions blocked doesn't match.
+
   - policy: cert-manager-limit-duration
     rule: certificate-duration-max-100days 
     resource: acme-crt-short

--- a/cert-manager/limit-duration/resource.yaml
+++ b/cert-manager/limit-duration/resource.yaml
@@ -51,6 +51,7 @@ spec:
   dnsNames:
   - example.com
   issuerRef:
-    name: acme-prod
+    name: letsencrypt-test
     kind: Issuer
     group: cert-manager.io
+  duration: 2164h0m0s


### PR DESCRIPTION


Signed-off-by: viveksahu26 <vivekkumarsahu650@gmail.com>

## Related Issue(s)
closes https://github.com/kyverno/policies/issues/355
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
Variables in the policy whose values in not provided by the  user either through resource file or values file then it will be assigned nil as a value. Therefore, status or result of the policy will be `error`.
<!--
What does this PR do?
-->
/kind bug
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
