### PR TITLE
fix: require-storageclass policy

### DIFF
--- a/other/require-storageclass/artifacthub-pkg.yml
+++ b/other/require-storageclass/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ readme: |
 annotations:
   kyverno/category: "Other, Multi-Tenancy"
   kyverno/subject: "PersistentVolumeClaim, StatefulSet"
-digest: 9a08729b9f122dcecff442e5a39a903b228cd19d95bde90a56e09871a419e388
+digest: e99e3f27171a721aa76970de2f591c33104b08886120a17baaa0679e7e09c76a

--- a/other/require-storageclass/kyverno-test.yaml
+++ b/other/require-storageclass/kyverno-test.yaml
@@ -21,6 +21,11 @@ results:
     result: pass
   - policy: require-storageclass
     rule: ss-storageclass
+    resource: goodss-novct
+    kind: StatefulSet
+    result: pass
+  - policy: require-storageclass
+    rule: ss-storageclass
     resource: badss
     kind: StatefulSet
     result: fail

--- a/other/require-storageclass/require-storageclass.yaml
+++ b/other/require-storageclass/require-storageclass.yaml
@@ -11,8 +11,8 @@ metadata:
       PersistentVolumeClaims (PVCs) and StatefulSets may optionally define a StorageClass
       to dynamically provision storage. In a multi-tenancy environment where StorageClasses are
       far more common, it is often better to require storage only be provisioned from these
-      StorageClasses. This policy requires that PVCs and StatefulSets define the storageClassName
-      field with some value.
+      StorageClasses. This policy requires that PVCs and StatefulSets containing
+      volumeClaimTemplates define the storageClassName field with some value.
 spec:
   validationFailureAction: audit
   background: true
@@ -38,6 +38,6 @@ spec:
       message: "StatefulSets must define a storageClassName."
       pattern:
         spec:
-          volumeClaimTemplates:
+          =(volumeClaimTemplates):
             - spec:
                 storageClassName: "?*"

--- a/other/require-storageclass/resource.yaml
+++ b/other/require-storageclass/resource.yaml
@@ -71,6 +71,29 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
+  name: goodss-novct
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  serviceName: "nginx"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: nginx
+        image: thisdoesnotexist:0.8
+        ports:
+        - containerPort: 80
+          name: web
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
   name: badss
 spec:
   selector:


### PR DESCRIPTION
## Related Issue(s)

Fixes #617 

## Description

Enhance Require StorageClass policy to only require storageClassName if the StatefulSet has volumeClaimTemplates.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
