### PR TITLE
feat: add cri-dockerd flavor to disallow-cri-sock-mount policy

### DIFF
--- a/best-practices/disallow-cri-sock-mount/02-manifests.yaml
+++ b/best-practices/disallow-cri-sock-mount/02-manifests.yaml
@@ -9,6 +9,8 @@ apply:
   shouldFail: true
 - file: pod-crio-sock.yaml
   shouldFail: true
+- file: pod-cri-dockerd-sock.yaml
+  shouldFail: true
 - file: pod-emptydir-vol.yaml
   shouldFail: false
 - file: pod-no-volumes.yaml

--- a/best-practices/disallow-cri-sock-mount/artifacthub-pkg.yml
+++ b/best-practices/disallow-cri-sock-mount/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: disallow-cri-sock-mount
-version: 1.1.0
+version: 1.0.0
 displayName: Disallow CRI socket mounts
 createdAt: "2023-04-10T19:47:15.000Z"
 description: >-
@@ -19,10 +19,4 @@ readme: |
 annotations:
   kyverno/category: "Best Practices, EKS Best Practices"
   kyverno/subject: "Pod"
-digest: 2eaa240566025fa1195b0ceb9698b356a4e675a28c8bd4ad469f5b4aa441fee5
-changes:
-  - kind: added
-    description: Add CRI Dockerd socket mount validation
-    links:
-      - name: Github PR
-        url: https://github.com/kyverno/policies/pull/753
+digest: d1d1668af87e2bc2fd5449e13a5db36301a73ed28f71a2d1a5b28a455188d2df

--- a/best-practices/disallow-cri-sock-mount/artifacthub-pkg.yml
+++ b/best-practices/disallow-cri-sock-mount/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: disallow-cri-sock-mount
-version: 1.0.0
+version: 1.1.0
 displayName: Disallow CRI socket mounts
 createdAt: "2023-04-10T19:47:15.000Z"
 description: >-
@@ -20,3 +20,9 @@ annotations:
   kyverno/category: "Best Practices, EKS Best Practices"
   kyverno/subject: "Pod"
 digest: 2eaa240566025fa1195b0ceb9698b356a4e675a28c8bd4ad469f5b4aa441fee5
+changes:
+  - kind: added
+    description: Add CRI Dockerd socket mount validation
+    links:
+      - name: Github PR
+        url: https://github.com/kyverno/policies/pull/753

--- a/best-practices/disallow-cri-sock-mount/disallow-cri-sock-mount.yaml
+++ b/best-practices/disallow-cri-sock-mount/disallow-cri-sock-mount.yaml
@@ -56,3 +56,16 @@ spec:
           =(volumes):
             - =(hostPath):
                 path: "!/var/run/crio.sock"
+  - name: validate-dockerd-sock-mount
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    validate:
+      message: "Use of the Docker CRI socket is not allowed."
+      pattern:
+        spec:
+          =(volumes):
+            - =(hostPath):
+                path: "!/var/run/cri-dockerd.sock"

--- a/best-practices/disallow-cri-sock-mount/pod-cri-dockerd-sock.yaml
+++ b/best-practices/disallow-cri-sock-mount/pod-cri-dockerd-sock.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-with-cri-dockerd-sock-mount
+spec:
+  containers:
+  - name: myshell
+    image: "ubuntu:18.04"
+    command:
+    - /bin/sleep
+    - "300"
+  volumes:
+  - name: dockersock
+    hostPath:
+      path: /var/run/cri-dockerd.sock


### PR DESCRIPTION
## Related Issue(s)

N/A

## Description
During implementation in our environment, we noted that cri-dockerd was missing from the `disallow-cri-sock-mount` policy. So adding that simple use case in to the existing policy and updating associated test files. 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [X] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [X] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [X] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
