### PR TITLE
restrict_node_selection - reduce spec.nodename false-positives

### DIFF
--- a/other/restrict_node_selection/restrict_node_selection.yaml
+++ b/other/restrict_node_selection/restrict_node_selection.yaml
@@ -37,9 +37,8 @@ spec:
     preconditions:
       all:
       - key: "{{request.operation || 'BACKGROUND'}}"
-        operator: Equal
-        value:
-        - CREATE
+        operator: Equals
+        value: CREATE
     validate:
       message: Setting the nodeName field is prohibited.
       pattern:

--- a/other/restrict_node_selection/restrict_node_selection.yaml
+++ b/other/restrict_node_selection/restrict_node_selection.yaml
@@ -34,6 +34,12 @@ spec:
       - resources:
           kinds:
           - Pod
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: Equal
+        value:
+        - CREATE
     validate:
       message: Setting the nodeName field is prohibited.
       pattern:


### PR DESCRIPTION
The current behaviour is scanning all running pods for the definition of spec.nodename.  
This will always be true, because after the deployment of a pod it is filled with the worker nodename the pod is running at.  
As a result we have many false-positive events.

## Related Issue(s)
closes #525 
closes #512 
Closes #529

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

What we really want to make sure is, that a user is not targeting a specific nodename in it's deployment files at creation time.
This way it is up to the scheduler to choose the best node, especially during rolling updates or renaming of worker nodes.

With adding a precondition to check only on CREATE events we make sure deployed pods are not triggering events anymore.

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
