### PR TITLE
fix: modify result for add-default-resources

### DIFF
--- a/other/add-default-resources/kyverno-test.yaml
+++ b/other/add-default-resources/kyverno-test.yaml
@@ -10,13 +10,12 @@ results:
     patchedResource: patchedResource1.yaml
     kind: Pod
     result: pass
-# nginx-demo2 will get skip as resource already has memory and cpu requests
   - policy: add-default-resources
     rule: add-default-requests
     resource: nginx-demo2
     patchedResource: patchedResource2.yaml
     kind: Pod
-    result: pass
+    result: skip
   - policy: add-default-resources
     rule: add-default-requests
     resource: nginx-demo3

--- a/other/add-default-resources/kyverno-test.yaml
+++ b/other/add-default-resources/kyverno-test.yaml
@@ -13,7 +13,6 @@ results:
   - policy: add-default-resources
     rule: add-default-requests
     resource: nginx-demo2
-    patchedResource: patchedResource2.yaml
     kind: Pod
     result: skip
   - policy: add-default-resources


### PR DESCRIPTION
## Related Issue(s)
https://github.com/kyverno/kyverno/issues/6975
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
use `skip` as a result in `kyverno-test.yaml` as mutation won't occur on `nginx-demo2` because it has both memory and cpu fields.

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
