### PR TITLE
make periodSeconds optional

### DIFF
--- a/best-practices/require_probes/require_probes.yaml
+++ b/best-practices/require_probes/require_probes.yaml
@@ -31,6 +31,6 @@ spec:
         spec:
           containers:
           - livenessProbe:
-              periodSeconds: ">0"
+              =(periodSeconds): ">0"
             readinessProbe:
-              periodSeconds: ">0"
+              =(periodSeconds): ">0"


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek@users.noreply.github.com>

## Related Issue(s)

https://github.com/kyverno/kyverno/issues/4983

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

Make periodSeconds optional so the check works also on the CLI if periodSeconds is not set.
In the cluster periodSeconds has a default of 10 secdonds so the policy would work.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
