### PR TITLE
Fix background scan mode for policies using request.operation in preconditions

### DIFF
--- a/argo/application-prevent-default-project/application-prevent-default-project.yaml
+++ b/argo/application-prevent-default-project/application-prevent-default-project.yaml
@@ -24,7 +24,7 @@ spec:
               - Application
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: NotEquals
           value: DELETE
       validate:

--- a/argo/application-prevent-updates-project/application-prevent-updates-project.yaml
+++ b/argo/application-prevent-updates-project/application-prevent-updates-project.yaml
@@ -24,7 +24,7 @@ spec:
               - Application
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: Equals
           value: UPDATE
       validate:

--- a/argo/applicationset-name-matches-project/applicationset-name-matches-project.yaml
+++ b/argo/applicationset-name-matches-project/applicationset-name-matches-project.yaml
@@ -25,7 +25,7 @@ spec:
               - ApplicationSet
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: NotEquals
           value: DELETE
       validate:

--- a/argo/appproject-clusterresourceblacklist/appproject-clusterresourceblacklist.yaml
+++ b/argo/appproject-clusterresourceblacklist/appproject-clusterresourceblacklist.yaml
@@ -28,7 +28,7 @@ spec:
               - AppProject
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: AnyIn
           value: ["CREATE", "UPDATE"]
       validate:
@@ -52,7 +52,7 @@ spec:
               - AppProject
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: AnyIn
           value: ["CREATE", "UPDATE"]
       validate:

--- a/best-practices/require_drop_all/require_drop_all.yaml
+++ b/best-practices/require_drop_all/require_drop_all.yaml
@@ -25,7 +25,7 @@ spec:
               - Pod
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: NotEquals
           value: DELETE
       validate:

--- a/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
+++ b/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
@@ -26,7 +26,7 @@ spec:
               - Pod
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: NotEquals
           value: DELETE
       validate:

--- a/openshift/disallow-self-provisioner-binding/disallow-self-provisioner-binding.yaml
+++ b/openshift/disallow-self-provisioner-binding/disallow-self-provisioner-binding.yaml
@@ -27,7 +27,7 @@ spec:
       - key: "{{request.object.metadata.name}}"
         operator: Equals
         value: self-provisioners
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equals
         value: UPDATE
     validate:

--- a/openshift/unique-routes/unique-routes.yaml
+++ b/openshift/unique-routes/unique-routes.yaml
@@ -32,7 +32,7 @@ spec:
             jmesPath: "items[].spec.host"
       preconditions:
         all:
-          - key: "{{ request.operation }}"
+          - key: "{{ request.operation || 'BACKGROUND' }}"
             operator: NotEquals
             value: "DELETE"
       validate:

--- a/openshift/validate-routes/check-routes.yaml
+++ b/openshift/validate-routes/check-routes.yaml
@@ -24,7 +24,7 @@ spec:
               - route.openshift.io/v1/Route
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: NotEquals
           value: ["DELETE"]
       validate:

--- a/other/add_certificates_volume/add_certificates_volume.yaml
+++ b/other/add_certificates_volume/add_certificates_volume.yaml
@@ -28,7 +28,7 @@ spec:
       - key: '{{request.object.metadata.annotations."inject-certs"}}'
         operator: Equals
         value: enabled
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
           - CREATE

--- a/other/add_default_resources/add-default-resources.yaml
+++ b/other/add_default_resources/add-default-resources.yaml
@@ -27,7 +27,7 @@ spec:
           - Pod
     preconditions:
       any:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE

--- a/other/advanced_restrict_image_registries/advanced-restrict-image-registries.yaml
+++ b/other/advanced_restrict_image_registries/advanced-restrict-image-registries.yaml
@@ -42,7 +42,7 @@ spec:
             namespace: default
       preconditions:
         any:
-        - key: "{{request.operation}}"
+        - key: "{{request.operation || 'BACKGROUND'}}"
           operator: In
           value:
           - CREATE

--- a/other/allowed-base-images/allowed-base-images.yaml
+++ b/other/allowed-base-images/allowed-base-images.yaml
@@ -28,7 +28,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     context:

--- a/other/allowed_label_changes/allowed-label-changes.yaml
+++ b/other/allowed_label_changes/allowed-label-changes.yaml
@@ -34,7 +34,7 @@ spec:
           - CronJob
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: Equals
         value: UPDATE
     validate:

--- a/other/annotate-base-images/annotate-base-images.yaml
+++ b/other/annotate-base-images/annotate-base-images.yaml
@@ -27,7 +27,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     mutate:

--- a/other/block-pod-exec-by-namespace-label.yaml
+++ b/other/block-pod-exec-by-namespace-label.yaml
@@ -27,7 +27,7 @@ spec:
         jmesPath: "metadata.labels.exec"
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: Equals
         value: CONNECT
     validate:

--- a/other/block-pod-exec-by-namespace.yaml
+++ b/other/block-pod-exec-by-namespace.yaml
@@ -22,7 +22,7 @@ spec:
         - PodExecOptions
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: Equals
         value: CONNECT
     validate:

--- a/other/block-pod-exec-by-pod-and-container.yaml
+++ b/other/block-pod-exec-by-pod-and-container.yaml
@@ -23,7 +23,7 @@ spec:
         - PodExecOptions
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: Equals
         value: CONNECT
       - key: "{{ request.name }}"

--- a/other/block-pod-exec-by-pod-label.yaml
+++ b/other/block-pod-exec-by-pod-label.yaml
@@ -27,7 +27,7 @@ spec:
         jmesPath: "metadata.labels.exec"
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: Equals
         value: CONNECT
     validate:

--- a/other/block-pod-exec-by-pod-name.yaml
+++ b/other/block-pod-exec-by-pod-name.yaml
@@ -23,7 +23,7 @@ spec:
         - PodExecOptions
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: Equals
         value: CONNECT
     validate:

--- a/other/block_images_with_volumes/block-images-with-volumes.yaml
+++ b/other/block_images_with_volumes/block-images-with-volumes.yaml
@@ -26,7 +26,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     validate:

--- a/other/block_large_images/block-large-images.yaml
+++ b/other/block_large_images/block-large-images.yaml
@@ -26,7 +26,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     validate:

--- a/other/block_updates_deletes/block_updates_deletes.yaml
+++ b/other/block_updates_deletes/block_updates_deletes.yaml
@@ -32,7 +32,7 @@ spec:
       deny:
         conditions:
           any:
-            - key: "{{request.operation}}"
+            - key: "{{request.operation || 'BACKGROUND'}}"
               operator: In
               value:
               - DELETE

--- a/other/check_nvidia_gpu/check-nvidia-gpu.yaml
+++ b/other/check_nvidia_gpu/check-nvidia-gpu.yaml
@@ -27,7 +27,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     validate:

--- a/other/enforce_resources_as_ratio/enforce-resources-as-ratio.yaml
+++ b/other/enforce_resources_as_ratio/enforce-resources-as-ratio.yaml
@@ -26,7 +26,7 @@ spec:
           - Pod
     preconditions:
       any:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: In
         value:
         - CREATE

--- a/other/ensure-production-matches-staging/ensure-production-matches-staging.yaml
+++ b/other/ensure-production-matches-staging/ensure-production-matches-staging.yaml
@@ -35,7 +35,7 @@ spec:
           - Deployment
     preconditions:
       any:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE        
@@ -66,7 +66,7 @@ spec:
           - Deployment
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE        
@@ -107,7 +107,7 @@ spec:
           - Deployment
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE        

--- a/other/ensure_readonly_hostpath/ensure_readonly_hostpath.yaml
+++ b/other/ensure_readonly_hostpath/ensure_readonly_hostpath.yaml
@@ -28,7 +28,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: In
         value:
         - CREATE

--- a/other/ingress_host_match_tls/ingress-host-match-tls.yaml
+++ b/other/ingress_host_match_tls/ingress-host-match-tls.yaml
@@ -28,7 +28,7 @@ spec:
           - Ingress
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equals
         value: CREATE
     validate:

--- a/other/inject_env_var_from_image_label/inject-env-var-from-image-label.yaml
+++ b/other/inject_env_var_from_image_label/inject-env-var-from-image-label.yaml
@@ -26,7 +26,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     mutate:

--- a/other/kubernetes_version_check/kubernetes-version-check.yaml
+++ b/other/kubernetes_version_check/kubernetes-version-check.yaml
@@ -26,7 +26,7 @@ spec:
           - Secret
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE

--- a/other/limit-configmap-for-sa/limit_configmap_for_sa.yaml
+++ b/other/limit-configmap-for-sa/limit_configmap_for_sa.yaml
@@ -48,7 +48,7 @@ spec:
       deny:
         conditions:
           all:
-          - key: "{{request.operation}}"
+          - key: "{{request.operation || 'BACKGROUND'}}"
             operator: "In"
             value:
             - "UPDATE"

--- a/other/limit-hostpath-type-pv/limit_hostpath_type_pv.yaml
+++ b/other/limit-hostpath-type-pv/limit_hostpath_type_pv.yaml
@@ -23,7 +23,7 @@ spec:
         - PersistentVolume
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE

--- a/other/limit-hostpath-vols/limit-hostpath-vols.yaml
+++ b/other/limit-hostpath-vols/limit-hostpath-vols.yaml
@@ -31,7 +31,7 @@ spec:
       - key: "{{ request.object.spec.volumes[?hostPath] | length(@) }}"
         operator: GreaterThanOrEquals
         value: 1
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE

--- a/other/limit_containers_per_pod/limit_containers_per_pod.yaml
+++ b/other/limit_containers_per_pod/limit_containers_per_pod.yaml
@@ -27,7 +27,7 @@ spec:
         - StatefulSet
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equal
         value: CREATE
     validate:
@@ -45,7 +45,7 @@ spec:
         - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equal
         value: CREATE
     validate:
@@ -63,7 +63,7 @@ spec:
         - CronJob
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equal
         value: CREATE
     validate:

--- a/other/nfs-subdir-external-provisioner-storage-path/nfs-subdir-external-provisioner-storage-path.yaml
+++ b/other/nfs-subdir-external-provisioner-storage-path/nfs-subdir-external-provisioner-storage-path.yaml
@@ -28,7 +28,7 @@ spec:
           - PersistentVolumeClaim
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE

--- a/other/only_trustworthy_registries_set_root/only-trustworthy-registries-set-root.yaml
+++ b/other/only_trustworthy_registries_set_root/only-trustworthy-registries-set-root.yaml
@@ -26,7 +26,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     validate:

--- a/other/only_trustworthy_registries_set_root/values.yaml
+++ b/other/only_trustworthy_registries_set_root/values.yaml
@@ -10,4 +10,3 @@ policies:
       - name: pod-with-root-user
         values:
           request.operation: UPDATE
-         

--- a/other/prepend_image_registry/prepend_image_registry.yaml
+++ b/other/prepend_image_registry/prepend_image_registry.yaml
@@ -26,7 +26,7 @@ spec:
         - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE
@@ -46,7 +46,7 @@ spec:
         - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE

--- a/other/prevent-naked-pods/prevent-naked-pods.yaml
+++ b/other/prevent-naked-pods/prevent-naked-pods.yaml
@@ -28,7 +28,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     validate:

--- a/other/protect_node_taints/protect-node-taints.yaml
+++ b/other/protect_node_taints/protect-node-taints.yaml
@@ -29,7 +29,7 @@ spec:
       - cluster-admin
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equals
         value: UPDATE
     validate:

--- a/other/record-creation-details/record-creation-details.yaml
+++ b/other/record-creation-details/record-creation-details.yaml
@@ -31,7 +31,7 @@ spec:
           - '*'
     preconditions:
       any:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equals
         value: CREATE
     mutate:
@@ -49,7 +49,7 @@ spec:
             kyverno.io/created-by: "?*"
     preconditions:
       any:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equals
         value: UPDATE
     validate:
@@ -73,7 +73,7 @@ spec:
             kyverno.io/created-by: "?*"
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equals
         value: UPDATE
       - key: "{{ request.oldObject.metadata.annotations.\"kyverno.io/created-by\" || '' }}"

--- a/other/require-base-image/require-base-image.yaml
+++ b/other/require-base-image/require-base-image.yaml
@@ -31,7 +31,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     validate:

--- a/other/require_emptydir_requests_limits/require-emptydir-requests-limits.yaml
+++ b/other/require_emptydir_requests_limits/require-emptydir-requests-limits.yaml
@@ -30,7 +30,7 @@ spec:
       - key: "{{ request.object.spec.volumes[?contains(keys(@), 'emptyDir')] || '' | length(@) }}"
         operator: GreaterThanOrEquals
         value: 1
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE

--- a/other/require_image_source/require-image-source.yaml
+++ b/other/require_image_source/require-image-source.yaml
@@ -28,7 +28,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     validate:

--- a/other/require_netpol/require_netpol.yaml
+++ b/other/require_netpol/require_netpol.yaml
@@ -25,7 +25,7 @@ spec:
         - Deployment
     preconditions:
       any:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equals
         value: CREATE
     context:

--- a/other/require_pdb/require_pdb.yaml
+++ b/other/require_pdb/require_pdb.yaml
@@ -24,7 +24,7 @@ spec:
         - Deployment
     preconditions:
       any:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equals
         value: CREATE
     context:

--- a/other/require_unique_external_dns/require_unique_external_dns.yaml
+++ b/other/require_unique_external_dns/require_unique_external_dns.yaml
@@ -34,7 +34,7 @@ spec:
             jmesPath: "items[].metadata.annotations.\"external-dns.alpha.kubernetes.io/hostname\""
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: In
           value:
             - CREATE

--- a/other/require_unique_uid_per_workload/require_unique_uid_per_workload.yaml
+++ b/other/require_unique_uid_per_workload/require_unique_uid_per_workload.yaml
@@ -35,7 +35,7 @@ spec:
           jmesPath: "items[?@.metadata.ownerReferences == false || metadata.ownerReferences[?uid != '{{ request.object.metadata.keys(@).contains(@, 'ownerReferences') && request.object.metadata.ownerReferences[0].uid }}']].spec.containers[].securityContext.to_string(runAsUser)"
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: Equals
         value: "CREATE"
     validate:

--- a/other/resolve_image_to_digest/resolve-image-to-digest.yaml
+++ b/other/resolve_image_to_digest/resolve-image-to-digest.yaml
@@ -25,7 +25,7 @@ spec:
           - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     mutate:

--- a/other/restart_deployment_on_secret_change/restart_deployment_on_secret_change.yaml
+++ b/other/restart_deployment_on_secret_change/restart_deployment_on_secret_change.yaml
@@ -33,7 +33,7 @@ spec:
           - default
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equals
         value: UPDATE
     mutate:

--- a/other/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
+++ b/other/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
@@ -28,7 +28,7 @@ spec:
               - Ingress
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: AnyIn
           value: ["CREATE", "UPDATE"]
       validate:

--- a/other/restrict_ingress_host/restrict_ingress_host.yaml
+++ b/other/restrict_ingress_host/restrict_ingress_host.yaml
@@ -29,7 +29,7 @@ spec:
             jmesPath: "items[].spec.rules[].host"
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: Equals
           value: CREATE
         - key: "{{ request.object.spec.rules[].host }}"
@@ -45,7 +45,7 @@ spec:
             - Ingress
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: Equals
           value: CREATE
         - key: "{{ request.object.spec.rules[].host | length(@)}}"

--- a/other/restrict_node_label_changes.yaml
+++ b/other/restrict_node_label_changes.yaml
@@ -41,7 +41,7 @@ spec:
         - Node
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: Equals
         value: UPDATE
       - key: "{{ request.oldObject.metadata.labels.foo || '' }}"

--- a/other/restrict_node_label_creation.yaml
+++ b/other/restrict_node_label_creation.yaml
@@ -26,7 +26,7 @@ spec:
         - Node
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equals
         value: UPDATE
       - key: "{{request.object.metadata.labels.foo || '' }}"

--- a/other/restrict_pod_count_per_node/restrict_pod_count_per_node.yaml
+++ b/other/restrict_pod_count_per_node/restrict_pod_count_per_node.yaml
@@ -29,7 +29,7 @@ spec:
             jmesPath: "items[?spec.nodeName=='minikube'] | length(@)"
       preconditions:
         any:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: Equals
           value: "CREATE"
       validate:

--- a/other/restrict_secrets_by_label/restrict-secrets-by-label.yaml
+++ b/other/restrict_secrets_by_label/restrict-secrets-by-label.yaml
@@ -31,7 +31,7 @@ spec:
       - key: "{{ request.object.spec.[containers, initContainers, ephemeralContainers][].env[].valueFrom.secretKeyRef || '' | length(@) }}"
         operator: GreaterThanOrEquals
         value: 1
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     validate:
@@ -63,7 +63,7 @@ spec:
       - key: "{{ request.object.spec.[containers, initContainers, ephemeralContainers][].envFrom[].secretRef || '' | length(@) }}"
         operator: GreaterThanOrEquals
         value: 1
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     validate:
@@ -95,7 +95,7 @@ spec:
       - key: "{{ request.object.spec.volumes[].secret || '' | length(@) }}"
         operator: GreaterThanOrEquals
         value: 1
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: NotEquals
         value: DELETE
     validate:

--- a/other/restrict_secrets_by_name/restrict-secrets-by-name.yaml
+++ b/other/restrict_secrets_by_name/restrict-secrets-by-name.yaml
@@ -27,7 +27,7 @@ spec:
         - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE
@@ -61,7 +61,7 @@ spec:
         - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE
@@ -92,7 +92,7 @@ spec:
         - Pod
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: In
         value:
         - CREATE

--- a/other/scale_deployment_zero/scale_deployment_zero.yaml
+++ b/other/scale_deployment_zero/scale_deployment_zero.yaml
@@ -29,7 +29,7 @@ spec:
           - v1/Pod.status
     preconditions:
       all:
-      - key: "{{request.operation}}"
+      - key: "{{request.operation || 'BACKGROUND'}}"
         operator: Equals
         value: UPDATE
       - key: "{{request.object.status.containerStatuses[0].restartCount}}"

--- a/other/unique-ingress-host-and-path/unique-ingress-host-and-path.yaml
+++ b/other/unique-ingress-host-and-path/unique-ingress-host-and-path.yaml
@@ -27,7 +27,7 @@ spec:
               - Ingress
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: NotEquals
           value: DELETE
       context:

--- a/other/unique-ingress-paths.yaml
+++ b/other/unique-ingress-paths.yaml
@@ -38,7 +38,7 @@ spec:
             jmesPath: "items[].spec.rules[].http.paths[].path"
       preconditions:
         any:
-        - key: "{{request.operation}}"
+        - key: "{{request.operation || 'BACKGROUND'}}"
           operator: Equals
           value: "CREATE"
       validate:

--- a/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
+++ b/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
@@ -25,7 +25,7 @@ spec:
               - Pod
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: NotEquals
           value: DELETE
       validate:
@@ -47,7 +47,7 @@ spec:
               - Pod
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: NotEquals
           value: DELETE
       validate:

--- a/psp-migration/check_supplemental_groups/check-supplemental-groups.yaml
+++ b/psp-migration/check_supplemental_groups/check-supplemental-groups.yaml
@@ -27,7 +27,7 @@ spec:
             - Pod
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: In
         value:
         - CREATE

--- a/psp-migration/restrict_adding_capabilities/restrict-adding-capabilities.yaml
+++ b/psp-migration/restrict_adding_capabilities/restrict-adding-capabilities.yaml
@@ -29,7 +29,7 @@ spec:
               - Pod
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ request.operation || 'BACKGROUND' }}"
           operator: NotEquals
           value: DELETE
       validate:

--- a/tekton/block-tekton-task-runs/block-tekton-task-runs.yaml
+++ b/tekton/block-tekton-task-runs/block-tekton-task-runs.yaml
@@ -29,7 +29,7 @@ spec:
           name: "system:serviceaccount:tekton-pipelines:tekton-pipelines-controller"
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: AnyIn
         value:
         - CREATE

--- a/tekton/require-tekton-namespace-pipelinerun/require-tekton-namespace-pipelinerun.yaml
+++ b/tekton/require-tekton-namespace-pipelinerun/require-tekton-namespace-pipelinerun.yaml
@@ -24,7 +24,7 @@ spec:
           - PipelineRun
     preconditions:
       all:
-      - key: "{{ request.operation }}"
+      - key: "{{ request.operation || 'BACKGROUND' }}"
         operator: Equals
         value: CREATE
     validate:


### PR DESCRIPTION
Signed-off-by: Chip Zoller <chipzoller@gmail.com>

## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

<!--
What does this PR do?
-->

This PR fixes the ability to apply policies which use `request.operation` in preconditions in background mode by setting the value to `BACKGROUND` if `request.operation` cannot be resolved. In background mode, there is no AdmissionReview data and so `operation` evaluates to `null` which either causes errors or no policy report entries to be created.
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
