### PR TITLE
fix: restrict escalation verbs

### DIFF
--- a/other/restrict-escalation-verbs-roles/kyverno-test.yaml
+++ b/other/restrict-escalation-verbs-roles/kyverno-test.yaml
@@ -1,0 +1,32 @@
+name: restrict-escalation-verbs-roles
+policies:
+- restrict-escalation-verbs-roles.yaml
+resources:
+- resource.yaml
+results:
+- policy: restrict-escalation-verbs-roles
+  rule: escalate
+  resources:
+  - goodclusterrole01
+  - goodclusterrole02
+  kind: ClusterRole
+  result: pass
+- policy: restrict-escalation-verbs-roles
+  rule: escalate
+  resources:
+  - badclusterrole01
+  - badclusterrole02
+  kind: ClusterRole
+  result: fail
+- policy: restrict-escalation-verbs-roles
+  rule: escalate
+  resources:
+  - goodrole01
+  kind: Role
+  result: pass
+- policy: restrict-escalation-verbs-roles
+  rule: escalate
+  resources:
+  - badrole01
+  kind: Role
+  result: fail

--- a/other/restrict-escalation-verbs-roles/resource.yaml
+++ b/other/restrict-escalation-verbs-roles/resource.yaml
@@ -1,0 +1,128 @@
+# Source: keda-base/charts/keda/templates/10-keda-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: goodclusterrole01
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - configmaps/status
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - external
+  - pods
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - '*/scale'
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - '*'
+# Source: keda-base/charts/keda/templates/20-metrics-clusterrole.yaml
+- apiGroups:
+  - external.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: goodclusterrole02 # system:discovery
+rules:
+- nonResourceURLs:
+  - /api
+  - /api/*
+  - /apis
+  - /apis/*
+  - /healthz
+  - /livez
+  - /openapi
+  - /openapi/*
+  - /readyz
+  - /version
+  - /version/
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: badclusterrole01
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - escalate
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: badclusterrole02
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: goodrole01
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - configmaps/status
+  - events
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: badrole01
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - impersonate

--- a/other/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
+++ b/other/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
@@ -13,9 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       The verbs `impersonate`, `bind`, and `escalate` may all potentially lead to
       privilege escalation and should be tightly controlled. This policy prevents
-      use of these verbs in Role or ClusterRole resources. In order to
-      fully implement this control, it is recommended to pair this policy with another which
-      also prevents use of the wildcard ('*') in the verbs list.
+      use of these verbs in Role or ClusterRole resources.
 spec:
   validationFailureAction: audit
   background: true
@@ -29,9 +27,23 @@ spec:
               - ClusterRole
       validate:
         message: "Use of verbs `escalate`, `bind`, and `impersonate` are forbidden."
-        deny:
-          conditions:
-            any:
-            - key: ["escalate","bind","impersonate"]
-              operator: AnyIn
-              value: "{{ request.object.rules[].verbs[] }}"
+        foreach:
+        - list: "request.object.rules[]"
+          deny:
+            conditions:
+              all:
+              - key: "{{ element.apiGroups || '' }}"
+                operator: AnyIn
+                value:
+                - rbac.authorization.k8s.io
+              - key: "{{ element.resources || '' }}"
+                operator: AnyIn
+                value:
+                - clusterroles
+                - roles
+              - key: "{{ element.verbs }}"
+                operator: AnyIn
+                value:
+                - bind
+                - escalate
+                - impersonate


### PR DESCRIPTION
## Related Issue(s)

Fixes #452 

## Description

Enhances the `restrict-escalation-verbs-roles` policy so that it only denies RBAC rules that apply to `roles` or `clusterroles` _resources_ in _apiGroup_ `rbac.authorization.k8s.io`. That is, it only forbids Roles or ClusterRoles that can bind, escalate or impersonate Roles or ClusterRoles.

In this enhanced form, it implements CIS Benchmark for Kubernetes 5.1.8.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
