### PR TITLE
fix: modify test manifest for add-default-resources and set-karpenter-non-cpu-limits

### DIFF
--- a/karpenter/set-karpenter-non-cpu-limits/kyverno-test.yaml
+++ b/karpenter/set-karpenter-non-cpu-limits/kyverno-test.yaml
@@ -59,4 +59,4 @@ results:
     namespace: test
     kind: Pod
     patchedResource: pod-memory-patched4.yaml
-    result: pass
+    result: skip

--- a/other/add-default-resources/kyverno-test.yaml
+++ b/other/add-default-resources/kyverno-test.yaml
@@ -16,7 +16,7 @@ results:
     resource: nginx-demo2
     patchedResource: patchedResource2.yaml
     kind: Pod
-    result: pass
+    result: skip
   - policy: add-default-resources
     rule: add-default-requests
     resource: nginx-demo3


### PR DESCRIPTION

## Related Issue(s)
https://github.com/kyverno/kyverno/pull/7396

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
Fix the expected result in the test manifest of policies:
1. add-default-resources
2. set-karpenter-non-cpu-limits

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
