### PR TITLE
chore: split kuttl test steps 

### DIFF
--- a/other/rec-req/refresh-volumes-in-pods/04-check-annotations.yaml
+++ b/other/rec-req/refresh-volumes-in-pods/04-check-annotations.yaml
@@ -14,13 +14,3 @@ commands:
 - script: |
     annotation=$(kubectl get pod pod04 -n refresh-vols-ns -o json | kyverno jp query "metadata.annotations.\"corp.org/random\" || '' " | tail -n 1 | cut -d '"' -f 2)
     if [ "$annotation" = "1234abcd" ]; then exit 0; else exit 1; fi
-- script: |
-    val=$(kubectl exec pod01 -n refresh-vols-ns -- cat /mnt/foo/foo)
-    if [ "$val" = "bar" ]; then exit 0; else exit 1; fi
-- script: |
-    val=$(kubectl exec pod02 -n refresh-vols-ns -- cat /mnt/foo/foo)
-    if [ "$val" = "bar" ]; then exit 0; else exit 1; fi
-- script: |
-    val=$(kubectl exec pod04 -n refresh-vols-ns -- cat /mnt/foo/foo)
-    if [ "$val" = "bar" ]; then exit 0; else exit 1; fi
-- command: kubectl delete all --all --force --grace-period=0 -n refresh-vols-ns

--- a/other/rec-req/refresh-volumes-in-pods/05-check.yaml
+++ b/other/rec-req/refresh-volumes-in-pods/05-check.yaml
@@ -1,0 +1,14 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- command: sleep 3
+- script: |
+    val=$(kubectl exec pod01 -n refresh-vols-ns -- cat /mnt/foo/foo)
+    if [ "$val" = "bar" ]; then exit 0; else exit 1; fi
+- script: |
+    val=$(kubectl exec pod02 -n refresh-vols-ns -- cat /mnt/foo/foo)
+    if [ "$val" = "bar" ]; then exit 0; else exit 1; fi
+- script: |
+    val=$(kubectl exec pod04 -n refresh-vols-ns -- cat /mnt/foo/foo)
+    if [ "$val" = "bar" ]; then exit 0; else exit 1; fi
+- command: kubectl delete all --all --force --grace-period=0 -n refresh-vols-ns


### PR DESCRIPTION
This PR attempts to fix the flaky kuttl test `refresh-volumes-in-pods`, ref https://github.com/kyverno/kyverno/issues/8334.

I'm able to consistently reproduce the issue by removing the `sleep 5` command, the tests ran in Kyverno CIs could take longer than 5s. I'm splitting the check step into 2 and adding more delay to see if it helps.

```
        ]
    logger.go:42: 16:43:29 | refresh-volumes-in-pods/4-check | running command: [sh -c val=$(kubectl exec pod01 -n refresh-vols-ns -- cat /mnt/foo/foo)
        if [ "$val" = "bar" ]; then exit 0; else exit 1; fi
        ]
    logger.go:42: 16:43:29 | refresh-volumes-in-pods/4-check | command failure, skipping 3 additional commands
    case.go:367: failed in step 4-check
    case.go:369: exit status 1
```