### PR TITLE
revert assert policy kind for kuttl fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go 
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: Test Policy
         run: go run ./cmd/cli/kubectl-kyverno test ../policies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go 
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
-          go-version: 1.19
+          go-version: 1.20
 
       - name: Test Policy
         run: go run ./cmd/cli/kubectl-kyverno test ../policies

--- a/argo/application-field-validation/policy-ready.yaml
+++ b/argo/application-field-validation/policy-ready.yaml
@@ -1,5 +1,5 @@
 apiVersion: kyverno.io/v1
-kind: Changed
+kind: ClusterPolicy
 metadata:
   name: application-field-validation
 status:


### PR DESCRIPTION
## Related Issue(s)

## Description

Reverts the `kind` field of an asserted ClusterPolicy after `render` has been improved to not fail due to kuttl tests.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
