### PR TITLE
check type only if set

### DIFF
--- a/best-practices/restrict_node_port/restrict_node_port.yaml
+++ b/best-practices/restrict_node_port/restrict_node_port.yaml
@@ -26,4 +26,4 @@ spec:
       message: "Services of type NodePort are not allowed."
       pattern:
         spec:
-          type: "!NodePort"
+          =(type): "!NodePort"


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek@users.noreply.github.com>

## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

<!--
What does this PR do?
-->

* checks "type" only if set otherwise rule will also fail on default, which is "ClusterIP", when the type is not set

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
