### PR TITLE
Strip '-kubeconfig' suffix from config-syncer cluster name to minimize confusion

### DIFF
--- a/kubeops/config-syncer-secret-generation-from-rancher-capi/config-syncer-secret-generation-from-rancher-capi.yaml
+++ b/kubeops/config-syncer-secret-generation-from-rancher-capi/config-syncer-secret-generation-from-rancher-capi.yaml
@@ -42,7 +42,7 @@ spec:
       variable:
         value: |
           {{ secretList | [].{
-              "name": metadata.name,
+              "name": replace_all(metadata.name, '-kubeconfig', ''),
               "cluster": data.value | base64_decode(@) | parse_yaml(@).clusters[].cluster[] | [0] } || '\[\]'
           }}
         jmesPath: 'to_string(@)'
@@ -50,7 +50,7 @@ spec:
       variable:
         value: |
           {{ secretList | [].{
-              "name": metadata.name,
+              "name": replace_all(metadata.name, '-kubeconfig', ''),
               "user": data.value | base64_decode(@) | parse_yaml(@).users[].user[] | [0] } || '\[\]'
           }}
         jmesPath: 'to_string(@)'
@@ -58,7 +58,7 @@ spec:
 #      variable:
 #        value: |
 #          {{ secretList | [].{
-#              "name": metadata.name,
+#              "name": replace_all(metadata.name, '-kubeconfig', ''),
 #              "context": { "cluster": metadata.name, "user": metadata.name } }
 #          }}
 #        jmesPath: 'to_string(@)'
@@ -66,8 +66,8 @@ spec:
       variable:
         value: |
           {{ secretList | [].{
-              "name": metadata.name,
-              "context": ['CLUSTER_BEGIN', metadata.name, 'CLUSTER_END', 'USER_BEGIN', metadata.name, 'USER_END'] } || '\[\]'
+              "name": replace_all(metadata.name, '-kubeconfig', ''),
+              "context": ['CLUSTER_BEGIN', replace_all(metadata.name, '-kubeconfig', ''), 'CLUSTER_END', 'USER_BEGIN', replace_all(metadata.name, '-kubeconfig', ''), 'USER_END'] } || '\[\]'
           }}
         jmesPath: "to_string(@) | replace_all(@, '[\"CLUSTER_BEGIN\",', '{\"cluster\":') | replace_all(@, '\"CLUSTER_END\",\"USER_BEGIN\",', '\"user\":') | replace_all(@, ',\"USER_END\"]', '}')"
     - name: kubeconfigData


### PR DESCRIPTION
## Related Issue(s)
Closes #448

## Description
Strip '-kubeconfig' suffix from config-syncer cluster name to minimize confusion #448

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
