### PR TITLE
Introduce ClusterPolicy config-syncer-secret-generation-from-rancher-capi

### DIFF
--- a/kubeops/README.md
+++ b/kubeops/README.md
@@ -1,0 +1,8 @@
+# Kubeops Policy Examples
+
+This directory contains examples in order to apply policies on
+[Kubeops](https://github.com/kubeops) curated tools.
+
+Examples
+
+- config-syncer-secret-generation-from-rancher-capi (formerly kubed) - Enable config syncer for Rancher downstream clusters by generating a kubeconfig Secret consisting of downstream cluster contexts where you want to sync your ConfigMap/Secret.

--- a/kubeops/config-syncer-secret-generation-from-rancher-capi/config-syncer-secret-generation-from-rancher-capi.yaml
+++ b/kubeops/config-syncer-secret-generation-from-rancher-capi/config-syncer-secret-generation-from-rancher-capi.yaml
@@ -1,0 +1,89 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: config-syncer-secret-generation-from-rancher-capi
+  annotations:
+    policies.kyverno.io/title: Kubeops Config Syncer Secret Generation From Rancher CAPI Secret
+    policies.kyverno.io/category: Kubeops
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Secret
+    kyverno.io/kyverno-version: 1.8.0
+    policies.kyverno.io/minversion: 1.7.1
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/description: >-
+      This policy generates and synchronizes a Kubeops Config Syncer merged kubeconfig
+      Secret from Rancher managed cluster CAPI secrets. This kubeconfig Secret is
+      required by the Kubeops Config Syncer for it to sync ConfigMaps/Secrets from
+      the Rancher management cluster to downstream clusters.
+spec:
+  generateExistingOnPolicyUpdate: true
+  rules:
+  - name: source-rancher-non-local-cluster-and-capi-secret
+    match:
+      all:
+      - resources:
+          kinds:
+          - provisioning.cattle.io/v1/Cluster
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - fleet-local
+    context:
+    - name: secretList
+      apiCall:
+        urlPath: "/api/v1/namespaces/{{request.object.metadata.namespace}}/secrets"
+        jmesPath: "items[?metadata.name.contains(@, '-kubeconfig')]"
+    - name: kubeconfigClustersData
+      variable:
+        value: |
+          {{ secretList | [].{
+              "name": metadata.name,
+              "cluster": data.value | base64_decode(@) | parse_yaml(@).clusters[].cluster[] | [0] }
+          }}
+        jmesPath: 'to_string(@)'
+    - name: kubeconfigUsersData
+      variable:
+        value: |
+          {{ secretList | [].{
+              "name": metadata.name,
+              "user": data.value | base64_decode(@) | parse_yaml(@).users[].user[] | [0] }
+          }}
+        jmesPath: 'to_string(@)'
+#    - name: kubeconfigContextsData # Enable when Kyverno variable substitution bug is resolved
+#      variable:
+#        value: |
+#          {{ secretList | [].{
+#              "name": metadata.name,
+#              "context": { "cluster": metadata.name, "user": metadata.name } }
+#          }}
+#        jmesPath: 'to_string(@)'
+    - name: kubeconfigContextsData # Use until Kyverno variable substitition bug is resolved
+      variable:
+        value: |
+          {{ secretList | [].{
+              "name": metadata.name,
+              "context": ['CLUSTER_BEGIN', metadata.name, 'CLUSTER_END', 'USER_BEGIN', metadata.name, 'USER_END'] }
+          }}
+        jmesPath: "to_string(@) | replace_all(@, '[\"CLUSTER_BEGIN\",', '{\"cluster\":') | replace_all(@, '\"CLUSTER_END\",\"USER_BEGIN\",', '\"user\":') | replace_all(@, ',\"USER_END\"]', '}')"
+    - name: kubeconfigData
+      variable:
+        value: |
+          {
+            "apiVersion": "v1",
+            "kind": "Config",
+            "clusters": {{ kubeconfigClustersData }},
+            "users": {{ kubeconfigUsersData }},
+            "contexts": {{ kubeconfigContextsData }}
+          }
+        jmesPath: 'to_string(@)'
+    generate:
+      synchronize: true
+      apiVersion: v1
+      kind: Secret
+      name: kubed
+      namespace: kube-system
+      data:
+        type: Opaque
+        data:
+          kubeconfig: "{{ kubeconfigData | base64_encode(@) }}"


### PR DESCRIPTION
## Related Issue(s)

Closes #418

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
Implement ClusterPolicy config-syncer-secret-generation-from-rancher-capi.

Note that Kyverno 1.8.0 appears to contain a JMESPath bug that currently prevents this policy from working. Below, please find the contents of the Config Syncer/Kubed Secret generated by this policy. Specifically, notice that the `contexts` json element was rendered incorrectly. This may be due to the fact that the `contexts.context` element is complex. If I change `contexts.context` to be a simple property like `context: metadata.name`, the `contexts` json element renders correctly.

This issue is currently preventing me from using this ClusterPolicy. Please investigate.
```
$ kubectl -n kube-system get secret kubed -o jsonpath='{.data.kubeconfig}' | base64 -d
{
  "apiVersion": "v1",
  "kind": "Config",
  "clusters": [{"cluster":{"certificate-authority-data":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJ2VENDQVdPZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQkdNUnd3R2dZRFZRUUtFeE5rZVc1aGJXbGoKYkdsemRHVnVaWEl0YjNKbk1TWXdKQVlEVlFRRERCMWtlVzVoYldsamJHbHpkR1Z1WlhJdFkyRkFNVFkyTlRNNApOakV5T1RBZUZ3MHlNakV3TVRBd056RTFNamxhRncwek1qRXdNRGN3TnpFMU1qbGFNRVl4SERBYUJnTlZCQW9UCkUyUjVibUZ0YVdOc2FYTjBaVzVsY2kxdmNtY3hKakFrQmdOVkJBTU1IV1I1Ym1GdGFXTnNhWE4wWlc1bGNpMWoKWVVBeE5qWTFNemcyTVRJNU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRStwenNjNVhMdWttSQp6aVNLeThkZ0FiTnB1NFFWR0VnSVBzTGwyN3JsVTM0SHh5TmhxZEtNN05rcm1ZWHkrTTZIc2dxR3NiSWpiZjYxCk9kZm94b1RwRGFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWUQKVlIwT0JCWUVGRHBseTZON2hoNUdybDdhKzA4TXY0UDhpWXFPTUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDSUhidwo0N0hyZmx6aEVWbTBUZXpraFV5QjI4SWJWTkJPbmd5NVFOWDk3SXpiQWlFQTY2VUtiSC92WWIyekYyZUhKV2JCCmtGaFdkQW1rU0NmZW5VNnk1UkVRbHlVPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t","server":"https://<my-server>.<my-domain>/k8s/clusters/c-m-74lz8h8w"},"name":"k8sds-1-kubeconfig"},{"cluster":{"certificate-authority-data":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJ2VENDQVdPZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQkdNUnd3R2dZRFZRUUtFeE5rZVc1aGJXbGoKYkdsemRHVnVaWEl0YjNKbk1TWXdKQVlEVlFRRERCMWtlVzVoYldsamJHbHpkR1Z1WlhJdFkyRkFNVFkyTlRNNApOakV5T1RBZUZ3MHlNakV3TVRBd056RTFNamxhRncwek1qRXdNRGN3TnpFMU1qbGFNRVl4SERBYUJnTlZCQW9UCkUyUjVibUZ0YVdOc2FYTjBaVzVsY2kxdmNtY3hKakFrQmdOVkJBTU1IV1I1Ym1GdGFXTnNhWE4wWlc1bGNpMWoKWVVBeE5qWTFNemcyTVRJNU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRStwenNjNVhMdWttSQp6aVNLeThkZ0FiTnB1NFFWR0VnSVBzTGwyN3JsVTM0SHh5TmhxZEtNN05rcm1ZWHkrTTZIc2dxR3NiSWpiZjYxCk9kZm94b1RwRGFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdLa01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWUQKVlIwT0JCWUVGRHBseTZON2hoNUdybDdhKzA4TXY0UDhpWXFPTUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDSUhidwo0N0hyZmx6aEVWbTBUZXpraFV5QjI4SWJWTkJPbmd5NVFOWDk3SXpiQWlFQTY2VUtiSC92WWIyekYyZUhKV2JCCmtGaFdkQW1rU0NmZW5VNnk1UkVRbHlVPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t","server":"https://<my-server>.<my-domain>/k8s/clusters/c-m-jdwpx2dh"},"name":"k8sds-2-kubeconfig"}]
,
  "users": [{"name":"k8sds-1-kubeconfig","user":{"token":"u-bdrxdhr4cm:kgc6txcgspr2mjsj2f2s5nfgfwbnprl65bwcv4cgxvmxmk5sfgntqp"}},{"name":"k8sds-2-kubeconfig","user":{"token":"u-zt4s4t6rpu:v5spt8mzsscg5vtq278gjtv6dc5j56lzc6g5cmxj7fjnrrctvjblvw"}}]
,
  "contexts": {{ secretList | parse_yaml(@) | items[?metadata.name.contains(@, '-kubeconfig')].{
    "name": metadata.name,
    "context": { "cluster": metadata.name, "user": metadata.name } }
}}

}
```



<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
