### PR TITLE
kubevirt: Only enforce use of instance types and preferences

### DIFF
--- a/kubevirt/README.md
+++ b/kubevirt/README.md
@@ -6,4 +6,4 @@ This directory contains a few examples in order to apply policies on
 Examples
 
 - add-services - Add a service for every VMI which is getting created. This is an example for a generating policy.
-- enforce-instancetype - Enforce the use of instance types, prevent the creation of "custom" VMs. This is an example for a validating policy.
+- enforce-instancetype - Enforce the use of instance types and preferences. This is an example for a validating policy.

--- a/kubevirt/enforce-instancetype/artifacthub-pkg.yml
+++ b/kubevirt/enforce-instancetype/artifacthub-pkg.yml
@@ -1,9 +1,9 @@
 name: enforce-instancetype
-version: 1.0.0
+version: 1.1.0
 displayName: Enforce instanceTypes
 createdAt: "2023-04-10T20:18:08.000Z"
 description: >-
-  Check VirtualMachines and validate that they are not using a domain template (`.spec.template.domain`) but instead are based on instaceTypes and preferences only.
+  Check VirtualMachines and validate that they are using an instance type and preference.
 install: |-
   ```shell
   kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/kubevirt/enforce-instancetype/enforce-instancetype.yaml
@@ -12,11 +12,11 @@ keywords:
   - kyverno
   - KubeVirt
 readme: |
-  Check VirtualMachines and validate that they are not using a domain template (`.spec.template.domain`) but instead are based on instaceTypes and preferences only.
+  Check VirtualMachines and validate that they are using an instance type and preference.
   
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "KubeVirt"
   kyverno/kubernetesVersion: "1.24-1.25"
   kyverno/subject: "VirtualMachine"
-digest: cf4f4910d38aaa599c81554b5b7987ff1e9186bcb8a2163c343f2bb11ec239a3
+digest: fd5e58353ef32aab91803a63e1a1f95ff0e311344f33a88f99ebe37757e64990

--- a/kubevirt/enforce-instancetype/enforce-instancetype.yaml
+++ b/kubevirt/enforce-instancetype/enforce-instancetype.yaml
@@ -7,23 +7,23 @@ metadata:
     policies.kyverno.io/category: KubeVirt
     policies.kyverno.io/subject: VirtualMachine
     policies.kyverno.io/description: >-
-      Check VirtualMachines and validate that they are not using a domain template (`.spec.template.domain`)
-      but instead are based on instaceTypes and preferences only.
+      Check VirtualMachines and validate that they are using an instance type and preference.
     kyverno.io/kyverno-version: "1.8.0-rc2"
     kyverno.io/kubernetes-version: "1.24-1.25"
 spec:
   validationFailureAction: enforce
   rules:
-  - name: k6t-dont-allow-domain-template
+  - name: k6t-ensure-instance-type-and-preference
     match:
       any: 
       - resources:
           kinds:
           - VirtualMachine
     validate:
-      message: "VirtualMachines must only use instanceTypes and preferences, a domain template is not allowed."
+      message: "VirtualMachines must use instance types and preferences"
       pattern:
         spec:
-          template:
-            spec:
-              domain: null
+          instancetype:
+            name: ?*
+          preference:
+            name: ?*

--- a/kubevirt/enforce-instancetype/kyverno-test.yaml
+++ b/kubevirt/enforce-instancetype/kyverno-test.yaml
@@ -5,13 +5,13 @@ resources:
   - resource.yaml
 results:
 - policy: k6t-enforce-instancetype
-  rule: k6t-dont-allow-domain-template
+  rule: k6t-ensure-instance-type-and-preference
   kind: VirtualMachine
   resources:
   - vm-valid
   result: pass
 - policy: k6t-enforce-instancetype
-  rule: k6t-dont-allow-domain-template
+  rule: k6t-ensure-instance-type-and-preference
   kind: VirtualMachine
   resources:
   - vm-invalid


### PR DESCRIPTION
## Related Issue(s)


## Description

The policy would previously check for the use of `spec.template.domain` that is not actually invalid when using instance types and preferences.

This change drops that check and replaces it with two validations ensuring both `spec.instancetype.name` and `spec.preference.name` are provided. Any remaining validation being left to the submission webhooks within KubeVirt itself.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
