### PR TITLE
chore: bump golang to 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Go 
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.20"
+          go-version: ~1.21.1
 
       - name: Test Policy
         run: go run ./cmd/cli/kubectl-kyverno test ../policies
@@ -108,7 +108,7 @@ jobs:
       - name: Set up Go 
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.20"
+          go-version: ~1.21.1
       - name: Lint policies
         run: |
           set -e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: ~1.20.2
+          go-version: ~1.21.1
       - name: Install Tools
         run: |
           GOBIN=$(pwd)/.tools/ go install sigs.k8s.io/kind@v0.19.0


### PR DESCRIPTION
## Related Issue(s)

This PR bumps golang to 1.21.
