### PR TITLE
add consul min tls version

### DIFF
--- a/consul/enforce-min-tls-version/enforce-min-tls-version.yaml
+++ b/consul/enforce-min-tls-version/enforce-min-tls-version.yaml
@@ -6,7 +6,7 @@ metadata:
    policies.kyverno.io/title: Enforce Consul min TLS version 
    policies.kyverno.io/category: Consul
    policies.kyverno.io/severity: medium
-   policies.kyverno.io/subject: TlsVersion
+   policies.kyverno.io/subject: Mesh
    kyverno.io/kyverno-version: 1.8.0
    policies.kyverno.io/minversion: 1.6.0
    kyverno.io/kubernetes-version: "1.24"

--- a/consul/enforce-min-tls-version/enforce-min-tls-version.yaml
+++ b/consul/enforce-min-tls-version/enforce-min-tls-version.yaml
@@ -1,0 +1,30 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+ name: enforce-min-tls-version
+ annotations:
+   policies.kyverno.io/title: Enforce Consul min TLS version 
+   policies.kyverno.io/category: Consul
+   policies.kyverno.io/severity: medium
+   policies.kyverno.io/subject: TlsVersion
+   kyverno.io/kyverno-version: 1.8.0
+   policies.kyverno.io/minversion: 1.6.0
+   kyverno.io/kubernetes-version: "1.24"
+   policies.kyverno.io/description: >-
+     This policy will check the TLS Min version to ensure that whenever the mesh is set, there is a minimum version of TLS set for all the service mesh proxies and this enforces that service mesh mTLS traffic uses TLS v1.2 or newer.
+spec:
+ validationFailureAction: enforce
+ background: true
+ rules:
+   - name: check-for-tls-version
+     match:
+       resources:
+         kinds:
+           - Mesh
+     validate:
+       message: The minimum version of TLS is TLS v1_2
+       pattern:
+         spec:
+             tls:
+               incoming:
+                 tlsMinVersion: TLSv1_2

--- a/consul/enforce-min-tls-version/kyverno-test.yaml
+++ b/consul/enforce-min-tls-version/kyverno-test.yaml
@@ -4,15 +4,13 @@ policies:
 resources:
   - resource.yaml
 results:
-##### Pods - Bad
   - policy: enforce-min-tls-version
-    rule: adding-capabilities
+    rule: check-for-tls-version
     resource: badmesh
     kind: Mesh
     result: fail
-  ###### Pods - Good
   - policy: enforce-min-tls-version
-    rule: adding-capabilities
+    rule: check-for-tls-version
     resource: goodmesh
     kind: Mesh
     result: pass

--- a/consul/enforce-min-tls-version/kyverno-test.yaml
+++ b/consul/enforce-min-tls-version/kyverno-test.yaml
@@ -1,0 +1,18 @@
+name: enforce-min-tls-version
+policies:
+  - enforce-min-tls-version.yaml
+resources:
+  - resource.yaml
+results:
+##### Pods - Bad
+  - policy: enforce-min-tls-version
+    rule: adding-capabilities
+    resource: mesh01
+    kind: Mesh
+    result: fail
+  ###### Pods - Good
+  - policy: enforce-min-tls-version
+    rule: adding-capabilities
+    resource: goodmesh
+    kind: Mesh
+    result: pass

--- a/consul/enforce-min-tls-version/kyverno-test.yaml
+++ b/consul/enforce-min-tls-version/kyverno-test.yaml
@@ -7,7 +7,7 @@ results:
 ##### Pods - Bad
   - policy: enforce-min-tls-version
     rule: adding-capabilities
-    resource: mesh01
+    resource: badmesh
     kind: Mesh
     result: fail
   ###### Pods - Good

--- a/consul/enforce-min-tls-version/resource.yaml
+++ b/consul/enforce-min-tls-version/resource.yaml
@@ -1,0 +1,19 @@
+###### Pods - Bad
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: Mesh
+metadata:
+  name: badmesh
+spec:
+  tls:
+    incoming:
+      tlsMinVersion: TLSv1_1
+--- 
+###### Pods - Good
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: Mesh
+metadata:
+  name: goodmesh
+spec:
+  tls:
+    incoming:
+      tlsMinVersion: TLSv1_2

--- a/consul/enforce-min-tls-version/resource.yaml
+++ b/consul/enforce-min-tls-version/resource.yaml
@@ -1,4 +1,3 @@
-###### Pods - Bad
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: Mesh
 metadata:
@@ -8,7 +7,6 @@ spec:
     incoming:
       tlsMinVersion: TLSv1_1
 --- 
-###### Pods - Good
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: Mesh
 metadata:


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->
 #446 
## Description
We want to create a policy for Consul service mesh to add a policy for the mesh configuration. The policy will check the TLS Min version to ensure that whenever the mesh is configured, there is a minimum version of TLS set for all the service mesh proxies.
cc @shivaylamba
<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
