### PR TITLE
Restrict deprecated registry

### DIFF
--- a/other/restrict_deprecated_registry/kyverno-test.yaml
+++ b/other/restrict_deprecated_registry/kyverno-test.yaml
@@ -1,0 +1,12 @@
+name: restrict-deprecated-registry
+policies:
+  -  restrict_deprecated_registry.yaml
+resources:
+  -  resource.yaml
+results:
+  - policy: restrict-deprecated-registry
+    rule: restrict-deprecated-registry
+    resource: test-pod
+    kind: Pod
+    namespace: policy-test
+    result: fail

--- a/other/restrict_deprecated_registry/kyverno-test.yaml
+++ b/other/restrict_deprecated_registry/kyverno-test.yaml
@@ -6,7 +6,13 @@ resources:
 results:
   - policy: restrict-deprecated-registry
     rule: restrict-deprecated-registry
-    resource: test-pod
+    resource: test-pod-bad
     kind: Pod
     namespace: policy-test
     result: fail
+  - policy: restrict-deprecated-registry
+    rule: restrict-deprecated-registry
+    resource: test-pod-good
+    kind: Pod
+    namespace: policy-test
+    result: pass

--- a/other/restrict_deprecated_registry/resource.yaml
+++ b/other/restrict_deprecated_registry/resource.yaml
@@ -1,25 +1,13 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-pod
+  name: test-pod-bad
   namespace: policy-test
   labels:
     app: test
 spec:
   containers:
-    - name: test1
-      image: registry.k8s.io/google-containers/pause:3.2
-      imagePullPolicy: Always
-      securityContext:  
-        allowPrivilegeEscalation: false  
-        runAsUser: 1000  
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        capabilities:
-          drop: ["ALL"]  
-        seccompProfile:
-          type: "RuntimeDefault"
-    - name: test2
+    - name: test
       image: k8s.gcr.io/google-containers/pause:3.2
       imagePullPolicy: Always
       securityContext:  
@@ -31,3 +19,26 @@ spec:
           drop: ["ALL"]  
         seccompProfile:
           type: "RuntimeDefault"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-good
+  namespace: policy-test
+  labels:
+    app: test
+spec:
+  containers:
+    - name: test
+      image: registry.k8s.io/google-containers/pause:3.2
+      imagePullPolicy: Always
+      securityContext:  
+        allowPrivilegeEscalation: false  
+        runAsUser: 1000  
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop: ["ALL"]  
+        seccompProfile:
+          type: "RuntimeDefault"
+

--- a/other/restrict_deprecated_registry/resource.yaml
+++ b/other/restrict_deprecated_registry/resource.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: policy-test
+  labels:
+    app: test
+spec:
+  containers:
+    - name: test1
+      image: registry.k8s.io/google-containers/pause:3.2
+      imagePullPolicy: Always
+      securityContext:  
+        allowPrivilegeEscalation: false  
+        runAsUser: 1000  
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop: ["ALL"]  
+        seccompProfile:
+          type: "RuntimeDefault"
+    - name: test2
+      image: k8s.gcr.io/google-containers/pause:3.2
+      imagePullPolicy: Always
+      securityContext:  
+        allowPrivilegeEscalation: false  
+        runAsUser: 1000  
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop: ["ALL"]  
+        seccompProfile:
+          type: "RuntimeDefault"

--- a/other/restrict_deprecated_registry/restrict_deprecated_registry.yaml
+++ b/other/restrict_deprecated_registry/restrict_deprecated_registry.yaml
@@ -1,0 +1,37 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-deprecated-registry
+  annotations:
+    policies.kyverno.io/title: "Restrict Deprecated Registry"
+    policies.kyverno.io/category: Best Practices, EKS Best Practices
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/minversion: 1.9.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Legacy k8s.gcr.io container image registry will be frozen in early April 2023
+      k8s.gcr.io image registry will be frozen from the 3rd of April 2023.  
+      Images for Kubernetes 1.27 will not be available in the k8s.gcr.io image registry.
+      Please read our announcement for more details.
+      https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/     
+spec:
+  validationFailureAction: Enforce
+  # validationFailureAction: Audit
+  background: true
+  rules:
+  - name: restrict-deprecated-registry
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+        message: "The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used."
+        foreach:
+          - list: "request.object.spec.[initContainers, ephemeralContainers, containers][]"
+            deny:
+              conditions:
+                all:
+                  - key: "{{ element.image }}"
+                    operator: Equals
+                    value: "k8s.gcr.io/*"


### PR DESCRIPTION
## Related Issue(s)

N/A

## Description

As part of an effort to help the Kubernetes community with the impending registry freeze, mentioned in this [blog post](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/), I wrote the following example Kyverno policy for this effort. 

The Kyverno policy is used to detect the use of container images that use the now deprecated, soon to be frozen, `k8s.gcr.io` container image registry.

The policy is set to enforce mode, but can be set to audit mode instead.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [X] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [X] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
