### PR TITLE
add prevent-linkerd-port-skipping

### DIFF
--- a/linkerd/prevent-linkerd-port-skipping/prevent-linkerd-port-skipping.yaml
+++ b/linkerd/prevent-linkerd-port-skipping/prevent-linkerd-port-skipping.yaml
@@ -1,0 +1,31 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: prevent-linkerd-port-skipping
+  annotations:
+    policies.kyverno.io/title: Prevent Linkerd Port Skipping
+    policies.kyverno.io/category: Linkerd
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Linkerd has the ability to skip inbound and outbound ports assigned to Pods, exempting
+      them from mTLS. This can be important in some narrow use cases but
+      generally should be avoided. This policy prevents Pods from setting
+      the annotations `config.linkerd.io/skip-inbound-ports` or `config.linkerd.io/skip-outbound-ports`.
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+  - name: pod-prevent-port-skipping
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "Pods may not skip ports. The annotations `config.linkerd.io/skip-inbound-ports` or `config.linkerd.io/skip-outbound-ports` must not be set."
+      pattern:
+        metadata:
+          =(annotations):
+            X(config.linkerd.io/skip-inbound-ports): "null"
+            X(config.linkerd.io/skip-outbound-ports): "null"


### PR DESCRIPTION
Signed-off-by: Chip Zoller <chipzoller@gmail.com>

## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

<!--
What does this PR do?
-->
Adds a new Linkerd policy to prevent Pod port skipping.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
