### PR TITLE
add: new policy to mutate dns policy and dns config

### DIFF
--- a/other/dns-policy-and-dns-config/dns-policy-and-dns-config.yaml
+++ b/other/dns-policy-and-dns-config/dns-policy-and-dns-config.yaml
@@ -1,0 +1,56 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: dns-policy
+  annotations:
+    policies.kyverno.io/title: Change DNS Config and Policy
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.7.3
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The Default DNS policy in Kubernetes gives the flexibility of service 
+      access; however, it costs some latency on a high scale, and it needs to 
+      be optimized. This policy helps us to optimize the performance of DNS 
+      queries by setting DNS Options, nodelocalDNS IP, and search Domains. 
+spec:
+  rules:
+  - name: dns-policy
+    context:
+    - name: dictionary
+      configMap:
+        # kubelet-config cm would also works by using clusterDomain 
+        # instead of clusterName; but kubeadm-config sounds more reliable
+        # when considering kubelet-config is changed every cluster upgrade, etc.
+        name: kubeadm-config 
+        namespace: kube-system
+    match:
+      resources:
+        kinds:
+        - Pod
+    preconditions:
+      any:
+      - key: "{{ request.object.spec.dnsPolicy }}"
+        operator: In
+        value: 
+        - ClusterFirst
+        - ClusterFirstWithHostNet
+        - None
+    mutate:
+      patchStrategicMerge:
+        spec:
+          dnsConfig:
+            nameservers:
+            - 169.254.25.10 # NodelocalDNS IP
+            options:
+            - name: timeout
+              value: "1"
+            - name: ndots
+              value: "2"
+            - name: attempts
+              value: "1"
+            searches:
+            - svc.{{dictionary.data.ClusterConfiguration | parse_yaml(@).clusterName}}
+            - '{{ request.namespace }}.svc.{{ dictionary.data.ClusterConfiguration | parse_yaml(@).clusterName }}'
+          dnsPolicy: None

--- a/other/verify_image_cve-2022-42889.yaml
+++ b/other/verify_image_cve-2022-42889.yaml
@@ -1,0 +1,45 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: check-image-vulns-cve-2022-42889
+  annotations:
+    policies.kyverno.io/title: Verify Image Check CVE-2022-42889
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.7.0
+    kyverno.io/kyverno-version: 1.8.1
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/description: >-
+      CVE-2022-42889 is a critical vulnerability in the Apache Commons Text library which
+      could lead to arbitrary code executions and occurs in versions 1.5 through 1.9. Detecting
+      the affected package may be done in an SBOM by identifying the "commons-text" package
+      with one of the affected versions. This policy checks attested SBOMs in CycloneDX format of an image
+      specified under `imageReferences` and denies it if it contains versions 1.5-1.9 of the commons-text
+      package. Using this for your own purposes will require customizing the `imageReferences`,
+      `subject`, and `issuer` fields based on your image signatures and attestations.
+spec:
+  validationFailureAction: audit
+  webhookTimeoutSeconds: 10
+  rules:
+    - name: cve-2022-42889
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      verifyImages:
+      - imageReferences:
+        - "myreg.org/myrepo/someimage*"
+        attestors:
+        - entries:
+          - keyless:
+              subject: "mysubject"
+              issuer: "myissuer"
+        attestations:
+        - predicateType: https://cyclonedx.org/schema
+          conditions:
+          - all:
+            - key: "{{ components[?name=='commons-text'].version || 'none' }}"
+              operator: AllNotIn
+              value: ["1.5","1.6","1.7","1.8","1.9"]


### PR DESCRIPTION
## Related Issue(s)

None

## Description

The Default DNS policy in Kubernetes gives the flexibility of service access; however, it costs some latency and performance problems on a high scale, and it needs to be optimized. This policy helps us to optimize the performance of DNS queries by setting DNS Options, nodelocalDNS IP, and search Domains. 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [ ] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.

Unfortunately, within the policy, we read data on the `kubeadm-config` configmap; that's why testing this scenario with kyverno cli is not possible; but I tested the policy, and clearly, it works as expected. I don't want to add test materials to the commit, but I'm sharing the [manifest](https://gist.github.com/ugur99/0b34f1de16d7104a79eec5a0cd7a55b6). I hope it works.
![image](https://user-images.githubusercontent.com/57688057/196745817-060d6476-722a-43ab-b111-4caea718c413.png)


