### PR TITLE
add check-image-vulns-cve-2022-42889

### DIFF
--- a/other/verify_image_cve-2022-42889.yaml
+++ b/other/verify_image_cve-2022-42889.yaml
@@ -1,0 +1,45 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: check-image-vulns-cve-2022-42889
+  annotations:
+    policies.kyverno.io/title: Verify Image Check CVE-2022-42889
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.7.0
+    kyverno.io/kyverno-version: 1.8.1
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/description: >-
+      CVE-2022-42889 is a critical vulnerability in the Apache Commons Text library which
+      could lead to arbitrary code executions and occurs in versions 1.5 through 1.9. Detecting
+      the affected package may be done in an SBOM by identifying the "commons-text" package
+      with one of the affected versions. This policy checks attested SBOMs in CycloneDX format of an image
+      specified under `imageReferences` and denies it if it contains versions 1.5-1.9 of the commons-text
+      package. Using this for your own purposes will require customizing the `imageReferences`,
+      `subject`, and `issuer` fields based on your image signatures and attestations.
+spec:
+  validationFailureAction: audit
+  webhookTimeoutSeconds: 10
+  rules:
+    - name: cve-2022-42889
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      verifyImages:
+      - imageReferences:
+        - "myreg.org/myrepo/someimage*"
+        attestors:
+        - entries:
+          - keyless:
+              subject: "mysubject"
+              issuer: "myissuer"
+        attestations:
+        - predicateType: https://cyclonedx.org/schema
+          conditions:
+          - all:
+            - key: "{{ components[?name=='commons-text'].version || 'none' }}"
+              operator: AllNotIn
+              value: ["1.5","1.6","1.7","1.8","1.9"]


### PR DESCRIPTION
Signed-off-by: Chip Zoller <chipzoller@gmail.com>

## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

<!--
What does this PR do?
-->
* Adds check-image-vulns-cve-2022-42889 policy
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
