### PR TITLE
Fix image path for prepend_image_registry policy

### DIFF
--- a/other/prepend_image_registry/failpatchedResource.yaml
+++ b/other/prepend_image_registry/failpatchedResource.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   automountServiceAccountToken: false
   initContainers:
-  - name: alpine
-    image: alpine:latest
+  - name: kyverno
+    image: kyverno/kyverno:latest
   - name: busybox
     image: busybox:1.28
   containers:
-  - name: nginx
-    image: nginx:1.2.3
+  - name: kyverno
+    image: kyverno/kyverno:1.2.3
   - name: redis
     image: redis:latest

--- a/other/prepend_image_registry/patchedResource.yaml
+++ b/other/prepend_image_registry/patchedResource.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   automountServiceAccountToken: false
   initContainers:
-  - name: alpine
-    image: registry.io/alpine:latest
+  - name: kyverno
+    image: registry.io/kyverno/kyverno:latest
   - name: busybox
     image: registry.io/busybox:1.28
   containers:
-  - name: nginx
-    image: registry.io/nginx:1.2.3
+  - name: kyverno
+    image: registry.io/kyverno/kyverno:1.2.3
   - name: redis
     image: registry.io/redis:latest

--- a/other/prepend_image_registry/patchedResourceWithoutInitContainer.yaml
+++ b/other/prepend_image_registry/patchedResourceWithoutInitContainer.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   automountServiceAccountToken: false
   containers:
-  - name: nginx
-    image: nginx:1.2.3
+  - name: kyverno
+    image: kyverno/kyverno:1.2.3
   - name: redis
     image: redis:latest

--- a/other/prepend_image_registry/prepend_image_registry.yaml
+++ b/other/prepend_image_registry/prepend_image_registry.yaml
@@ -63,4 +63,4 @@ spec:
           spec:
             initContainers:
             - name: "{{ element.name }}"           
-              image: registry.io/{{ images.initContainers."{{element.name}}".name}}:{{images.initContainers."{{element.name}}".tag}}
+              image: registry.io/{{ images.initContainers."{{element.name}}".path}}:{{images.initContainers."{{element.name}}".tag}}

--- a/other/prepend_image_registry/resource.yaml
+++ b/other/prepend_image_registry/resource.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   automountServiceAccountToken: false
   initContainers:
-  - name: alpine
-    image: alpine:latest
+  - name: kyverno
+    image: kyverno/kyverno:latest
   - name: busybox
     image: busybox:1.28
   containers:
-  - name: nginx
-    image: nginx:1.2.3
+  - name: kyverno
+    image: kyverno/kyverno:1.2.3
   - name: redis
     image: redis:latest

--- a/other/prepend_image_registry/resourceFailed.yaml
+++ b/other/prepend_image_registry/resourceFailed.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   automountServiceAccountToken: false
   initContainers:
-  - name: alpine
-    image: alpine:latest
+  - name: kyverno
+    image: kyverno/kyverno:latest
   - name: busybox
     image: busybox:1.28
   containers:
-  - name: nginx
-    image: nginx:1.2.3
+  - name: kyverno
+    image: kyverno/kyverno:1.2.3
   - name: redis
     image: redis:latest

--- a/other/prepend_image_registry/withoutinitcontainer.yaml
+++ b/other/prepend_image_registry/withoutinitcontainer.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   automountServiceAccountToken: false
   initContainers:
-  - name: alpine
-    image: alpine:latest
+  - name: kyverno
+    image: kyverno/kyverno:latest
   - name: busybox
     image: busybox:1.28
   containers:
-  - name: nginx
-    image: nginx:1.2.3
+  - name: kyverno
+    image: kyverno/kyverno:1.2.3
   - name: redis
     image: redis:latest


### PR DESCRIPTION
## Related Issue(s)

Resolves: #509

## Description

Fix the image path for the prepend-registry-initcontainers rule so that it uses the image path for the path instead of the image name. We also update the resources used in the tests to use an image containing a path.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
