### PR TITLE
adding a virtual service policy that blocks wildcards

### DIFF
--- a/istio/restrict-virtual-service-wildcard/kyverno-test.yaml
+++ b/istio/restrict-virtual-service-wildcard/kyverno-test.yaml
@@ -1,0 +1,16 @@
+name: restrict-virtual-service-wildcard
+policies:
+  - restrict-virtual-service-wildcard.yaml
+resources:
+  - resources.yaml
+results:
+  - policy: restrict-virtual-service-wildcard
+    rule: block-virtual-service-wildcard
+    resource: badvs
+    kind: VirtualService
+    result: fail
+  - policy: restrict-virtual-service-wildcard
+    rule: block-virtual-service-wildcard
+    resource: goodvs
+    kind: VirtualService
+    result: pass

--- a/istio/restrict-virtual-service-wildcard/resources.yaml
+++ b/istio/restrict-virtual-service-wildcard/resources.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: badvs
+spec:
+  hosts:
+  - "*.com"
+  gateways:
+  - bookinfo-gateway
+  http:
+  - match:
+    - uri:
+        exact: /productpage
+    - uri:
+        prefix: /static
+    - uri:
+        exact: /login
+    - uri:
+        exact: /logout
+    - uri:
+        prefix: /api/v1/products
+    route:
+    - destination:
+        host: productpage
+        port:
+          number: 9080
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: goodvs
+spec:
+  hosts:
+  - "foo.com"
+  gateways:
+  - bookinfo-gateway
+  http:
+  - match:
+    - uri:
+        exact: /productpage
+    - uri:
+        prefix: /static
+    - uri:
+        exact: /login
+    - uri:
+        exact: /logout
+    - uri:
+        prefix: /api/v1/products
+    route:
+    - destination:
+        host: productpage
+        port:
+          number: 9080

--- a/istio/restrict-virtual-service-wildcard/restrict-virtual-service-wildcard.yaml
+++ b/istio/restrict-virtual-service-wildcard/restrict-virtual-service-wildcard.yaml
@@ -4,9 +4,9 @@ metadata:
   name: restrict-virtual-service-wildcard
   annotations:
     policies.kyverno.io/title: Restrict Virtual Service Host with Wildcards
-    policies.kyverno.io/category: Other
+    policies.kyverno.io/category: Istio
     policies.kyverno.io/severity: medium
-    kyverno.io/kyverno-version: 1.6.2
+    kyverno.io/kyverno-version: 1.8.4
     policies.kyverno.io/minversion: 1.6.0
     kyverno.io/kubernetes-version: "1.23"
     policies.kyverno.io/subject: VirtualService
@@ -18,7 +18,7 @@ metadata:
       character and allows for more governance when a single mesh deployment 
       model is used.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   background: true
   rules:
     - name: block-virtual-service-wildcard

--- a/istio/restrict-virtual-service-wildcard/restrict-virtual-service-wildcard.yaml
+++ b/istio/restrict-virtual-service-wildcard/restrict-virtual-service-wildcard.yaml
@@ -1,0 +1,44 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-virtual-service-wildcard
+  annotations:
+    policies.kyverno.io/title: Restrict Virtual Service Host with Wildcards
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.6.2
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/subject: VirtualService
+    policies.kyverno.io/description: >-
+      Virtual Services optionally accept a wildcard as an alternative
+      to precise matching. In some cases, this may be too permissive as it
+      would direct unintended traffic to the given resource. This
+      policy enforces that any Virtual Service host does not contain a wildcard
+      character and allows for more governance when a single mesh deployment 
+      model is used.
+spec:
+  validationFailureAction: enforce
+  background: true
+  rules:
+    - name: block-virtual-service-wildcard
+      match:
+        any:
+        - resources:
+            kinds:
+              - VirtualService
+      preconditions:
+        all:
+        - key: "{{ request.operation || 'BACKGROUND' }}"
+          operator: AnyIn
+          value: ["CREATE", "UPDATE"]
+      validate:
+        message: "Wildcards are not permitted as hosts."
+        foreach:
+        - list: "request.object.spec.hosts"
+          deny:
+            conditions:
+              any:
+              - key: "{{ contains(element, '*') }}"
+                operator: Equals
+                value: true


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->
no related issue
## Description

<!--
What does this PR do?
-->
Adds an example policy that restricts wildcards in the hosts for a VirtualService.
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
