### PR TITLE
KubeVirt: Introduce rule to enforce instanceType usage

### DIFF
--- a/kubevirt/k6t-only-instancetype/k6t-require-instancetype.yaml
+++ b/kubevirt/k6t-only-instancetype/k6t-require-instancetype.yaml
@@ -1,0 +1,30 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: k6t-require-instancetype
+  annotations:
+    policies.kyverno.io/title: Require instanceType
+    policies.kyverno.io/category: KubeVirt
+    kyverno.io/kyverno-version: 1.6.2
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.25"
+    policies.kyverno.io/subject: VirtualMachine
+    policies.kyverno.io/description: >-
+      Check VirtualMachines and validate that they are not using a domain template (`.spec.template.domain`)
+      but instead are based on instaceTypes and preferences only.
+spec:
+  validationFailureAction: enforce
+  rules:
+  - name: k6t-dont-allow-domain-template
+    match:
+      any: 
+      - resources:
+          kinds:
+          - VirtualMachine
+    validate:
+      message: "VirtualMachines must only use instanceTypes and preferences, a domain template is not allowed."
+      pattern:
+        spec:
+          template:
+            spec:
+              domain: null

--- a/kubevirt/k6t-only-instancetype/kyverno-test.yaml
+++ b/kubevirt/k6t-only-instancetype/kyverno-test.yaml
@@ -1,0 +1,18 @@
+name: kubevirt_only_instancetype_test
+policies:
+  - k6t-require-instancetype.yaml
+resources:
+  - vm.yaml
+results:
+- policy: k6t-require-instancetype
+  rule: k6t-dont-allow-domain-template
+  kind: VirtualMachine
+  resources:
+  - vm-valid
+  result: pass
+- policy: k6t-require-instancetype
+  rule: k6t-dont-allow-domain-template
+  kind: VirtualMachine
+  resources:
+  - vm-invalid
+  result: fail

--- a/kubevirt/k6t-only-instancetype/vm.yaml
+++ b/kubevirt/k6t-only-instancetype/vm.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm: vm-cirros
+  name: vm-valid
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-cirros
+    spec:
+      instanceType:
+        name: c1.small
+      preference:
+        name: linux
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |
+            #!/bin/sh
+
+            echo 'printed from cloud-init userdata'
+        name: cloudinitdisk
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm: vm-cirros
+  name: vm-invalid
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-cirros
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: 128Mi
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |
+            #!/bin/sh
+
+            echo 'printed from cloud-init userdata'
+        name: cloudinitdisk
+


### PR DESCRIPTION
Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>

## Related Issue(s)

None

## Description

Introduces a basic rule in order to enforce the usage of instanceTypes and preferences, and prevents the usage of domain templates in VMs.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
