### PR TITLE
fix: check for empty namespaceMapping in block-velero-restore

### DIFF
--- a/velero/block-velero-restore/artifacthub-pkg.yml
+++ b/velero/block-velero-restore/artifacthub-pkg.yml
@@ -9,7 +9,7 @@ description: >-
       This policy protect restore operation into system or any protected namespaces, listed in deny condition section. 
       It checks the Restore CRD object and its namespaceMapping field. If destination match protected namespace
       then operation fails and warning message is throw.
-digest: 52fa945f2ddced3532c567c2760782b990b2fc44acd7a88e4c905e1130f85336
+digest: 8dc53eeed16dfae126f70003803e7f14a7373f202e01398a785b8f2747b3d2f9
 install: |-
     ```shell
     kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/velero/block-velero-restore/block-velero-restore.yaml

--- a/velero/block-velero-restore/block-velero-restore.yaml
+++ b/velero/block-velero-restore/block-velero-restore.yaml
@@ -27,7 +27,7 @@ spec:
       deny:
         conditions:
           any:
-            - key: "{{request.object.spec.namespaceMapping | values(@)}}"
+            - key: "{{request.object.spec.namespaceMapping || `{}` | values(@)}}"
               operator: AnyIn
               value:
               - kube-system

--- a/velero/block-velero-restore/kyverno-test.yaml
+++ b/velero/block-velero-restore/kyverno-test.yaml
@@ -6,6 +6,16 @@ resources:
 results:
   - policy: block-velero-restore
     rule: block-velero-restore-to-protected-namespace
-    resource: my-restore-backup-0000111122223333
+    resource: badrestore01
     kind: Restore
     result: fail
+  - policy: block-velero-restore
+    rule: block-velero-restore-to-protected-namespace
+    resource: restore-without-namespace-mapping
+    kind: Restore
+    result: pass
+  - policy: block-velero-restore
+    rule: block-velero-restore-to-protected-namespace
+    resource: goodrestore01
+    kind: Restore
+    result: pass

--- a/velero/block-velero-restore/resource.yaml
+++ b/velero/block-velero-restore/resource.yaml
@@ -1,7 +1,12 @@
+#######################################################
+## Rule: block-velero-restore-to-protected-namespace ##
+#######################################################
+###### Restore - Bad
+---
 apiVersion: velero.io/v1
 kind: Restore
 metadata:
-  name: my-restore-backup-0000111122223333
+  name: badrestore01
   namespace: velero
 spec:
   backupName: my-backup
@@ -10,3 +15,38 @@ spec:
   namespaceMapping:
     default: kube-system
 restorePVs: true
+---
+###### Restore - Good
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: restore-without-namespace-mapping
+  namespace: velero
+spec:
+  backupName: my-backup
+  excludedResources:
+  - nodes
+  - events
+  - events.events.k8s.io
+  - backups.velero.io
+  - restores.velero.io
+  - resticrepositories.velero.io
+  - csinodes.storage.k8s.io
+  - volumeattachments.storage.k8s.io
+  - backuprepositories.velero.io
+  includedNamespaces:
+  - '*'
+---
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: goodrestore01
+  namespace: velero
+spec:
+  backupName: my-backup
+  includedResources:
+  - '*'
+  namespaceMapping:
+    default: ingress-nginx
+restorePVs: true
+---


### PR DESCRIPTION
## Related Issue(s)

Fixes #583

## Description
Set default value for namespaceMapping if it doesn't exists

**Note**: I do not possess experience in writing Kyverno policies, please let me know if you think there is a better way to go about the use case of `namespaceMapping` not existing in the Velero restore.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
