### PR TITLE
Have policies apply on UPDATE when appropriate

### DIFF
--- a/other/ingress-host-match-tls/ingress-host-match-tls.yaml
+++ b/other/ingress-host-match-tls/ingress-host-match-tls.yaml
@@ -29,8 +29,10 @@ spec:
     preconditions:
       all:
       - key: "{{request.operation || 'BACKGROUND'}}"
-        operator: Equals
-        value: CREATE
+        operator: AllIn
+        value:
+        - CREATE
+        - UPDATE
     validate:
       message: "The host(s) in spec.rules[].host must match those in spec.tls[].hosts[]."
       deny:

--- a/other/ingress-host-match-tls/ingress-host-match-tls.yaml
+++ b/other/ingress-host-match-tls/ingress-host-match-tls.yaml
@@ -29,7 +29,7 @@ spec:
     preconditions:
       all:
       - key: "{{request.operation || 'BACKGROUND'}}"
-        operator: AllIn
+        operator: AnyIn
         value:
         - CREATE
         - UPDATE

--- a/other/limit-containers-per-pod/limit-containers-per-pod.yaml
+++ b/other/limit-containers-per-pod/limit-containers-per-pod.yaml
@@ -29,8 +29,10 @@ spec:
     preconditions:
       all:
       - key: "{{request.operation || 'BACKGROUND'}}"
-        operator: Equal
-        value: CREATE
+        operator: AllIn
+        value:
+        - CREATE
+        - UPDATE
     validate:
       message: "Pods can only have a maximum of 4 containers."
       deny:
@@ -67,8 +69,10 @@ spec:
     preconditions:
       all:
       - key: "{{request.operation || 'BACKGROUND'}}"
-        operator: Equal
-        value: CREATE
+        operator: AllIn
+        value:
+        - CREATE
+        - UPDATE
     validate:
       message: "Pods can only have a maximum of 4 containers."
       deny:

--- a/other/limit-containers-per-pod/limit-containers-per-pod.yaml
+++ b/other/limit-containers-per-pod/limit-containers-per-pod.yaml
@@ -29,7 +29,7 @@ spec:
     preconditions:
       all:
       - key: "{{request.operation || 'BACKGROUND'}}"
-        operator: AllIn
+        operator: AnyIn
         value:
         - CREATE
         - UPDATE
@@ -69,7 +69,7 @@ spec:
     preconditions:
       all:
       - key: "{{request.operation || 'BACKGROUND'}}"
-        operator: AllIn
+        operator: AnyIn
         value:
         - CREATE
         - UPDATE

--- a/other/pdb-minavailable/pdb-minavailable.yaml
+++ b/other/pdb-minavailable/pdb-minavailable.yaml
@@ -28,8 +28,10 @@ spec:
       preconditions:
         all:
           - key: "{{request.operation || 'BACKGROUND'}}"
-            operator: Equals
-            value: CREATE
+            operator: AllIn
+            value:
+            - CREATE
+            - UPDATE
       context:
         - name: minavailable
           apiCall:

--- a/other/pdb-minavailable/pdb-minavailable.yaml
+++ b/other/pdb-minavailable/pdb-minavailable.yaml
@@ -28,7 +28,7 @@ spec:
       preconditions:
         all:
           - key: "{{request.operation || 'BACKGROUND'}}"
-            operator: AllIn
+            operator: AnyIn
             value:
             - CREATE
             - UPDATE

--- a/other/restrict-ingress-host/restrict-ingress-host.yaml
+++ b/other/restrict-ingress-host/restrict-ingress-host.yaml
@@ -31,7 +31,7 @@ spec:
       preconditions:
         all:
         - key: "{{ request.operation || 'BACKGROUND' }}"
-          operator: AllIn
+          operator: AnyIn
           value:
           - CREATE
           - UPDATE
@@ -50,7 +50,7 @@ spec:
       preconditions:
         all:
         - key: "{{ request.operation || 'BACKGROUND' }}"
-          operator: AllIn
+          operator: AnyIn
           value:
           - CREATE
           - UPDATE

--- a/other/restrict-ingress-host/restrict-ingress-host.yaml
+++ b/other/restrict-ingress-host/restrict-ingress-host.yaml
@@ -31,8 +31,10 @@ spec:
       preconditions:
         all:
         - key: "{{ request.operation || 'BACKGROUND' }}"
-          operator: Equals
-          value: CREATE
+          operator: AllIn
+          value:
+          - CREATE
+          - UPDATE
         - key: "{{ request.object.spec.rules[].host }}"
           operator: AnyIn
           value: "{{ hosts }}"
@@ -48,8 +50,10 @@ spec:
       preconditions:
         all:
         - key: "{{ request.operation || 'BACKGROUND' }}"
-          operator: Equals
-          value: CREATE
+          operator: AllIn
+          value:
+          - CREATE
+          - UPDATE
         - key: "{{ request.object.spec.rules[].host | length(@)}}"
           operator: GreaterThan
           value: 1

--- a/other/unique-ingress-paths/unique-ingress-paths.yaml
+++ b/other/unique-ingress-paths/unique-ingress-paths.yaml
@@ -39,7 +39,7 @@ spec:
       preconditions:
         any:
         - key: "{{request.operation || 'BACKGROUND'}}"
-          operator: AllIn
+          operator: AnyIn
           value:
           - CREATE
           - UPDATE

--- a/other/unique-ingress-paths/unique-ingress-paths.yaml
+++ b/other/unique-ingress-paths/unique-ingress-paths.yaml
@@ -39,8 +39,10 @@ spec:
       preconditions:
         any:
         - key: "{{request.operation || 'BACKGROUND'}}"
-          operator: Equals
-          value: "CREATE"
+          operator: AllIn
+          value:
+          - CREATE
+          - UPDATE
       validate:
         message: >-
           The root path /{{request.object.spec.rules[].http.paths[].path | [0] | to_string(@) | split(@, '/') | [1]}} exists


### PR DESCRIPTION
## Description

Some policies only validate on `CREATE`, but apply to mutable objects. Let's validate on `UPDATE` as well.

I have checked that current policies can be bypassed using `kubectl apply`, `kubectl patch`, or `kubectl edit`, which is a big problem.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [ ] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [ ] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.

# Additional notes

I have not updated the policies that are labelled as examples and look to not be complete solutions. I have also ignored policies that use resource types I am not familiar with, such as `PipelineRun`, so it is possible a similar change needs to be made for the policies of those custom resources.