### PR TITLE
chore: remove k8s 1.24 and add k8s 1.28

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,14 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
-          - name: v1.24
-            version: v1.24.15
           - name: v1.25
             version: v1.25.11
           - name: v1.26
             version: v1.26.6
           - name: v1.27
             version: v1.27.3
+          - name: v1.28
+            version: v1.28.0
         tests:
           - argo
           - aws


### PR DESCRIPTION
## Related Issue(s)

This PR removes k8s 1.24 and adds k8s 1.28 to the test grid.
