### PR TITLE
Added policy - block-cluster-admin-from-ns.yaml

### DIFF
--- a/other/block-cluster-admin-from-ns/README.md
+++ b/other/block-cluster-admin-from-ns/README.md
@@ -1,0 +1,59 @@
+# Explainer:
+In this policy, I’ve told `Kyverno` to look for all user operations (`CREATE, UPDATE, DELETE`), on every object kind, in the testnamespace namespace, and for the `clusterRole cluster-admin`. I’ve also added the `subject User testuser` so it won’t include all the cluster-admins in the cluster.
+
+## FYI!
+1. The subject can also include groups:
+```YAML
+subjects:
+- kind: Group
+  name: my-group
+```
+2. Optional list of namespaces. Supports wildcards (* and ?):
+```YAML
+namespaces: 
+ - "openshift-*"
+```
+
+# Run the following commands for testing: 
+1. Create a new user (test) + grant it RBAC cluster-admin
+
+kubectl create user testuser
+kubectl adm policy add-cluster-role-to-user clusteradmin testuser
+3. Test all commands with “regular” cluster-admin user
+
+kubectl create -f pod.yaml -n testnamespace
+# output: 
+# pod/nginx created
+
+kubectl edit pod ngins -n testnamespace
+# output:
+# pod/nginx edited
+
+kubectl delete -f pod.yaml -n testnamespace
+# output:
+# pod "nginx" deleted
+4. Test a command with “test” cluster-admin user
+
+kubectl create -f pod.yaml -n testnamespace --as=testuser
+# output: 
+# Error from server: error when creating "test-pod.yaml": admission webhook "validate.kyverno.svc-fail" denied the request: 
+
+# policy Pod/testnamespace/nginx2 for resource violation: 
+
+# block-cluster-admin-from-ns:
+#   block-cluster-admin-from-ns: The cluster-admin 'testuser' user cannot touch testnamespace Namespace.
+Note! It’s the same output for all the commands I just wanted to keep it as clean as possible
+
+Notice that the error message is the one that I’ve written myself inside the policy, and it can be edited based on your needs!
+
+Our pod.yaml example
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+    ports:
+    - containerPort: 80

--- a/other/block-cluster-admin-from-ns/artifacthub-pkg.yml
+++ b/other/block-cluster-admin-from-ns/artifacthub-pkg.yml
@@ -1,0 +1,24 @@
+---
+name: block-cluster-admin-from-ns 
+version: 1.0.0 
+displayName: Block a Cluster Admin/s from CREATE/UPDATE/DELETE any object in a Namespace
+createdAt: "2023-05-18T00:00:00.000Z"
+description: >-
+  In some cases we would want to block operations (CREATE/UPDATE/DELETE) of certain privileged users (i.e. cluster-admins), in a specific namespace.
+          In this policy, Kyverno look for all user operations (`CREATE, UPDATE, DELETE`), on every object kind (Pod,Deployment,Route,Service,etc.), in the testnamespace namespace, and for the `clusterRole cluster-admin`. The `subject User testuser` is also mentioned so it won’t include all the cluster-admins in the cluster, but will be flexiable enough to apply only for a sub-group of the cluster-admins in the cluster.
+install: |- 
+    ```shell
+    kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
+    ```   
+keywords:
+  - rbac
+  - cluster-admin 
+  - kyverno
+readme: | 
+  In some cases we would want to block operations (CREATE/UPDATE/DELETE) of certain privileged users (i.e. cluster-admins), in a specific namespace.
+          In this policy, Kyverno look for all user operations (`CREATE, UPDATE, DELETE`), on every object kind (Pod,Deployment,Route,Service,etc.), in the testnamespace namespace, and for the `clusterRole cluster-admin`. The `subject User testuser` is also mentioned so it won’t include all the cluster-admins in the cluster, but will be flexiable enough to apply only for a sub-group of the cluster-admins in the cluster.  
+annotations: 
+  policies.kyverno.io/category: other
+  policies.kyverno.io/subject: Namespace, ClusterRole, User
+  policies.kyverno.io/minversion: 1.9.0
+digest: 8b212d6056e1871537018ab93e1236f971b42a4c

--- a/other/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
+++ b/other/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
@@ -1,0 +1,36 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: block-cluster-admin-from-ns
+  annotations:
+    policies.kyverno.io/title: Block Cluster Admin from Namespace
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/subject: RBAC
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: block-cluster-admin-from-ns
+    match:
+      any:
+      - resources:
+          kinds:
+          - "*"
+          namespaces:
+          - testnamespace
+        clusterRoles:
+        - cluster-admin
+        subjects:
+        - kind: User
+          name: testuser
+    validate:
+      message: "The cluster-admin 'testuser' user cannot touch testnamespace Namespace."
+      deny:
+        conditions:
+          any:
+            - key: "{{request.operation || 'BACKGROUND'}}"
+              operator: AnyIn
+              value:
+              - CREATE
+              - UPDATE
+              - DELETE

--- a/other/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
+++ b/other/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/minversion: 1.9.0
     policies.kyverno.io/description: >-
           In some cases we would want to block operations (CREATE/UPDATE/DELETE) of certain privileged users (i.e. cluster-admins), in a specific namespace.
-          In this policy, Kyverno look for all user operations (`CREATE, UPDATE, DELETE`), on every object kind (Pod,Deployment,Route,Service,etc.), in the testnamespace namespace, and for the `clusterRole cluster-admin`. The `subject User testuser` is also mentioned so it won’t include all the cluster-admins in the cluster, but will be flexiable enough to apply only for a sub-group of the cluster-admins in the cluster
+          In this policy, Kyverno look for all user operations (`CREATE, UPDATE, DELETE`), on every object kind (Pod,Deployment,Route,Service,etc.), in the testnamespace namespace, and for the `clusterRole cluster-admin`. The `subject User testuser` is also mentioned so it won’t include all the cluster-admins in the cluster, but will be flexiable enough to apply only for a sub-group of the cluster-admins in the cluster.
 spec:
   validationFailureAction: Enforce
   background: false

--- a/other/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
+++ b/other/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     policies.kyverno.io/title: Block a Cluster Admin/s from CREATE/UPDATE/DELETE any object in a Namespace
     policies.kyverno.io/category: other
-    policies.kyverno.io/subject: Namespace, ClusterRole, User
+    policies.kyverno.io/subject: Namespace, ClusterRole, User 
     policies.kyverno.io/minversion: 1.9.0
     policies.kyverno.io/description: >-
           In some cases we would want to block operations (CREATE/UPDATE/DELETE) of certain privileged users (i.e. cluster-admins), in a specific namespace.
-          In this policy, Kyverno look for all user operations (`CREATE, UPDATE, DELETE`), on every object kind (Pod,Deployment,Route,Service,etc.), in the testnamespace namespace, and for the `clusterRole cluster-admin`. The `subject User testuser` is also mentioned so it won’t include all the cluster-admins in the cluster, but will be flexiable enough to apply only for a sub-group of the cluster-admins in the cluster.
+          In this policy, Kyverno look for all user operations (`CREATE, UPDATE, DELETE`), on every object kind (Pod,Deployment,Route,Service,etc.), in the testnamespace namespace, and for the `clusterRole cluster-admin`. The `subject User testuser` is also mentioned so it won’t include all the cluster-admins in the cluster, but will be flexiable enough to apply only for a sub-group of the cluster-admins in the cluster
 spec:
   validationFailureAction: Enforce
   background: false

--- a/other/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
+++ b/other/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
@@ -3,11 +3,15 @@ kind: ClusterPolicy
 metadata:
   name: block-cluster-admin-from-ns
   annotations:
-    policies.kyverno.io/title: Block Cluster Admin from Namespace
-    policies.kyverno.io/category: Sample
-    policies.kyverno.io/subject: RBAC
+    policies.kyverno.io/title: Block a Cluster Admin/s from CREATE/UPDATE/DELETE any object in a Namespace
+    policies.kyverno.io/category: other
+    policies.kyverno.io/subject: Namespace, ClusterRole, User
+    policies.kyverno.io/minversion: 1.9.0
+    policies.kyverno.io/description: >-
+          In some cases we would want to block operations (CREATE/UPDATE/DELETE) of certain privileged users (i.e. cluster-admins), in a specific namespace.
+          In this policy, Kyverno look for all user operations (`CREATE, UPDATE, DELETE`), on every object kind (Pod,Deployment,Route,Service,etc.), in the testnamespace namespace, and for the `clusterRole cluster-admin`. The `subject User testuser` is also mentioned so it won’t include all the cluster-admins in the cluster, but will be flexiable enough to apply only for a sub-group of the cluster-admins in the cluster.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: block-cluster-admin-from-ns


### PR DESCRIPTION
## Related Issue(s)
[x]

## Description
In this policy, I’ve told `Kyverno` to look for all user operations (`CREATE, UPDATE, DELETE`), on every object kind, in the testnamespace namespace, and for the `clusterRole cluster-admin`. I’ve also added the `subject User testuser` so it won’t include all the cluster-admins in the cluster.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
