### PR TITLE
Policy updates for 1.9

### DIFF
--- a/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
+++ b/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/title: Disallow Default Namespace
+    policies.kyverno.io/minversion: 1.6.0
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
@@ -13,16 +14,19 @@ metadata:
       isolate cluster resources across multiple applications and users. As a best
       practice, workloads should be isolated with Namespaces. Namespaces should be required
       and the default (empty) Namespace should not be used. This policy validates that Pods
-      specify a Namespace name other than `default`.
+      specify a Namespace name other than `default`. Rule auto-generation is disabled here
+      due to Pod controllers need to specify the `namespace` field under the top-level `metadata`
+      object and not at the Pod template level.
 spec:
   validationFailureAction: audit
   background: true
   rules:
   - name: validate-namespace
     match:
-      resources:
-        kinds:
-        - Pod
+      any:
+      - resources:
+          kinds:
+          - Pod
     validate:
       message: "Using 'default' namespace is not allowed."
       pattern:
@@ -30,12 +34,13 @@ spec:
           namespace: "!default"
   - name: validate-podcontroller-namespace
     match:
-      resources:
-        kinds:
-        - DaemonSet
-        - Deployment
-        - Job
-        - StatefulSet
+      any:
+      - resources:
+          kinds:
+          - DaemonSet
+          - Deployment
+          - Job
+          - StatefulSet
     validate:
       message: "Using 'default' namespace is not allowed for pod controllers."
       pattern:

--- a/best-practices/require_drop_all/require_drop_all.yaml
+++ b/best-practices/require_drop_all/require_drop_all.yaml
@@ -12,7 +12,8 @@ metadata:
       Capabilities permit privileged actions without giving full root access. All
       capabilities should be dropped from a Pod, with only those required added back.
       This policy ensures that all containers explicitly specify the `drop: ["ALL"]`
-      ability.      
+      ability. Note that this policy also illustrates how to cover drop entries in any
+      case although this may not strictly conform to the Pod Security Standards.
 spec:
   validationFailureAction: audit
   background: true

--- a/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
+++ b/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
@@ -13,7 +13,8 @@ metadata:
       CAP_NET_RAW capability, enabled by default, allows processes in a container to
       forge packets and bind to any interface potentially leading to MitM attacks.
       This policy ensures that all containers explicitly drop the CAP_NET_RAW
-      ability.      
+      ability. Note that this policy also illustrates how to cover drop entries in any
+      case although this may not strictly conform to the Pod Security Standards.
 spec:
   validationFailureAction: audit
   background: true

--- a/other/advertise-node-extended-resources/advertise-node-extended-resources.yaml
+++ b/other/advertise-node-extended-resources/advertise-node-extended-resources.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: advertise-node-extended-resources
+  annotations:
+    policies.kyverno.io/title: Advertise Node Extended Resources
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.9.0
+    policies.kyverno.io/minversion: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: Node
+    policies.kyverno.io/description: >-
+      Kubernetes Nodes, in addition to standard compute resources like
+      CPU and memory, may offer extended resources such as FPGAs and GPUs, both
+      of which can be defined per custom design. These extended resources are
+      advertised in the `status` object of a Node. This policy, functional only
+      starting in Kyverno 1.9, adds the extended resource `example.com/dongle` with
+      a value/capacity of `2` to Kubernetes Nodes.
+spec:
+  background: false
+  rules:
+    - name: advertise-dongle
+      match:
+        any:
+        - resources:
+            kinds:
+            - Node/status
+      mutate:
+        patchStrategicMerge:
+          status:
+            capacity:
+              example.com/dongle: 2

--- a/other/allowed-image-repos/allowed-image-repos.yaml
+++ b/other/allowed-image-repos/allowed-image-repos.yaml
@@ -1,0 +1,38 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: allowed-image-repos
+  annotations:
+    policies.kyverno.io/title: Allowed Image Repositories
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      In addition to restricting the image registry from which images are pulled, in some cases
+      and environments it may be required to also restrict which image repositories are used, 
+      for example in some restricted Namespaces. This policy ensures that the only allowed
+      image repositories present in a given Pod, across any container type, come from the
+      designated list.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+    - name: good-repos
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          All images in this Pod must come from an authorized repository.
+        deny:
+          conditions:
+            all:
+            - key: "{{ images.[containers, initContainers, ephemeralContainers][].*.name[] }}"
+              operator: AnyNotIn
+              value:
+              - myknownimage
+              - kyverno

--- a/other/metadata-match-regex/metadata-match-regex.yaml
+++ b/other/metadata-match-regex/metadata-match-regex.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: metadata-match-regex
+  annotations:
+    policies.kyverno.io/title: Metadata Matches Regex
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod, Label
+    policies.kyverno.io/description: >-
+      Rather than a simple check to see if given metadata such as labels and annotations are present,
+      in some cases they need to be present and the values match a specified regular expression. This
+      policy illustrates how to ensure a label with key `corp.org/version` is both present and matches
+      a given regex, in this case ensuring semver is met.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+  - name: check-for-regex
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: >-
+        The label `corp.org/version` is required and must match the specified regex: ^v[0-9].[0-9].[0-9]$
+      deny:
+        conditions:
+          all:
+          - key: "{{ regex_match('^v[0-9].[0-9].[0-9]$','{{request.object.metadata.labels.\"corp.org/version\" || 'empty'}}') }}"
+            operator: Equals
+            value: false

--- a/other/pdb-maxunavailable/pdb-maxunavailable.yaml
+++ b/other/pdb-maxunavailable/pdb-maxunavailable.yaml
@@ -1,0 +1,30 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: pdb-maxunavailable
+  annotations:
+    policies.kyverno.io/title: PodDisruptionBudget maxUnavailable Non-Zero
+    policies.kyverno.io/category: Other
+    kyverno.io/kyverno-version: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: PodDisruptionBudget
+    policies.kyverno.io/description: >-
+      A PodDisruptionBudget which sets its maxUnavailable value to zero prevents
+      all voluntary evictions including Node drains which may impact maintenance tasks.
+      This policy enforces that if a PodDisruptionBudget specifies the maxUnavailable field
+      it must be greater than zero.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+    - name: pdb-maxunavailable
+      match:
+        any:
+          - resources:
+              kinds:
+                - PodDisruptionBudget
+      validate:
+        message: "The value of maxUnavailable must be greater than zero."
+        pattern:
+          spec:
+            =(maxUnavailable): ">0"

--- a/other/pdb-minavailable/pdb-minavailable.yaml
+++ b/other/pdb-minavailable/pdb-minavailable.yaml
@@ -1,0 +1,47 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: pdb-minavailable-check
+  annotations:
+    policies.kyverno.io/title: Check PodDisruptionBudget minAvailable
+    policies.kyverno.io/category: Other
+    kyverno.io/kyverno-version: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: PodDisruptionBudget, Deployment, StatefulSet
+    policies.kyverno.io/description: >-
+      When a Pod controller which can run multiple replicas is subject to an active PodDisruptionBudget,
+      if the replicas field has a value equal to the minAvailable value of the PodDisruptionBudget
+      it may prevent voluntary disruptions including Node drains which may impact routine maintenance
+      tasks and disrupt operations. This policy checks incoming Deployments and StatefulSets which have
+      a matching PodDisruptionBudget to ensure these two values do not match.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+    - name: pdb-minavailable
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+      preconditions:
+        all:
+          - key: "{{request.operation || 'BACKGROUND'}}"
+            operator: Equals
+            value: CREATE
+      context:
+        - name: minavailable
+          apiCall:
+            urlPath: "/apis/policy/v1/namespaces/{{request.namespace}}/poddisruptionbudgets"
+            jmesPath: "items[?label_match(spec.selector.matchLabels, `{{request.object.spec.template.metadata.labels}}`)] | [0] | spec.minAvailable || `0`"
+      validate:
+        message: >-
+          The matching PodDisruptionBudget for this resource has its minAvailable value equal to the replica count
+          which is not permitted.
+        deny:
+          conditions:
+            any:
+              - key: "{{ request.object.spec.replicas }}"
+                operator: Equals
+                value: "{{ minavailable }}"

--- a/other/policy-for-exceptions/policy-for-exceptions.yaml
+++ b/other/policy-for-exceptions/policy-for-exceptions.yaml
@@ -1,0 +1,90 @@
+apiVersion: kyverno.io/v2beta1
+kind: ClusterPolicy
+metadata:
+  name: policy-for-exceptions
+  annotations:
+    policies.kyverno.io/title: Policy for PolicyExceptions
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.9.0
+    kyverno.io/kyverno-version: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: PolicyException
+    policies.kyverno.io/description: >-
+      A PolicyException grants the applicable resource(s) or subject(s) the ability
+      to bypass an existing Kyverno policy. Care should be taken to ensure that
+      the allowed PolicyExceptions are scoped fine enough and according to your
+      organization's operation. This is a Kyverno policy intended to provide guardrails
+      for Kyverno PolicyExceptions and contains a number of rules which may help
+      with these scoping best practices. These rules may be changed/removed depending
+      on the exception practices to be implemented.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+  - name: single-policy
+    match:
+      any:
+      - resources:
+          kinds:
+          - PolicyException
+    validate:
+      message: >-
+        An exception is only allowed for a single policy.
+        Please create a separate exception per policy.
+      deny:
+        conditions:
+          any:
+          - key: "{{request.object.spec.exceptions[] | length(@)}}"
+            operator: GreaterThan
+            value: 1
+  - name: require-match-name
+    match:
+      any:
+      - resources:
+          kinds:
+          - PolicyException
+    validate:
+      message: >-
+        An exception must explicitly specify a name for a resource match.
+      pattern:
+        spec:
+          match:
+            =(any):
+            - resources:
+                names: "?*"
+            =(all):
+            - resources:
+                names: "?*"
+  - name: require-subject
+    match:
+      any:
+      - resources:
+          kinds:
+          - PolicyException
+    validate:
+      message: >-
+        An exception must explicitly specify a subject which is expected to create the resource.
+      pattern:
+        spec:
+          match:
+            =(any):
+            - subjects: 
+              - name: "?*"
+            =(all):
+            - subjects: 
+              - name: "?*"
+  - name: no-cross-namespace-exceptions
+    match:
+      any:
+      - resources:
+          kinds:
+          - PolicyException
+    validate:
+      message: >-
+        An exception can only be created in the same Namespace as the resource being excluded.
+      deny:
+        conditions:
+          any:
+          - key: "{{ request.object.spec.match.[any, all][].resources[].namespaces[] }}"
+            operator: AnyNotIn
+            value: "{{ request.namespace }}"

--- a/other/replace-ingress-hosts/replace-ingress-hosts.yaml
+++ b/other/replace-ingress-hosts/replace-ingress-hosts.yaml
@@ -1,0 +1,46 @@
+apiVersion: kyverno.io/v2beta1
+kind: ClusterPolicy
+metadata:
+  name: replace-ingress-hosts
+  annotations:
+    policies.kyverno.io/title: Replace Ingress Hosts
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.9.0
+    policies.kyverno.io/minversion: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: Ingress
+    policies.kyverno.io/description: >-
+      An Ingress may specify host names at a variety of locations in the same resource.
+      In some cases, those host names should be modified to, for example, update domain names
+      silently. The replacement must be done in all the fields where a host name can be specified.
+      This policy, illustrating the use of nested foreach loops and operable in Kyverno 1.9+, replaces
+      host names that end with `old.com` with `new.com`.
+spec:
+  background: false
+  rules:
+    - name: replace-old-with-new
+      match:
+        any:
+          - resources:
+              kinds:
+                - Ingress
+      mutate:
+        foreach:
+          - list: request.object.spec.rules
+            patchesJson6902: |-
+              - path: /spec/rules/{{elementIndex}}/host
+                op: replace
+                value: {{replace_all('{{element.host}}', '.old.com', '.new.com')}}
+          - list: request.object.spec.tls[]
+            foreach:
+              - list: "element.hosts"
+                patchesJson6902: |-
+                  - path: /spec/tls/{{elementIndex0}}/hosts/{{elementIndex1}}
+                    op: replace
+                    value: "{{ replace_all('{{element}}', '.old.com', '.new.com') }}"
+          - list: request.object.spec.tls[]
+            patchesJson6902: |-
+              - path: /spec/tls/{{elementIndex}}/secretName
+                op: replace
+                value: "{{ replace_all('{{element.secretName}}', '.old.com', '.new.com') }}"

--- a/other/require-annotations/require-annotations.yaml
+++ b/other/require-annotations/require-annotations.yaml
@@ -1,0 +1,30 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-annotations
+  annotations:
+    policies.kyverno.io/title: Require Annotations
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod, Annotation
+    policies.kyverno.io/description: >-
+      Define and use annotations that identify semantic attributes of your application or Deployment.
+      A common set of annotations allows tools to work collaboratively, describing objects in a common manner that
+      all tools can understand. The recommended annotations describe applications in a way that can be
+      queried. This policy validates that the annotation `corp.org/department` is specified with some value.      
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+  - name: check-for-annotation
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "The annotation `corp.org/department` is required."
+      pattern:
+        metadata:
+          annotations:
+            corp.org/department: "?*"

--- a/other/require-ingress-https/require-ingress-https.yaml
+++ b/other/require-ingress-https/require-ingress-https.yaml
@@ -1,0 +1,60 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-ingress-https
+  annotations:
+    policies.kyverno.io/title: Require Ingress HTTPS
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: Ingress
+    policies.kyverno.io/description: >-
+      Ingress resources should only allow secure traffic by disabling
+      HTTP and therefore only allowing HTTPS. This policy requires that all
+      Ingress resources set the annotation `kubernetes.io/ingress.allow-http` to
+      `"false"` and specify TLS in the spec.
+spec:
+  background: true
+  validationFailureAction: audit
+  rules:
+  - name: has-annotation
+    match:
+      any:
+      - resources:
+          kinds:
+          - Ingress
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+    validate:
+      message: "The kubernetes.io/ingress.allow-http annotation must be set to false."
+      pattern:
+        metadata:
+          annotations:
+            kubernetes.io/ingress.allow-http: "false"
+  - name: has-tls
+    match:
+      any:
+      - resources:
+          kinds:
+          - Ingress
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+    validate:
+      message: "TLS must be defined."
+      deny:
+        conditions:
+          all:
+          - key: tls
+            operator: AnyNotIn
+            value: "{{ request.object.spec.keys(@) }}"

--- a/other/require-unique-service-selector/require-unique-service-selector.yaml
+++ b/other/require-unique-service-selector/require-unique-service-selector.yaml
@@ -1,0 +1,46 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-unique-service-selector
+  annotations:
+    policies.kyverno.io/title: Require Unique Service Selector
+    policies.kyverno.io/category: Other
+    kyverno.io/kyverno-version: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: Service
+    policies.kyverno.io/description: >-
+      Services select eligible Pods by way of label matches. Having multiple
+      Service apply based on same labels can cause conflicts and have unintended
+      consequences. This policy ensures that within the same Namespace a Service has
+      a unique set of labels as a selector.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+    - name: check-service-selector
+      match:
+        any:
+          - resources:
+              kinds:
+                - Service
+      preconditions:
+        all:
+          - key: "{{request.operation || 'BACKGROUND'}}"
+            operator: NotEquals
+            value: DELETE
+      context:
+        - name: services
+          apiCall:
+            urlPath: "/api/v1/namespaces/{{request.namespace}}/services"
+            jmesPath: "items[?spec.selector]"
+        - name: service_count
+          variable:
+            jmesPath: "services[?label_match(spec.selector, `{{request.object.spec.selector}}`)] | length(@)"
+      validate:
+        message: "There is already a matching selector for this Service."
+        deny:
+          conditions:
+            any:
+              - key: "{{service_count}}"
+                operator: GreaterThan
+                value: 0

--- a/other/require_vuln_scan/require-vulnerability-scan.yaml
+++ b/other/require_vuln_scan/require-vulnerability-scan.yaml
@@ -4,7 +4,7 @@ metadata:
   name: require-vulnerability-scan
   annotations:
     policies.kyverno.io/title: Require Image Vulnerability Scans
-    policies.kyverno.io/category: Other
+    policies.kyverno.io/category: Software Supply Chain Security
     policies.kyverno.io/severity: medium
     kyverno.io/kyverno-version: 1.9.0
     policies.kyverno.io/minversion: 1.8.3

--- a/other/require_vuln_scan/require-vulnerability-scan.yaml
+++ b/other/require_vuln_scan/require-vulnerability-scan.yaml
@@ -6,9 +6,9 @@ metadata:
     policies.kyverno.io/title: Require Image Vulnerability Scans
     policies.kyverno.io/category: Other
     policies.kyverno.io/severity: medium
-    kyverno.io/kyverno-version: 1.7.0
-    policies.kyverno.io/minversion: 1.7.0
-    kyverno.io/kubernetes-version: "1.23"
+    kyverno.io/kyverno-version: 1.9.0
+    policies.kyverno.io/minversion: 1.8.3
+    kyverno.io/kubernetes-version: "1.24"
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       An important part of ensuring software supply chain integrity is performing
@@ -32,13 +32,15 @@ spec:
       verifyImages:
       - imageReferences:
         - "ghcr.io/myorg/myrepo:*"
-        attestors:
-        - entries:
-          - keyless:
-              subject: "https://github.com/myorg/myrepo/.github/workflows/*"
-              issuer: "https://token.actions.githubusercontent.com"
         attestations:
         - predicateType: cosign.sigstore.dev/attestation/vuln/v1
+          attestors:
+          - entries:
+            - keyless:
+                subject: "https://github.com/myorg/myrepo/.github/workflows/*"
+                issuer: "https://token.actions.githubusercontent.com"
+                rekor:
+                  url: https://rekor.sigstore.dev
           conditions:
           - all:
             - key: "{{ time_since('','{{metadata.scanFinishedOn}}','') }}"

--- a/other/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml
+++ b/other/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml
@@ -1,0 +1,41 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-edit-for-endpoints
+  annotations:
+    policies.kyverno.io/title: Restrict Edit for Endpoints CVE-2021-25740
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/subject: ClusterRole
+    kyverno.io/kyverno-version: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/description: >-
+      Clusters not initially installed with Kubernetes 1.22 may be vulnerable to an issue
+      defined in CVE-2021-25740 which could enable users to send network traffic to locations
+      they would otherwise not have access to via a confused deputy attack. This was due to
+      the system:aggregate-to-edit ClusterRole having edit permission of Endpoints.
+      This policy, intended to run in background mode, checks if your cluster is vulnerable
+      to CVE-2021-25740 by ensuring the system:aggregate-to-edit ClusterRole does not have
+      the edit permission of Endpoints.
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+    - name: system-aggregate-to-edit-check
+      match:
+        any:
+        - resources:
+            kinds:
+            - ClusterRole
+            names:
+            - system:aggregate-to-edit
+      validate:
+        message: >-
+          This cluster may still be vulnerable to CVE-2021-25740. The system:aggregate-to-edit ClusterRole
+          should not have edit permission over Endpoints.
+        deny:
+          conditions:
+            all:
+            - key: edit
+              operator: AnyIn
+              value: "{{ request.object.rules[?resources[?contains(@,'endpoints')]].verbs[] }}"

--- a/other/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.yaml
+++ b/other/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.yaml
@@ -1,0 +1,66 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-pod-controller-serviceaccount-updates
+  annotations:
+    policies.kyverno.io/title: Restrict Pod Controller ServiceAccount Updates
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: Medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/description: >-
+      ServiceAccounts which have the ability to edit/patch workloads which they created
+      may potentially use that privilege to update to a different ServiceAccount with higher
+      privileges. This policy, intended to be run in `enforce` mode, blocks updates
+      to Pod controllers if those updates modify the serviceAccountName field. Updates to Pods
+      directly for this field are not possible as it is immutable once set.
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+    - name: block-serviceaccount-updates
+      match:
+        any:
+        - resources:
+            kinds:
+            - DaemonSet
+            - Deployment
+            - Job
+            - StatefulSet
+            - ReplicaSet
+            - ReplicationController
+      preconditions:
+        all:
+        - key: "{{ request.operation }}"
+          operator: Equals
+          value: UPDATE
+      validate:
+        message: >-
+          The serviceAccountName field may not be changed once created.
+        deny:
+          conditions:
+            all:
+            - key: "{{ request.object.spec.template.spec.serviceAccountName || 'empty'}}"
+              operator: NotEquals
+              value: "{{ request.oldObject.spec.template.spec.serviceAccountName || 'empty'}}"
+    - name: block-serviceaccount-updates-cronjob
+      match:
+        any:
+        - resources:
+            kinds:
+            - CronJob
+      preconditions:
+        all:
+        - key: "{{ request.operation }}"
+          operator: Equals
+          value: UPDATE
+      validate:
+        message: >-
+          The serviceAccountName field may not be changed once created.
+        deny:
+          conditions:
+            all:
+            - key: "{{ request.object.spec.jobTemplate.spec.template.spec.serviceAccountName || 'empty'}}"
+              operator: NotEquals
+              value: "{{ request.oldObject.spec.jobTemplate.spec.template.spec.serviceAccountName || 'empty'}}"

--- a/other/restrict-scale/restrict-scale.yaml
+++ b/other/restrict-scale/restrict-scale.yaml
@@ -1,0 +1,87 @@
+apiVersion: kyverno.io/v2beta1
+kind: ClusterPolicy
+metadata:
+  name: restrict-scale
+  annotations:
+    policies.kyverno.io/title: Restrict Scale
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.9.0
+    policies.kyverno.io/minversion: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: Deployment
+    policies.kyverno.io/description: >-
+      Pod controllers such as Deployments which implement replicas and permit the scale action
+      use a `/scale` subresource to control this behavior. In addition to checks for creations of
+      such controllers that their replica is in a certain shape, the scale operation and subresource
+      needs to be accounted for as well. This policy, operable beginning in Kyverno 1.9, is a collection
+      of rules which can be used to limit the replica count both upon creation of a Deployment and
+      when a scale operation is performed.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+  # This rule can be used to limit scale operations based upon Deployment labels assuming the given label
+  # is also used as a selector.
+  - name: scale-max-eight
+    match:
+      any:
+      - resources:
+          kinds:
+          - Deployment/scale
+    validate:
+      message: The replica count for this Deployment may not exceed 8.
+      pattern:
+        =(status):
+          =(selector): "*type=monitoring*"
+        spec:
+          replicas: <9
+  # This rule can be used for more advanced decision making, for example limiting scale based
+  # upon Deployment annotations which are not sent by the API server to admission controllers
+  # when a scale is performed.
+  - name: scale-max-eight-annotations
+    match:
+      any:
+      - resources:
+          kinds:
+          - Deployment/scale
+    context:
+      - name: parentdeploy
+        apiCall:
+          urlPath: "/apis/apps/v1/namespaces/{{request.namespace}}/deployments?fieldSelector=metadata.name={{request.name}}"
+          jmesPath: "items[0]"
+      - name: dept
+        variable:
+          jmesPath: parentdeploy.metadata.annotations."corp.org/dept"
+          default: empty
+    validate:
+      message: The replica count for this Deployment may not exceed 8.
+      deny:
+        conditions:
+          all:
+          - key: "{{dept}}"
+            operator: Equals
+            value: engineering
+          - key: "{{request.object.spec.replicas}}"
+            operator: GreaterThan
+            value: 8
+  # This rule, which is a simple check on Deployments for replicas (not scaling them) can be used
+  # to complement scale operations. This may be needed along with at least one of the prior two rules
+  # to fully limit the number of total replicas allowed. For example, this rule would limit creation of
+  # Deployments to no more than 4 replicas, without an additional rule for scaling it would not prevent
+  # scaling over 4. By combining this CREATE rule with one of the scale rules above, a cluster admin
+  # may effectively provide an allowed range of replicas good for both day1 and day2 operations.
+  - name: create-max-four
+    match:
+      any:
+      - resources:
+          kinds:
+          - Deployment
+          selector:
+            matchLabels:
+              type: monitoring
+    validate:
+      message: The replica count for this Deployment may not exceed 4.
+      pattern:
+        spec:
+          replicas: <5

--- a/other/verify-image-gcpkms.yaml
+++ b/other/verify-image-gcpkms.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-image-gcpkms
+  annotations:
+    policies.kyverno.io/title: Verify Image GCP KMS
+    policies.kyverno.io/category: Software Supply Chain Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.8.1
+    policies.kyverno.io/description: >-
+      Using the Cosign project, OCI images may be signed to ensure supply chain
+      security is maintained. Those signatures can be verified before pulling into
+      a cluster. This policy checks the signature of an image repo called
+      ghcr.io/kyverno/test-verify-image to ensure it has been signed by verifying
+      its signature against the provided public key. This policy serves as an illustration for
+      how to configure a similar rule and will require replacing with your image(s) and keys.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+    - name: verify-image
+      match:
+        any:
+        - resources:
+            kinds:
+            - Pod
+      verifyImages:
+      - imageReferences:
+        - "ghcr.io/kyverno/test-verify-image:*"
+        attestors:
+        - count: 1
+          entries:
+          - keys:
+              kms: gcpkms://projects/omni-163105/locations/asia-south1/keyRings/first-ring/cryptoKeys/jerry/versions/1

--- a/other/verify_image.yaml
+++ b/other/verify_image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: verify-image
   annotations:
     policies.kyverno.io/title: Verify Image
-    policies.kyverno.io/category: Sample, EKS Best Practices
+    policies.kyverno.io/category: Software Supply Chain Security, EKS Best Practices
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.7.0

--- a/other/verify_image.yaml
+++ b/other/verify_image.yaml
@@ -27,7 +27,7 @@ spec:
               - Pod
       verifyImages:
       - imageReferences:
-        - "ghcr.io/kyverno/test-verify-image:*"
+        - "ghcr.io/kyverno/test-verify-image*"
         mutateDigest: true
         attestors:
         - entries:

--- a/other/verify_image_cve-2022-42889.yaml
+++ b/other/verify_image_cve-2022-42889.yaml
@@ -7,8 +7,8 @@ metadata:
     policies.kyverno.io/category: Security
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-    policies.kyverno.io/minversion: 1.7.0
-    kyverno.io/kyverno-version: 1.8.1
+    policies.kyverno.io/minversion: 1.8.3
+    kyverno.io/kyverno-version: 1.9.0
     kyverno.io/kubernetes-version: "1.24"
     policies.kyverno.io/description: >-
       CVE-2022-42889 is a critical vulnerability in the Apache Commons Text library which
@@ -31,13 +31,15 @@ spec:
       verifyImages:
       - imageReferences:
         - "myreg.org/myrepo/someimage*"
-        attestors:
-        - entries:
-          - keyless:
-              subject: "mysubject"
-              issuer: "myissuer"
         attestations:
         - predicateType: https://cyclonedx.org/schema
+          attestors:
+          - entries:
+            - keyless:
+                subject: "mysubject"
+                issuer: "myissuer"
+                rekor:
+                  url: https://rekor.sigstore.dev
           conditions:
           - all:
             - key: "{{ components[?name=='commons-text'].version || 'none' }}"

--- a/other/verify_image_cve-2022-42889.yaml
+++ b/other/verify_image_cve-2022-42889.yaml
@@ -4,7 +4,7 @@ metadata:
   name: check-image-vulns-cve-2022-42889
   annotations:
     policies.kyverno.io/title: Verify Image Check CVE-2022-42889
-    policies.kyverno.io/category: Security
+    policies.kyverno.io/category: Software Supply Chain Security
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.8.3

--- a/other/verify_image_slsa.yaml
+++ b/other/verify_image_slsa.yaml
@@ -18,7 +18,7 @@ metadata:
       when produced through GitHub Actions. It requires configuration based upon
       your own values.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: audit
   webhookTimeoutSeconds: 30
   rules:
     - name: check-slsa-keyless
@@ -30,24 +30,21 @@ spec:
       verifyImages:
       - imageReferences:
         - "myreg.org/path/repo:*"
-        attestors:
-        - entries:
-          - keyless:
-            # In the case of GitHub Actions, the subject will be set to your Actions workflow responsible
-            # for kicking off the process. Note that this will not be set to the external action
-            # responsible for the provenance generation.
-              subject: "https://github.com/myname/myrepo/.github/workflows/my-workflow.yaml@refs/heads/mybranch"
-              issuer: "https://token.actions.githubusercontent.com"
         attestations:
         - predicateType: https://slsa.dev/provenance/v0.2
+          attestors:
+          - count: 1
+            entries:
+            - keyless:
+                subject: "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v*"
+                issuer: "https://token.actions.githubusercontent.com"
+                rekor:
+                  url: https://rekor.sigstore.dev
           conditions:
           - all:
-            - key: "{{ invocation.configSource.uri }}"
-              operator: Equals
-              value: "git+https://github.com/myname/myrepo@refs/heads/mybranch"
-            - key: "{{ invocation.configSource.entryPoint }}"
-              operator: Equals
-              value: ".github/workflows/my-workflow.yaml"
-            - key: "{{ regex_match('^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v[0-9].[0-9].[0-9]$','{{ builder.id}}') }}"
+            # This expression uses a regex pattern to ensure the builder.id in the attestation is equal to the official
+            # SLSA provenance generator workflow and uses a tagged release in semver format. If using a specific SLSA
+            # provenance generation workflow, you may need to adjust the first input as necessary.
+            - key: "{{ regex_match('^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9].[0-9].[0-9]$','{{ builder.id}}') }}"
               operator: Equals
               value: true

--- a/other/verify_image_slsa.yaml
+++ b/other/verify_image_slsa.yaml
@@ -7,9 +7,9 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
-    policies.kyverno.io/minversion: 1.7.0
-    kyverno.io/kyverno-version: 1.7.2
-    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/minversion: 1.8.3
+    kyverno.io/kyverno-version: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
     policies.kyverno.io/description: >-
       Provenance is used to identify how an artifact was produced
       and from where it originated. SLSA provenance is an industry-standard

--- a/other/verify_image_slsa.yaml
+++ b/other/verify_image_slsa.yaml
@@ -4,7 +4,7 @@ metadata:
   name: verify-slsa-provenance-keyless
   annotations:
     policies.kyverno.io/title: Verify SLSA Provenance (Keyless)
-    policies.kyverno.io/category: Sample
+    policies.kyverno.io/category: Software Supply Chain Security
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.8.3

--- a/other/verify_image_with_multi_keys.yaml
+++ b/other/verify_image_with_multi_keys.yaml
@@ -4,7 +4,7 @@ metadata:
   name: verify-image-with-multi-keys
   annotations:
     policies.kyverno.io/title: Verify Image with Multiple Keys
-    policies.kyverno.io/category: Sample
+    policies.kyverno.io/category: Software Supply Chain Security
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.7.0

--- a/other/verify_sbom_cyclonedx.yaml
+++ b/other/verify_sbom_cyclonedx.yaml
@@ -1,0 +1,46 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-sbom-cyclonedx
+  annotations:
+    policies.kyverno.io/title: Verify CycloneDX SBOM (Keyless)
+    policies.kyverno.io/category: Software Supply Chain Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.8.3
+    kyverno.io/kyverno-version: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/description: >-
+      Software Bill of Materials (SBOM) provide details on the composition of a given
+      container image and may be represented in a couple different standards.
+      Having an SBOM can be important to ensuring images are built using verified
+      processes. This policy verifies that an image has an SBOM in CycloneDX format
+      and was signed by the expected subject and issuer when produced through GitHub Actions
+      and using Cosign's keyless signing. It requires configuration based upon your own values.
+spec:
+  validationFailureAction: audit
+  webhookTimeoutSeconds: 30
+  rules:
+    - name: check-sbom
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      verifyImages:
+      - imageReferences:
+        - "myreg.org/path/repo:*"
+        attestations:
+        - predicateType: https://cyclonedx.org/schema
+          attestors:
+          - entries:
+            - keyless:
+                subject: "mysubject"
+                issuer: "https://token.actions.githubusercontent.com"
+                rekor:
+                  url: https://rekor.sigstore.dev
+          conditions:
+          - all:
+            - key: "{{ Data.bomFormat }}"
+              operator: Equals
+              value: CycloneDX

--- a/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
+++ b/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
@@ -38,7 +38,7 @@ spec:
                 all:
                 - key: ALL
                   operator: AnyNotIn
-                  value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || `[]` }}"
+                  value: "{{ element.securityContext.capabilities.drop[] || `[]` }}"
     - name: adding-capabilities-strict
       match:
         any:
@@ -58,7 +58,7 @@ spec:
             deny:
               conditions:
                 all:
-                - key: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+                - key: "{{ element.securityContext.capabilities.add[] || `[]` }}"
                   operator: AnyNotIn
                   value:
                   - NET_BIND_SERVICE

--- a/tekton/verify-tekton-taskrun-vuln-scan/verify-tekton-taskrun-vuln-scan.yaml
+++ b/tekton/verify-tekton-taskrun-vuln-scan/verify-tekton-taskrun-vuln-scan.yaml
@@ -32,16 +32,16 @@ spec:
     verifyImages:
     - imageReferences:
       - "*"
-      attestors:
-      - entries:
-        - keys:
-            publicKeys: |-
-              -----BEGIN PUBLIC KEY-----
-              MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEahmSvGFmxMJABilV1usgsw6ImcQ/
-              gDaxw57Sq+uNGHW8Q3zUSx46PuRqdTI+4qE3Ng2oFZgLMpFN/qMrP0MQQg==
-              -----END PUBLIC KEY-----          
       attestations:
       - predicateType: https://grype.anchore.io/scan
+        attestors:
+        - entries:
+          - keys:
+              publicKeys: |-
+                -----BEGIN PUBLIC KEY-----
+                MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEahmSvGFmxMJABilV1usgsw6ImcQ/
+                gDaxw57Sq+uNGHW8Q3zUSx46PuRqdTI+4qE3Ng2oFZgLMpFN/qMrP0MQQg==
+                -----END PUBLIC KEY-----          
         conditions:
         - any:
           - key: "{{ matches[].vulnerability[].cvss[?metrics.impactScore > '8.0'][] | length(@) }}"


### PR DESCRIPTION
## Related Issue(s)

Closes #373 
Fixes #440
Fixes #450 
Fixes #457
Closes #478
Closes #479 
Closes #480 
Fixes #483

## Description

Adds these new validate policies without tests:

* Allowed Image Repositories
* Metadata Matches Regex
* PodDisruptionBudget maxUnavailable Non-Zero
* Check PodDisruptionBudget minAvailable
* Require Annotations
* Require Ingress HTTPS
* Require Unique Service Selector
* Restrict Edit for Endpoints CVE-2021-25740
* Restrict Pod Controller ServiceAccount Updates
* Verify CycloneDX SBOM (Keyless)
* Verify Image GCP KMS (restored from a previous removal)
* Policy for PolicyExceptions
* Restrict Scale
* Advertise Node Extended Resources
* Replace Ingress Hosts

Updates these policies for attestation changes in Kyverno 1.8.3:

* Verify Image Check CVE-2022-42889
* Require Image Vulnerability Scans
* Verify SLSA Provenance (Keyless)
* Check Tekton TaskRun Vulnerability Scan

Standardizes most of the verifyImages policies on a common category called "Software Supply Chain Security"
Walks back changes to the PSS Restricted policy to not use `to_upper()`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
