### PR TITLE
Add 2 samples, fix one

### DIFF
--- a/other/b-d/cordon-and-drain-node/artifacthub-pkg.yml
+++ b/other/b-d/cordon-and-drain-node/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: cordon-and-drain-node
+version: 1.0.0
+displayName: Cordon and Drain Node
+createdAt: "2023-07-27T21:52:03.000Z"
+description: >-
+  There are cases where either an operations or security incident may occur and Nodes should be evacuated and placed in an unused state for further analysis. For example, a Node is found to be running a vulnerable version of a CRI engine or kernel and to minimize chances of a compromise may need to be decommissioned so another can be built. This policy shows how to use Kyverno to both cordon and drain a given Node and uses a hypothetical label being written to it called `testing=drain` to illustrate the point. For production use, the match block should be modified to trigger on the appropriate condition.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/b-d/cordon-and-drain-node/cordon-and-drain-node.yaml
+  ```
+keywords:
+  - kyverno
+  - other
+readme: |
+  There are cases where either an operations or security incident may occur and Nodes should be evacuated and placed in an unused state for further analysis. For example, a Node is found to be running a vulnerable version of a CRI engine or kernel and to minimize chances of a compromise may need to be decommissioned so another can be built. This policy shows how to use Kyverno to both cordon and drain a given Node and uses a hypothetical label being written to it called `testing=drain` to illustrate the point. For production use, the match block should be modified to trigger on the appropriate condition.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "other"
+  kyverno/kubernetesVersion: "1.26"
+  kyverno/subject: "Node"
+digest: 67ff7112606cbb626b2eb4a034d013553757283ba1e7fa8b9e3dfe640cc8bf21

--- a/other/b-d/cordon-and-drain-node/artifacthub-pkg.yml
+++ b/other/b-d/cordon-and-drain-node/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "other"
   kyverno/kubernetesVersion: "1.26"
   kyverno/subject: "Node"
-digest: 67ff7112606cbb626b2eb4a034d013553757283ba1e7fa8b9e3dfe640cc8bf21
+digest: d9540eced93532fb54d51aa9ce0ca4d4b954737d6cc2eeb82687665bcfde826e

--- a/other/b-d/cordon-and-drain-node/cordon-and-drain-node.yaml
+++ b/other/b-d/cordon-and-drain-node/cordon-and-drain-node.yaml
@@ -1,0 +1,44 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cordon-and-drain-node
+  annotations:
+    policies.kyverno.io/title: Cordon and Drain Node
+    policies.kyverno.io/category: other
+    policies.kyverno.io/subject: Node
+    kyverno.io/kyverno-version: 1.10.1
+    kyverno.io/kubernetes-version: "1.26"
+    policies.kyverno.io/description: >-
+      There are cases where either an operations or security incident may occur and Nodes
+      should be evacuated and placed in an unused state for further analysis. For example,
+      a Node is found to be running a vulnerable version of a CRI engine or kernel and to
+      minimize chances of a compromise may need to be decommissioned so another can be built.
+      This policy shows how to use Kyverno to both cordon and drain a given Node and uses a
+      hypothetical label being written to it called `testing=drain` to illustrate the point.
+      For production use, the match block should be modified to trigger on the appropriate
+      condition.
+spec:
+  rules:
+    - name: mutate-node
+      match:
+        any:
+        - resources:
+            kinds:
+            - Node
+            operations:
+            - UPDATE
+            selector:
+              matchLabels:
+                testing: drain
+      mutate:
+        targets:
+        - apiVersion: v1
+          kind: Node
+          name: "{{request.object.metadata.name}}"
+        patchStrategicMerge:
+          spec:
+            unschedulable: true
+            taints:
+            - effect: NoExecute
+              key: kyverno-evicted
+              timeAdded: "{{ time_now_utc() }}" 

--- a/other/b-d/cordon-and-drain-node/cordon-and-drain-node.yaml
+++ b/other/b-d/cordon-and-drain-node/cordon-and-drain-node.yaml
@@ -7,6 +7,7 @@ metadata:
     policies.kyverno.io/category: other
     policies.kyverno.io/subject: Node
     kyverno.io/kyverno-version: 1.10.1
+    policies.kyverno.io/minversion: 1.10.0
     kyverno.io/kubernetes-version: "1.26"
     policies.kyverno.io/description: >-
       There are cases where either an operations or security incident may occur and Nodes

--- a/other/e-l/forbid-cpu-limits/01-assert.yaml
+++ b/other/e-l/forbid-cpu-limits/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: forbid-cpu-limits
+status:
+  ready: true

--- a/other/e-l/forbid-cpu-limits/01-enforce.yaml
+++ b/other/e-l/forbid-cpu-limits/01-enforce.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    sed 's/validationFailureAction: audit/validationFailureAction: Enforce/' forbid-cpu-limits.yaml | kubectl create -f - 

--- a/other/e-l/forbid-cpu-limits/02-manifests.yaml
+++ b/other/e-l/forbid-cpu-limits/02-manifests.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- file: pods-good.yaml
+  shouldFail: false
+- file: pods-bad.yaml
+  shouldFail: true
+- file: podcontrollers-good.yaml
+  shouldFail: false
+- file: podcontrollers-bad.yaml
+  shouldFail: true

--- a/other/e-l/forbid-cpu-limits/99-delete.yaml
+++ b/other/e-l/forbid-cpu-limits/99-delete.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  name: forbid-cpu-limits

--- a/other/e-l/forbid-cpu-limits/artifacthub-pkg.yml
+++ b/other/e-l/forbid-cpu-limits/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: forbid-cpu-limits
+version: 1.0.0
+displayName: Forbid CPU Limits
+createdAt: "2023-07-27T20:20:04.000Z"
+description: >-
+  Setting of CPU limits is a debatable poor practice as it can result, when defined, in potentially starving applications of much-needed CPU cycles even when they are available. Ensuring that CPU limits are not set may ensure apps run more effectively. This policy forbids any container in a Pod from defining CPU limits.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/e-l/forbid-cpu-limits/forbid-cpu-limits.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+readme: |
+  Setting of CPU limits is a debatable poor practice as it can result, when defined, in potentially starving applications of much-needed CPU cycles even when they are available. Ensuring that CPU limits are not set may ensure apps run more effectively. This policy forbids any container in a Pod from defining CPU limits.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.26"
+  kyverno/subject: "Pod"
+digest: ab06fedd32b519429eff449321a29c84db403982f3732621b32188ce9c98f767

--- a/other/e-l/forbid-cpu-limits/forbid-cpu-limits.yaml
+++ b/other/e-l/forbid-cpu-limits/forbid-cpu-limits.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: forbid-cpu-limits
+  annotations:
+    policies.kyverno.io/title: Forbid CPU Limits
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.10.0
+    kyverno.io/kubernetes-version: "1.26"
+    policies.kyverno.io/description: >-
+      Setting of CPU limits is a debatable poor practice as it can result, when defined, in potentially starving
+      applications of much-needed CPU cycles even when they are available. Ensuring that CPU limits are not
+      set may ensure apps run more effectively. This policy forbids any container in a Pod from defining CPU limits.
+spec:
+  background: true
+  validationFailureAction: Enforce
+  rules:
+  - name: check-cpu-limits
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: Containers may not define CPU limits.
+      pattern:
+        spec:
+          containers:
+          - (name): "*"
+            =(resources):
+              =(limits):
+                X(cpu): null

--- a/other/e-l/forbid-cpu-limits/kyverno-test.yaml
+++ b/other/e-l/forbid-cpu-limits/kyverno-test.yaml
@@ -1,0 +1,20 @@
+name: forbid-cpu-limits
+policies:
+  - forbid-cpu-limits.yaml
+resources:
+  - resource.yaml
+results:
+  - policy: forbid-cpu-limits
+    rule: check-cpu-limits
+    resources:
+    - good01
+    - good02
+    kind: Pod
+    result: pass
+  - policy: forbid-cpu-limits
+    rule: check-cpu-limits
+    resources:
+    - bad01
+    - bad02
+    kind: Pod
+    result: fail

--- a/other/e-l/forbid-cpu-limits/podcontrollers-bad.yaml
+++ b/other/e-l/forbid-cpu-limits/podcontrollers-bad.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: baddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox:1.35
+        name: busybox
+        resources:
+          limits:
+            cpu: 10m
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: baddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: webserver1
+        image: busybox:1.35
+        resources:
+          requests:
+            cpu: 10m
+      - name: webserver2
+        image: busybox:1.35
+        resources:
+          limits:
+            cpu: 10m
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob01
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: busybox
+        spec:
+          containers:
+          - image: busybox:1.35
+            name: busybox
+            resources:
+              limits:
+                cpu: 10m
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob02
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: busybox
+        spec:
+          containers:
+          - name: webserver1
+            image: busybox:1.35
+            resources:
+              requests:
+                cpu: 10m
+          - name: webserver2
+            image: busybox:1.35
+            resources:
+              limits:
+                cpu: 10m
+          restartPolicy: OnFailure

--- a/other/e-l/forbid-cpu-limits/podcontrollers-good.yaml
+++ b/other/e-l/forbid-cpu-limits/podcontrollers-good.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: gooddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox:1.35
+        name: busybox
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: gooddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox:1.35
+        name: busybox
+        resources:
+          requests:
+            cpu: 10m
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob01
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: busybox
+        spec:
+          containers:
+          - image: busybox:1.35
+            name: busybox
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob02
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: busybox
+        spec:
+          containers:
+          - image: busybox:1.35
+            name: busybox
+            resources:
+              requests:
+                cpu: 10m
+          restartPolicy: OnFailure

--- a/other/e-l/forbid-cpu-limits/pods-bad.yaml
+++ b/other/e-l/forbid-cpu-limits/pods-bad.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad01
+spec:
+  containers:
+  - name: webserver1
+    image: busybox:1.35
+    resources:
+      limits:
+        cpu: 10m
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad02
+spec:
+  containers:
+  - name: webserver1
+    image: busybox:1.35
+    resources:
+      requests:
+        cpu: 10m
+  - name: webserver2
+    image: busybox:1.35
+    resources:
+      limits:
+        cpu: 10m

--- a/other/e-l/forbid-cpu-limits/pods-good.yaml
+++ b/other/e-l/forbid-cpu-limits/pods-good.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good01
+spec:
+  containers:
+  - name: webserver1
+    image: busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good02
+spec:
+  containers:
+  - name: webserver1
+    image: busybox:1.35
+    resources:
+      requests:
+        cpu: 10m

--- a/other/e-l/forbid-cpu-limits/resource.yaml
+++ b/other/e-l/forbid-cpu-limits/resource.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad01
+spec:
+  containers:
+  - name: webserver1
+    image: busybox:1.35
+    resources:
+      limits:
+        cpu: 10m
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad02
+spec:
+  containers:
+  - name: webserver1
+    image: busybox:1.35
+    resources:
+      requests:
+        cpu: 10m
+  - name: webserver2
+    image: busybox:1.35
+    resources:
+      limits:
+        cpu: 10m
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good01
+spec:
+  containers:
+  - name: webserver1
+    image: busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good02
+spec:
+  containers:
+  - name: webserver1
+    image: busybox:1.35
+    resources:
+      requests:
+        cpu: 10m

--- a/other/res/restrict-ingress-host/02-manifests.yaml
+++ b/other/res/restrict-ingress-host/02-manifests.yaml
@@ -5,3 +5,7 @@ apply:
   shouldFail: false
 - file: ingress-bad.yaml
   shouldFail: true
+- file: ingress-updates-bad.yaml
+  shouldFail: true
+- file: ingress-updates-good.yaml
+  shouldFail: false

--- a/other/res/restrict-ingress-host/ingress-updates-bad.yaml
+++ b/other/res/restrict-ingress-host/ingress-updates-bad.yaml
@@ -1,0 +1,43 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: goodingress01
+spec:
+  rules:
+  - host: endpoint02
+    https:
+      paths:
+      - backend:
+          service:
+            name: demo-svc
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: goodingress01
+spec:
+  rules:
+  - host: endpoint01
+    https:
+      paths:
+      - backend:
+          service:
+            name: demo-svc
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+  - host: endpoint02
+    https:
+      paths:
+      - path: /testpath
+        pathType: Prefix
+        backend:
+          service:
+            name: test
+            port:
+              number: 80

--- a/other/res/restrict-ingress-host/ingress-updates-good.yaml
+++ b/other/res/restrict-ingress-host/ingress-updates-good.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: goodingress01
+spec:
+  rules:
+  - host: endpoint01
+    https:
+      paths:
+      - backend:
+          service:
+            name: demo-updated-svc
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: goodingress02
+spec:
+  rules:
+  - host: endpoint03
+    https:
+      paths:
+      - path: /testpath
+        pathType: Prefix
+        backend:
+          service:
+            name: test
+            port:
+              number: 80

--- a/other/res/restrict-ingress-host/kyverno-test.yaml
+++ b/other/res/restrict-ingress-host/kyverno-test.yaml
@@ -6,15 +6,15 @@ resources:
 variables: values.yaml
 results:
   - policy: unique-ingress-host
-    rule: check-single-host
+    rule: check-single-host-create
     resource: ingress-kyverno-host
     kind: Ingress
     result: fail
   - policy: unique-ingress-host
-    rule: check-single-host
+    rule: check-single-host-create
     resource: ingress-foo-host
     kind: Ingress
-    result: skip
+    result: pass
   - policy: unique-ingress-host
     rule: deny-multiple-hosts
     resource: ingress-kyverno-host

--- a/other/res/restrict-ingress-host/resource.yaml
+++ b/other/res/restrict-ingress-host/resource.yaml
@@ -14,7 +14,6 @@ spec:
             name: service1
             port:
               number: 80
-
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -32,7 +31,7 @@ spec:
             name: service2
             port:
               number: 80
-  - host: "foo.bar.com"
+  - host: foo.bar.com
     http:
       paths:
       - pathType: Prefix
@@ -42,6 +41,3 @@ spec:
             name: service1
             port:
               number: 80
-
-
-

--- a/other/res/restrict-ingress-host/restrict-ingress-host.yaml
+++ b/other/res/restrict-ingress-host/restrict-ingress-host.yaml
@@ -17,7 +17,7 @@ spec:
   validationFailureAction: audit
   background: false
   rules:
-    - name: check-single-host
+    - name: check-single-host-create
       match:
         any:
         - resources:
@@ -31,16 +31,40 @@ spec:
       preconditions:
         all:
         - key: "{{request.operation || 'BACKGROUND'}}"
-          operator: AnyIn
-          value:
-          - CREATE
-          - UPDATE
-        - key: "{{ request.object.spec.rules[].host }}"
-          operator: AnyIn
-          value: "{{ hosts }}"
+          operator: Equals
+          value: CREATE
       validate:
         message: "The Ingress host name must be unique."
-        deny: {}
+        deny:
+          conditions:
+            all:
+              - key: "{{ request.object.spec.rules[].host }}"
+                operator: AnyIn
+                value: "{{ hosts }}"
+    - name: check-single-host-update
+      match:
+        any:
+        - resources:
+            kinds:
+              - Ingress
+      preconditions:
+        all:
+        - key: "{{request.operation || 'BACKGROUND'}}"
+          operator: Equals
+          value: UPDATE
+      context:
+        - name: allhosts
+          apiCall:
+            urlPath: "/apis/networking.k8s.io/v1/ingresses"
+            jmesPath: "items[?metadata.uid!='{{ request.object.metadata.uid }}'].spec.rules[].host"
+      validate:
+        message: "The Ingress host name must be unique."
+        deny:
+          conditions:
+            all:
+              - key: "{{ request.object.spec.rules[].host }}"
+                operator: AnyIn
+                value: "{{ allhosts }}"
     - name: deny-multiple-hosts
       match:
         any:

--- a/other/res/restrict-ingress-host/values.yaml
+++ b/other/res/restrict-ingress-host/values.yaml
@@ -1,6 +1,6 @@
 policies:
 - name: unique-ingress-host
   rules:
-  - name: check-single-host
+  - name: check-single-host-create
     values:
       hosts: "[\"www.github.com\", \"www.kyverno.com\", \"www.nirmata.com\"]"


### PR DESCRIPTION
Signed-off-by: Chip Zoller <chipzoller@gmail.com>

## Related Issue(s)

Fixes #702 

## Description

Adds two new sample policies, one with kuttl and CLI tests, the other without. Updates restrict-ingress-host with a new rule to match explicitly on UPDATE ops.

## Checklist


- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
