### PR TITLE
fix deprecated kustomization command "bases" with "resources"

### DIFF
--- a/pod-security/enforce/kustomization.yaml
+++ b/pod-security/enforce/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - ../restricted
 
 patches:
@@ -7,4 +7,4 @@ patches:
         path: /spec/validationFailureAction
         value: enforce
     target:
-      kind: ClusterPolicy 
+      kind: ClusterPolicy

--- a/pod-security/kustomization.yaml
+++ b/pod-security/kustomization.yaml
@@ -1,2 +1,2 @@
-bases:
+resources:
 - restricted

--- a/pod-security/restricted/kustomization.yaml
+++ b/pod-security/restricted/kustomization.yaml
@@ -1,7 +1,5 @@
-bases:
-  - ../baseline
-  
 resources:
+  - ../baseline
   - disallow-capabilities-strict/disallow-capabilities-strict.yaml
   - disallow-privilege-escalation/disallow-privilege-escalation.yaml
   - require-run-as-non-root-user/require-run-as-non-root-user.yaml


### PR DESCRIPTION
## Related Issue(s)

https://github.com/kubernetes-sigs/kustomize/issues/2243

"bases" command is deprecated since kustomize v2.1.0  in 2019, and replaced by "resources".
https://github.com/kubernetes-sigs/kustomize/blob/661743c7e5bd8c3d9d6866b6bc0a6f0e0b0512eb/site/content/en/blog/releases/v2.1.0.md#resources-expanded-bases-deprecated

``` 
fatal: [localhost]: FAILED! => {"msg": "kustomize command failed with: # Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.\n# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.\n"}
``` 

