### PR TITLE
Add pdb checks

### DIFF
--- a/best-practices/require_reasonable_pdbs/kyverno-test.yaml
+++ b/best-practices/require_reasonable_pdbs/kyverno-test.yaml
@@ -1,0 +1,65 @@
+name: require-reasonable-pdbs
+policies:
+  - require_reasonable_pdbs.yaml
+resources:
+  - resource.yaml
+variables: variables.yaml
+results:
+  - policy: require-reasonable-pdbs
+    rule: require-resonable-pdb-percentage
+    resource: require-resonable-pdb-percentage-bad
+    kind: PodDisruptionBudget
+    result: fail
+  - policy: require-reasonable-pdbs
+    rule: require-resonable-pdb-percentage
+    resource: require-resonable-pdb-percentage-good
+    kind: PodDisruptionBudget
+    result: pass
+  - policy: require-reasonable-pdbs
+    rule: deployment-replicas-higher-than-pdb-minAvailable
+    resource: deployment-replicas-higher-than-pdb-minAvailable-bad
+    kind: PodDisruptionBudget
+    namespace: default
+    result: fail
+  - policy: require-reasonable-pdbs
+    rule: deployment-replicas-higher-than-pdb-minAvailable
+    resource: deployment-replicas-higher-than-pdb-minAvailable-good
+    kind: PodDisruptionBudget
+    namespace: default
+    result: pass
+  - policy: require-reasonable-pdbs
+    rule: statefulset-replicas-higher-than-pdb-minAvailable
+    resource: statefulset-replicas-higher-than-pdb-minAvailable-bad
+    kind: PodDisruptionBudget
+    namespace: default
+    result: fail
+  - policy: require-reasonable-pdbs
+    rule: statefulset-replicas-higher-than-pdb-minAvailable
+    resource: statefulset-replicas-higher-than-pdb-minAvailable-good
+    kind: PodDisruptionBudget
+    namespace: default
+    result: pass
+  - policy: require-reasonable-pdbs
+    rule: replicaset-replicas-higher-than-pdb-minAvailable
+    resource: replicaset-replicas-higher-than-pdb-minAvailable-bad
+    kind: PodDisruptionBudget
+    namespace: default
+    result: fail
+  - policy: require-reasonable-pdbs
+    rule: replicaset-replicas-higher-than-pdb-minAvailable
+    resource: replicaset-replicas-higher-than-pdb-minAvailable-good
+    kind: PodDisruptionBudget
+    namespace: default
+    result: pass
+  - policy: require-reasonable-pdbs
+    rule: pdb-maxUnavailable-zero
+    resource: pdb-maxUnavailable-zero-bad
+    kind: PodDisruptionBudget
+    namespace: default
+    result: fail
+  - policy: require-reasonable-pdbs
+    rule: pdb-maxUnavailable-zero
+    resource: pdb-maxUnavailable-zero-good
+    kind: PodDisruptionBudget
+    namespace: default
+    result: pass

--- a/best-practices/require_reasonable_pdbs/require_reasonable_pdbs.yaml
+++ b/best-practices/require_reasonable_pdbs/require_reasonable_pdbs.yaml
@@ -44,10 +44,10 @@ spec:
         kinds:
         - PodDisruptionBudget
     context:
-    - apiCall:
+    - name: deploymentreplicas
+      apiCall:
         jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
-        urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/deployments
-      name: deploymentreplicas 
+        urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/deployments 
     preconditions:
       all:
       - key: '{{ regex_match(''^[0-9]+$'', ''{{ request.object.spec.minAvailable || ''''}}'') }}'
@@ -70,10 +70,10 @@ spec:
         kinds:
         - PodDisruptionBudget
     context:
-    - apiCall:
+    - name: statefulsetreplicas
+      apiCall:
         jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
         urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/statefulsets
-      name: statefulsetreplicas
     preconditions:
       all:
       - key: '{{ regex_match(''^[0-9]+$'', ''{{ request.object.spec.minAvailable || ''''}}'') }}'
@@ -96,10 +96,10 @@ spec:
         kinds:
         - PodDisruptionBudget
     context:
-    - apiCall:
+    - name: replicasetreplicas
+      apiCall:
         jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
         urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/replicasets
-      name: replicasetreplicas
     preconditions:
       all:
       - key: '{{ regex_match(''^[0-9]+$'', ''{{ request.object.spec.minAvailable || ''''}}'') }}'
@@ -122,18 +122,18 @@ spec:
         kinds:
         - PodDisruptionBudget
     context:
-    - apiCall:
+    - name: deploymentreplicas
+      apiCall:
         jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
         urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/deployments
-      name: deploymentreplicas
-    - apiCall:
+    - name: statefulsetreplicas
+      apiCall:
         jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
         urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/statefulsets
-      name: statefulsetreplicas
-    - apiCall:
+    - name: replicasetreplicas
+      apiCall:
         jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
         urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/replicasets
-      name: replicasetreplicas
     preconditions:
       all:
       - key: '{{ regex_match(''^[0-9]+$'', ''{{ request.object.spec.maxUnavailable || ''''}}'') }}'

--- a/best-practices/require_reasonable_pdbs/require_reasonable_pdbs.yaml
+++ b/best-practices/require_reasonable_pdbs/require_reasonable_pdbs.yaml
@@ -1,0 +1,158 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-reasonable-pdbs
+  annotations:
+    policies.kyverno.io/title: Require Reasonable PDBs
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: PodDisruptionBudget
+    policies.kyverno.io/description: >-
+      PodDisruptionBudget resources are useful to ensuring mimimum availability is maintained at all time.
+      This policy validates that a PodDisruptionBudget with multiple replicas allows disruption.
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+  - name: require-resonable-pdb-percentage
+    match:
+      resources:
+        kinds:
+        - PodDisruptionBudget
+    preconditions:
+      any:
+      - key: '{{ regex_match(''^[0-9]+%$'', ''{{ request.object.spec.minAvailable || ''''}}'') }}'
+        operator: Equals
+        value: true
+      - key: '{{ regex_match(''^[0-9]+%$'', ''{{ request.object.spec.maxUnavailable || ''''}}'') }}'
+        operator: Equals
+        value: true
+    validate:
+      message: PodDisruptionBudget percentages should allow 50% out of service
+      deny:
+        conditions:
+          any:
+          - key: '{{ regex_match(''^([1-9]|[14][0-9]|5[0])%$'', ''{{ request.object.spec.minAvailable || ''50%''}}'') }}'
+            operator: Equals
+            value: false
+          - key: '{{ regex_match(''^([5-9][0-9]|100)%$'', ''{{ request.object.spec.maxUnavailable || ''50%''}}'') }}'
+            operator: Equals
+            value: false
+  - name: deployment-replicas-higher-than-pdb-minAvailable
+    match:
+      resources:
+        kinds:
+        - PodDisruptionBudget
+    context:
+    - apiCall:
+        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/deployments
+      name: deploymentreplicas 
+    preconditions:
+      all:
+      - key: '{{ regex_match(''^[0-9]+$'', ''{{ request.object.spec.minAvailable || ''''}}'') }}'
+        operator: Equals
+        value: true
+      - key: '{{ deploymentreplicas[0] }}'
+        operator: GreaterThan
+        value: 1
+    validate:
+      message: PodDisruption budget minAvailable ({{ request.object.spec.minAvailable }}) cannot be the same or higher than the replica count ({{ deploymentreplicas[0] }})
+      deny:
+        conditions:
+          all:
+          - key: '{{ request.object.spec.minAvailable }}'
+            operator: GreaterThanOrEquals
+            value: '{{ deploymentreplicas[0] }}'
+  - name: statefulset-replicas-higher-than-pdb-minAvailable
+    match:
+      resources:
+        kinds:
+        - PodDisruptionBudget
+    context:
+    - apiCall:
+        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/statefulsets
+      name: statefulsetreplicas
+    preconditions:
+      all:
+      - key: '{{ regex_match(''^[0-9]+$'', ''{{ request.object.spec.minAvailable || ''''}}'') }}'
+        operator: Equals
+        value: true
+      - key: '{{ statefulsetreplicas[0] }}'
+        operator: GreaterThan
+        value: 1
+    validate:
+      message: PodDisruption budget minAvailable ({{ request.object.spec.minAvailable }}) cannot be the same or higher than the replica count ({{ statefulsetreplicas[0] }})
+      deny:
+        conditions:
+          all:
+          - key: '{{ request.object.spec.minAvailable }}'
+            operator: GreaterThanOrEquals
+            value: '{{ statefulsetreplicas[0] }}'
+  - name: replicaset-replicas-higher-than-pdb-minAvailable
+    match:
+      resources:
+        kinds:
+        - PodDisruptionBudget
+    context:
+    - apiCall:
+        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/replicasets
+      name: replicasetreplicas
+    preconditions:
+      all:
+      - key: '{{ regex_match(''^[0-9]+$'', ''{{ request.object.spec.minAvailable || ''''}}'') }}'
+        operator: Equals
+        value: true
+      - key: '{{ replicasetreplicas[0] }}'
+        operator: GreaterThan
+        value: 1
+    validate:
+      message: PodDisruption budget minAvailable ({{ request.object.spec.minAvailable }}) cannot be the same or higher than the replica count ({{ replicasetreplicas[0] }})
+      deny:
+        conditions:
+          any:
+          - key: '{{ request.object.spec.minAvailable }}'
+            operator: GreaterThanOrEquals
+            value: '{{ replicasetreplicas[0] }}'
+  - name: pdb-maxUnavailable-zero
+    match:
+      resources:
+        kinds:
+        - PodDisruptionBudget
+    context:
+    - apiCall:
+        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/deployments
+      name: deploymentreplicas
+    - apiCall:
+        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/statefulsets
+      name: statefulsetreplicas
+    - apiCall:
+        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/replicasets
+      name: replicasetreplicas
+    preconditions:
+      all:
+      - key: '{{ regex_match(''^[0-9]+$'', ''{{ request.object.spec.maxUnavailable || ''''}}'') }}'
+        operator: Equals
+        value: true
+      any:
+      - key: '{{ deploymentreplicas[0] }}'
+        operator: GreaterThan
+        value: 1
+      - key: '{{ statefulsetreplicas[0] }}'
+        operator: GreaterThan
+        value: 1
+      - key: '{{ replicasetreplicas[0] }}'
+        operator: GreaterThan
+        value: 1
+    validate:
+      message: PodDisruptionBudget maxUnavailable ({{ request.object.spec.maxUnavailable }}) must be greater than 0
+      deny:
+        conditions:
+        - key: '{{ request.object.spec.maxUnavailable || '''' }}'
+          operator: Equals
+          value: 0

--- a/best-practices/require_reasonable_pdbs/require_reasonable_pdbs.yaml
+++ b/best-practices/require_reasonable_pdbs/require_reasonable_pdbs.yaml
@@ -46,7 +46,7 @@ spec:
     context:
     - name: deploymentreplicas
       apiCall:
-        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        jmesPath: items[?label_match(`{{request.object.spec.selector.matchLabels}}`, spec.template.metadata.labels)].spec.replicas || `[0]`
         urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/deployments 
     preconditions:
       all:
@@ -72,7 +72,7 @@ spec:
     context:
     - name: statefulsetreplicas
       apiCall:
-        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        jmesPath: items[?label_match(`{{request.object.spec.selector.matchLabels}}`, spec.template.metadata.labels)].spec.replicas || `[0]`
         urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/statefulsets
     preconditions:
       all:
@@ -98,7 +98,7 @@ spec:
     context:
     - name: replicasetreplicas
       apiCall:
-        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        jmesPath: items[?label_match(`{{request.object.spec.selector.matchLabels}}`, spec.template.metadata.labels)].spec.replicas || `[0]`
         urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/replicasets
     preconditions:
       all:
@@ -124,15 +124,15 @@ spec:
     context:
     - name: deploymentreplicas
       apiCall:
-        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        jmesPath: items[?label_match(`{{request.object.spec.selector.matchLabels}}`, spec.template.metadata.labels)].spec.replicas || `[0]`
         urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/deployments
     - name: statefulsetreplicas
       apiCall:
-        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        jmesPath: items[?label_match(`{{request.object.spec.selector.matchLabels}}`, spec.template.metadata.labels)].spec.replicas || `[0]`
         urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/statefulsets
     - name: replicasetreplicas
       apiCall:
-        jmesPath: items[?label_match(spec.template.metadata.labels, `{{request.object.spec.selector.matchLabels}}`)].spec.replicas || `[0]`
+        jmesPath: items[?label_match(`{{request.object.spec.selector.matchLabels}}`, spec.template.metadata.labels)].spec.replicas || `[0]`
         urlPath: /apis/apps/v1/namespaces/{{request.namespace}}/replicasets
     preconditions:
       all:

--- a/best-practices/require_reasonable_pdbs/resource.yaml
+++ b/best-practices/require_reasonable_pdbs/resource.yaml
@@ -1,0 +1,107 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: require-resonable-pdb-percentage-bad
+spec:
+  minAvailable: 100%
+  selector:
+    matchLabels:
+      app: require-resonable-pdb-percentage-bad
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: require-resonable-pdb-percentage-good
+spec:
+  maxUnavailable: 75%
+  selector:
+    matchLabels:
+      app: require-resonable-pdb-percentage-good
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: deployment-replicas-higher-than-pdb-minAvailable-bad
+  namespace: default
+spec:
+  minAvailable: 3
+  selector:
+    matchLabels:
+      app: deployment-replicas-higher-than-pdb-minAvailable-bad
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: deployment-replicas-higher-than-pdb-minAvailable-good
+  namespace: default
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: deployment-replicas-higher-than-pdb-minAvailable-good
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: statefulset-replicas-higher-than-pdb-minAvailable-bad
+  namespace: default
+spec:
+  minAvailable: 3
+  selector:
+    matchLabels:
+      app: statefulset-replicas-higher-than-pdb-minAvailable-bad
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: replicaset-replicas-higher-than-pdb-minAvailable-good
+  namespace: default
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: replicaset-replicas-higher-than-pdb-minAvailable-good
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: replicaset-replicas-higher-than-pdb-minAvailable-bad
+  namespace: default
+spec:
+  minAvailable: 3
+  selector:
+    matchLabels:
+      app: replicaset-replicas-higher-than-pdb-minAvailable-bad
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: statefulset-replicas-higher-than-pdb-minAvailable-good
+  namespace: default
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: statefulset-replicas-higher-than-pdb-minAvailable-good
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pdb-maxUnavailable-zero-bad
+  namespace: default
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: pdb-maxUnavailable-zero-bad
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pdb-maxUnavailable-zero-good
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: pdb-maxUnavailable-zero-good

--- a/best-practices/require_reasonable_pdbs/variables.yaml
+++ b/best-practices/require_reasonable_pdbs/variables.yaml
@@ -1,0 +1,25 @@
+policies:
+  - name: require-reasonable-pdbs
+    rules:
+      - name: deployment-replicas-higher-than-pdb-minAvailable
+        values:
+          deploymentreplicas:
+          - 3
+          request.namespace: default
+      - name: statefulset-replicas-higher-than-pdb-minAvailable
+        values:
+          statefulsetreplicas:
+          - 3
+          request.namespace: default
+      - name: replicaset-replicas-higher-than-pdb-minAvailable
+        values:
+          replicasetreplicas:
+          - 3
+          request.namespace: default
+      - name: pdb-maxUnavailable-zero
+        values:
+          deploymentreplicas:
+          - 3
+          statefulsetreplicas: []
+          replicasetreplicas: []
+          request.namespace: default

--- a/best-practices/require_replicas_allow_disruption/kyverno-test.yaml
+++ b/best-practices/require_replicas_allow_disruption/kyverno-test.yaml
@@ -1,0 +1,19 @@
+name: require-replicas-allow-disruption
+policies:
+  - require-replicas-allow-disruption.yaml
+resources:
+  - resource.yaml
+variables: variables.yaml
+results:
+  - policy: require-replicas-allow-disruption
+    rule: replicas-allow-voluntary-disruptions
+    resource: replicas-allow-voluntary-disruptions-good
+    kind: Deployment
+    namespace: default
+    result: fail
+  - policy: require-replicas-allow-disruption
+    rule: replicas-allow-voluntary-disruptions
+    resource: replicas-allow-voluntary-disruptions-bad
+    kind: Deployment
+    namespace: default
+    result: fail

--- a/best-practices/require_replicas_allow_disruption/require-replicas-allow-disruption.yaml
+++ b/best-practices/require_replicas_allow_disruption/require-replicas-allow-disruption.yaml
@@ -1,0 +1,45 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-replicas-allow-disruption
+  annotations:
+    policies.kyverno.io/title: Require Replicas Allow Disruption
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Deployment, StatefulSet, ReplicaSet
+    policies.kyverno.io/description: >-
+      Resources with multiple replicas should allow for some disruption.
+      This policy validates that the amount of replicas specified exceeds the minAvailable amount
+      in a matching PodDisruptionBudget
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+  - name: replicas-allow-voluntary-disruptions
+    match:
+      resources:
+        kinds:
+        - Deployment
+        - StatefulSet
+        - ReplicaSet
+    context:
+    - name: pdb_minAvailable
+      apiCall:
+        jmesPath: items[?label_match(spec.selector.matchLabels, `{{request.object.spec.template.metadata.labels}}`)].spec.minAvailable
+        urlPath: /apis/policy/v1beta1/namespaces/{{request.namespace}}/poddisruptionbudgets
+    preconditions:
+      all:
+      - key: '{{ request.object.spec.replicas }}'
+        operator: GreaterThan
+        value: 1
+      - key: '{{ regex_match(''^[0-9]+$'', ''{{ pdb_minAvailable[0] || ''''}}'') }}'
+        operator: Equals
+        value: true
+    validate:
+      message: Replica count ({{ request.object.spec.replicas }}) cannot be lower
+        than or equal to the PodDisruptionBudget minAvailable ({{ pdb_minAvailable[0] }})
+      deny:
+        conditions:
+        - key: '{{ request.object.spec.replicas }}'
+          operator: LessThanOrEquals
+          value: '{{ pdb_minAvailable[0] }}'

--- a/best-practices/require_replicas_allow_disruption/resource.yaml
+++ b/best-practices/require_replicas_allow_disruption/resource.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: replicas-allow-voluntary-disruptions-good
+  name: replicas-allow-voluntary-disruptions-good
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: replicas-allow-voluntary-disruptions-good
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: replicas-allow-voluntary-disruptions-good
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        resources: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: replicas-allow-voluntary-disruptions-bad
+  name: replicas-allow-voluntary-disruptions-bad
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: replicas-allow-voluntary-disruptions-bad
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: replicas-allow-voluntary-disruptions-bad
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        resources: {}

--- a/best-practices/require_replicas_allow_disruption/variables.yaml
+++ b/best-practices/require_replicas_allow_disruption/variables.yaml
@@ -1,0 +1,8 @@
+policies:
+  - name: require-replicas-allow-disruption
+    rules:         
+      - name: replicas-allow-voluntary-disruptions
+        values:
+          pdb_minAvailable:
+          - 3
+          request.object.spec.replicas: 3


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

<!--
What does this PR do?
-->

Description of these policies:
* require-reasonable-pdbs
  * This checks PDBs and cross-references deployments/statefulsets/replicas if they are present
   * If percentages are used it will check that `minAvailable` is between 1 and 50% or `maxUnavailable` is between 50 and 100%
   * If numbers are used it will check that minAvailable is less than the number of corresponding replicas in a deployment/statefulset/replicaset. There is a precondition of replicas greater than 1
   * If numbers are used it will check that maxUnavailable does not equal 0
* require-replicas-allow-disruption
   * This checks deployments/statefulsets/replicas and cross references PDBs if they are available
   * If numbers are used it checks to see that replicas are not less than or equal to PDB `minAvailable`. There is a precondition of replicas greater than 1

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
