### PR TITLE
feat: add pod security standards (baseline) in CEL expressions - Part 2

### DIFF
--- a/pod-security-cel/baseline/disallow-privileged-containers/01-assert.yaml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-privileged-containers
+status:
+  ready: true

--- a/pod-security-cel/baseline/disallow-privileged-containers/01-enforce.yaml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/01-enforce.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    sed 's/validationFailureAction: Audit/validationFailureAction: Enforce/' disallow-privileged-containers.yaml | kubectl create -f - 

--- a/pod-security-cel/baseline/disallow-privileged-containers/02-manifests.yaml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/02-manifests.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- file: ../../../pod-security/baseline/disallow-privileged-containers/pod-good.yaml
+  shouldFail: false
+- file: ../../../pod-security/baseline/disallow-privileged-containers/pod-bad.yaml
+  shouldFail: true
+- file: ../../../pod-security/baseline/disallow-privileged-containers/podcontroller-good.yaml
+  shouldFail: false
+- file: ../../../pod-security/baseline/disallow-privileged-containers/podcontroller-bad.yaml
+  shouldFail: true

--- a/pod-security-cel/baseline/disallow-privileged-containers/99-delete.yaml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/99-delete.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  name: disallow-privileged-containers

--- a/pod-security-cel/baseline/disallow-privileged-containers/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 9df73d54c268a8ce8099089040099ce8f5e8ff5ccb23559a7d04c0270b0451ce
+digest: 0c27d86370715bfe2fcae86c9390ca2e95f889f350a3153ba8685fdb5f5a8755

--- a/pod-security-cel/baseline/disallow-privileged-containers/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: disallow-privileged-containers
+version: 1.0.0
+displayName: Disallow Privileged Containers in CEL expressions
+description: >-
+  Privileged mode disables most security mechanisms and must not be allowed. This policy ensures Pods do not call for privileged mode.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/pod-security-cel/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
+  ```
+keywords:
+  - kyverno
+  - Pod Security Standards (Baseline)
+  - CEL Expressions
+readme: |
+  Privileged mode disables most security mechanisms and must not be allowed. This policy ensures Pods do not call for privileged mode.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Pod Security Standards (Baseline) in CEL"
+  kyverno/kubernetesVersion: "1.26-1.27"
+  kyverno/subject: "Pod"
+digest: 9df73d54c268a8ce8099089040099ce8f5e8ff5ccb23559a7d04c0270b0451ce

--- a/pod-security-cel/baseline/disallow-privileged-containers/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 0c27d86370715bfe2fcae86c9390ca2e95f889f350a3153ba8685fdb5f5a8755
+digest: 4c48385be967ef691a8d8fc839497328e9b4cfdfdd0fd767949e9f0299ba966e

--- a/pod-security-cel/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
@@ -1,0 +1,46 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-privileged-containers
+  annotations:
+    policies.kyverno.io/title: Disallow Privileged Containers in CEL expressions
+    policies.kyverno.io/category: Pod Security Standards (Baseline) in CEL
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.11.0
+    kyverno.io/kubernetes-version: "1.26-1.27"
+    policies.kyverno.io/description: >-
+      Privileged mode disables most security mechanisms and must not be allowed. This policy
+      ensures Pods do not call for privileged mode.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: privileged-containers
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged
+          and spec.initContainers[*].securityContext.privileged must be unset or set to `false`.
+        cel:
+          expressions:
+            - expression: >-
+                object.spec.containers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.privileged) ||
+                container.securityContext.privileged == false)
+
+            - expression: >-
+                !has(object.spec.initContainers) ||
+                object.spec.initContainers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.privileged) ||
+                container.securityContext.privileged == false)
+
+            - expression: >-
+                !has(object.spec.ephemeralContainers) ||
+                object.spec.ephemeralContainers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.privileged) ||
+                container.securityContext.privileged == false)

--- a/pod-security-cel/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
@@ -23,24 +23,30 @@ spec:
             kinds:
               - Pod
       validate:
-        message: >-
-          Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged
-          and spec.initContainers[*].securityContext.privileged must be unset or set to `false`.
         cel:
           expressions:
             - expression: >-
                 object.spec.containers.all(container, !has(container.securityContext) ||
                 !has(container.securityContext.privileged) ||
                 container.securityContext.privileged == false)
+              message: >-
+                Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged
+                must be unset or set to `false`.
 
             - expression: >-
                 !has(object.spec.initContainers) ||
                 object.spec.initContainers.all(container, !has(container.securityContext) ||
                 !has(container.securityContext.privileged) ||
                 container.securityContext.privileged == false)
+              message: >-
+                Privileged mode is disallowed. The fields spec.initContainers[*].securityContext.privileged
+                must be unset or set to `false`.
 
             - expression: >-
                 !has(object.spec.ephemeralContainers) ||
                 object.spec.ephemeralContainers.all(container, !has(container.securityContext) ||
                 !has(container.securityContext.privileged) ||
                 container.securityContext.privileged == false)
+              message: >-
+                Privileged mode is disallowed. The fields spec.ephemeralContainers[*].securityContext.privileged
+                must be unset or set to `false`.

--- a/pod-security-cel/baseline/disallow-privileged-containers/kyverno-test.yaml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/kyverno-test.yaml
@@ -1,0 +1,72 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: disallow-privileged-containers
+policies:
+- disallow-privileged-containers.yaml
+resources:
+- ../../../pod-security/baseline/disallow-privileged-containers/resource.yaml
+results:
+- kind: CronJob
+  policy: disallow-privileged-containers
+  resources:
+  - badcronjob01
+  - badcronjob02
+  - badcronjob03
+  - badcronjob04
+  - badcronjob05
+  result: fail
+  rule: privileged-containers
+- kind: Deployment
+  policy: disallow-privileged-containers
+  resources:
+  - baddeployment01
+  - baddeployment02
+  - baddeployment03
+  - baddeployment04
+  - baddeployment05
+  result: fail
+  rule: privileged-containers
+- kind: Pod
+  policy: disallow-privileged-containers
+  resources:
+  - badpod01
+  - badpod02
+  - badpod03
+  - badpod04
+  - badpod05
+  result: fail
+  rule: privileged-containers
+- kind: CronJob
+  policy: disallow-privileged-containers
+  resources:
+  - goodcronjob01
+  - goodcronjob02
+  - goodcronjob03
+  - goodcronjob04
+  - goodcronjob05
+  - goodcronjob06
+  result: pass
+  rule: privileged-containers
+- kind: Deployment
+  policy: disallow-privileged-containers
+  resources:
+  - gooddeployment01
+  - gooddeployment02
+  - gooddeployment03
+  - gooddeployment04
+  - gooddeployment05
+  - gooddeployment06
+  result: pass
+  rule: privileged-containers
+- kind: Pod
+  policy: disallow-privileged-containers
+  resources:
+  - goodpod01
+  - goodpod02
+  - goodpod03
+  - goodpod04
+  - goodpod05
+  - goodpod06
+  result: pass
+  rule: privileged-containers

--- a/pod-security-cel/baseline/disallow-proc-mount/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-proc-mount/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: ae39abc105a9d5739fdfbd384e8339e60c38958ffdefb13d0d440df2a08414fd
+digest: 48fbac14beda4385f57f55e55b84f99cfed3f8b5e88ab6c60046fdde00bf1273

--- a/pod-security-cel/baseline/disallow-proc-mount/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-proc-mount/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: ce3647a9f835eb5da49ae65ccc4976010b8f7fd3cba7b0ac66b05a6cf8fac3fb
+digest: ae39abc105a9d5739fdfbd384e8339e60c38958ffdefb13d0d440df2a08414fd

--- a/pod-security-cel/baseline/disallow-proc-mount/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-proc-mount/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: disallow-proc-mount
+version: 1.0.0
+displayName: Disallow procMount in CEL expressions
+description: >-
+  The default /proc masks are set up to reduce attack surface and should be required. This policy ensures nothing but the default procMount can be specified. Note that in order for users to deviate from the `Default` procMount requires setting a feature gate at the API server.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/pod-security-cel/baseline/disallow-proc-mount/disallow-proc-mount.yaml
+  ```
+keywords:
+  - kyverno
+  - Pod Security Standards (Baseline)
+  - CEL Expressions
+readme: |
+  The default /proc masks are set up to reduce attack surface and should be required. This policy ensures nothing but the default procMount can be specified. Note that in order for users to deviate from the `Default` procMount requires setting a feature gate at the API server.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Pod Security Standards (Baseline) in CEL"
+  kyverno/kubernetesVersion: "1.26-1.27"
+  kyverno/subject: "Pod"
+digest: ce3647a9f835eb5da49ae65ccc4976010b8f7fd3cba7b0ac66b05a6cf8fac3fb

--- a/pod-security-cel/baseline/disallow-proc-mount/disallow-proc-mount.yaml
+++ b/pod-security-cel/baseline/disallow-proc-mount/disallow-proc-mount.yaml
@@ -1,0 +1,50 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-proc-mount
+  annotations:
+    policies.kyverno.io/title: Disallow procMount in CEL expressions
+    policies.kyverno.io/category: Pod Security Standards (Baseline) in CEL
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.11.0
+    kyverno.io/kubernetes-version: "1.26-1.27"
+    policies.kyverno.io/description: >-
+      The default /proc masks are set up to reduce attack surface and should be required. This policy
+      ensures nothing but the default procMount can be specified. Note that in order for users
+      to deviate from the `Default` procMount requires setting a feature gate at the API
+      server.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: check-proc-mount
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Changing the proc mount from the default is not allowed. The fields
+          spec.containers[*].securityContext.procMount, spec.initContainers[*].securityContext.procMount,
+          and spec.ephemeralContainers[*].securityContext.procMount must be unset or
+          set to `Default`.
+        cel:
+          expressions:
+            - expression: >- 
+                object.spec.containers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.procMount) ||
+                container.securityContext.procMount == 'Default')
+      
+            - expression: >-
+                !has(object.spec.initContainers) ||
+                object.spec.initContainers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.procMount) ||
+                container.securityContext.procMount == 'Default')
+              
+            - expression: >- 
+                !has(object.spec.ephemeralContainers) ||
+                object.spec.ephemeralContainers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.procMount) ||
+                container.securityContext.procMount == 'Default')

--- a/pod-security-cel/baseline/disallow-proc-mount/disallow-proc-mount.yaml
+++ b/pod-security-cel/baseline/disallow-proc-mount/disallow-proc-mount.yaml
@@ -25,26 +25,30 @@ spec:
             kinds:
               - Pod
       validate:
-        message: >-
-          Changing the proc mount from the default is not allowed. The fields
-          spec.containers[*].securityContext.procMount, spec.initContainers[*].securityContext.procMount,
-          and spec.ephemeralContainers[*].securityContext.procMount must be unset or
-          set to `Default`.
         cel:
           expressions:
             - expression: >- 
                 object.spec.containers.all(container, !has(container.securityContext) ||
                 !has(container.securityContext.procMount) ||
                 container.securityContext.procMount == 'Default')
+              message: >-
+                Changing the proc mount from the default is not allowed. The field
+                spec.containers[*].securityContext.procMount must be unset or set to `Default`.
       
             - expression: >-
                 !has(object.spec.initContainers) ||
                 object.spec.initContainers.all(container, !has(container.securityContext) ||
                 !has(container.securityContext.procMount) ||
                 container.securityContext.procMount == 'Default')
+              message: >-
+                Changing the proc mount from the default is not allowed. The field
+                spec.initContainers[*].securityContext.procMount must be unset or set to `Default`.
               
             - expression: >- 
                 !has(object.spec.ephemeralContainers) ||
                 object.spec.ephemeralContainers.all(container, !has(container.securityContext) ||
                 !has(container.securityContext.procMount) ||
                 container.securityContext.procMount == 'Default')
+              message: >-
+                Changing the proc mount from the default is not allowed. The field
+                spec.ephemeralContainers[*].securityContext.procMount must be unset or set to `Default`.

--- a/pod-security-cel/baseline/disallow-proc-mount/kyverno-test.yaml
+++ b/pod-security-cel/baseline/disallow-proc-mount/kyverno-test.yaml
@@ -1,0 +1,72 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: disallow-proc-mount
+policies:
+- disallow-proc-mount.yaml
+resources:
+- ../../../pod-security/baseline/disallow-proc-mount/resource.yaml
+results:
+- kind: CronJob
+  policy: disallow-proc-mount
+  resources:
+  - badcronjob01
+  - badcronjob02
+  - badcronjob03
+  - badcronjob04
+  - badcronjob05
+  result: fail
+  rule: check-proc-mount
+- kind: Deployment
+  policy: disallow-proc-mount
+  resources:
+  - baddeployment01
+  - baddeployment02
+  - baddeployment03
+  - baddeployment04
+  - baddeployment05
+  result: fail
+  rule: check-proc-mount
+- kind: Pod
+  policy: disallow-proc-mount
+  resources:
+  - badpod01
+  - badpod02
+  - badpod03
+  - badpod04
+  - badpod05
+  result: fail
+  rule: check-proc-mount
+- kind: CronJob
+  policy: disallow-proc-mount
+  resources:
+  - goodcronjob01
+  - goodcronjob02
+  - goodcronjob03
+  - goodcronjob04
+  - goodcronjob05
+  - goodcronjob06
+  result: pass
+  rule: check-proc-mount
+- kind: Deployment
+  policy: disallow-proc-mount
+  resources:
+  - gooddeployment01
+  - gooddeployment02
+  - gooddeployment03
+  - gooddeployment04
+  - gooddeployment05
+  - gooddeployment06
+  result: pass
+  rule: check-proc-mount
+- kind: Pod
+  policy: disallow-proc-mount
+  resources:
+  - goodpod01
+  - goodpod02
+  - goodpod03
+  - goodpod04
+  - goodpod05
+  - goodpod06
+  result: pass
+  rule: check-proc-mount

--- a/pod-security-cel/baseline/disallow-selinux/01-assert.yaml
+++ b/pod-security-cel/baseline/disallow-selinux/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-selinux
+status:
+  ready: true

--- a/pod-security-cel/baseline/disallow-selinux/01-enforce.yaml
+++ b/pod-security-cel/baseline/disallow-selinux/01-enforce.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    sed 's/validationFailureAction: Audit/validationFailureAction: Enforce/' disallow-selinux.yaml | kubectl create -f - 

--- a/pod-security-cel/baseline/disallow-selinux/02-manifests.yaml
+++ b/pod-security-cel/baseline/disallow-selinux/02-manifests.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- file: ../../../pod-security/baseline/disallow-selinux/pod-good.yaml
+  shouldFail: false
+- file: ../../../pod-security/baseline/disallow-selinux/pod-bad.yaml
+  shouldFail: true
+- file: ../../../pod-security/baseline/disallow-selinux/podcontroller-good.yaml
+  shouldFail: false
+- file: ../../../pod-security/baseline/disallow-selinux/podcontroller-bad.yaml
+  shouldFail: true

--- a/pod-security-cel/baseline/disallow-selinux/99-delete.yaml
+++ b/pod-security-cel/baseline/disallow-selinux/99-delete.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  name: disallow-selinux

--- a/pod-security-cel/baseline/disallow-selinux/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-selinux/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 4d028ef08da7f6dffc6ecfe22eff55e643d57ddc14498142958fb572bf31dfe0
+digest: 47a3234e468d8f471a46a9a49fb053f6ae8a6576ecc732f34f9535e11feea43b

--- a/pod-security-cel/baseline/disallow-selinux/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-selinux/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: disallow-selinux
+version: 1.0.0
+displayName: Disallow SELinux in CEL expressions
+description: >-
+  SELinux options can be used to escalate privileges and should not be allowed. This policy ensures that the `seLinuxOptions` field is undefined.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/pod-security-cel/baseline/disallow-selinux/disallow-selinux.yaml
+  ```
+keywords:
+  - kyverno
+  - Pod Security Standards (Baseline)
+  - CEL Expressions
+readme: |
+  SELinux options can be used to escalate privileges and should not be allowed. This policy ensures that the `seLinuxOptions` field is undefined.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Pod Security Standards (Baseline) in CEL"
+  kyverno/kubernetesVersion: "1.26-1.27"
+  kyverno/subject: "Pod"
+digest: 4d028ef08da7f6dffc6ecfe22eff55e643d57ddc14498142958fb572bf31dfe0

--- a/pod-security-cel/baseline/disallow-selinux/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-selinux/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 47a3234e468d8f471a46a9a49fb053f6ae8a6576ecc732f34f9535e11feea43b
+digest: d6379e3637a2df6d05a1613d7a000aff5cf4f6f4cc983395574238cdd225fa39

--- a/pod-security-cel/baseline/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security-cel/baseline/disallow-selinux/disallow-selinux.yaml
@@ -23,11 +23,6 @@ spec:
             kinds:
               - Pod
       validate:
-        message: >-
-          Setting the SELinux type is restricted. The fields
-          spec.securityContext.seLinuxOptions.type, spec.containers[*].securityContext.seLinuxOptions.type,
-          , spec.initContainers[*].securityContext.seLinuxOptions, and spec.ephemeralContainers[*].securityContext.seLinuxOptions.type
-          must either be unset or set to one of the allowed values (container_t, container_init_t, or container_kvm_t).
         cel:
           expressions:
             - expression: >- 
@@ -37,6 +32,9 @@ spec:
                 object.spec.securityContext.seLinuxOptions.type == 'container_t' ||
                 object.spec.securityContext.seLinuxOptions.type == 'container_init_t' ||
                 object.spec.securityContext.seLinuxOptions.type == 'container_kvm_t'
+              message: >-
+                Setting the SELinux type is restricted. The field spec.securityContext.seLinuxOptions.type 
+                must either be unset or set to one of the allowed values (container_t, container_init_t, or container_kvm_t).
 
             - expression: >-
                 object.spec.containers.all(container, !has(container.securityContext) ||
@@ -45,6 +43,9 @@ spec:
                 container.securityContext.seLinuxOptions.type == 'container_t' ||
                 container.securityContext.seLinuxOptions.type == 'container_init_t' ||
                 container.securityContext.seLinuxOptions.type == 'container_kvm_t')
+              message: >-
+                Setting the SELinux type is restricted. The field spec.containers[*].securityContext.seLinuxOptions.type 
+                must either be unset or set to one of the allowed values (container_t, container_init_t, or container_kvm_t).
 
             - expression: >- 
                 !has(object.spec.initContainers) ||
@@ -54,6 +55,9 @@ spec:
                 container.securityContext.seLinuxOptions.type == 'container_t' ||
                 container.securityContext.seLinuxOptions.type == 'container_init_t' ||
                 container.securityContext.seLinuxOptions.type == 'container_kvm_t')
+              message: >-
+                Setting the SELinux type is restricted. The field spec.initContainers[*].securityContext.seLinuxOptions.type 
+                must either be unset or set to one of the allowed values (container_t, container_init_t, or container_kvm_t).
 
             - expression: >- 
                 !has(object.spec.ephemeralContainers) ||
@@ -63,6 +67,9 @@ spec:
                 container.securityContext.seLinuxOptions.type == 'container_t' ||
                 container.securityContext.seLinuxOptions.type == 'container_init_t' ||
                 container.securityContext.seLinuxOptions.type == 'container_kvm_t')
+              message: >-
+                Setting the SELinux type is restricted. The field spec.ephemeralContainers[*].securityContext.seLinuxOptions.type 
+                must either be unset or set to one of the allowed values (container_t, container_init_t, or container_kvm_t).
     - name: selinux-user-role
       match:
         any:
@@ -70,33 +77,38 @@ spec:
             kinds:
               - Pod
       validate:
-        message: >-
-          Setting the SELinux user or role is forbidden. The fields
-          spec.securityContext.seLinuxOptions.user, spec.securityContext.seLinuxOptions.role,
-          spec.containers[*].securityContext.seLinuxOptions.user, spec.containers[*].securityContext.seLinuxOptions.role,
-          spec.initContainers[*].securityContext.seLinuxOptions.user, spec.initContainers[*].securityContext.seLinuxOptions.role,
-          spec.ephemeralContainers[*].securityContext.seLinuxOptions.user, and spec.ephemeralContainers[*].securityContext.seLinuxOptions.role
-          must be unset.
         cel:
           expressions:
             - expression: >- 
                 !has(object.spec.securityContext) ||
                 !has(object.spec.securityContext.seLinuxOptions) ||
                 (!has(object.spec.securityContext.seLinuxOptions.user) && !has(object.spec.securityContext.seLinuxOptions.role))
+              message: >-
+                Setting the SELinux user or role is forbidden. The fields
+                spec.securityContext.seLinuxOptions.user and spec.securityContext.seLinuxOptions.role must be unset.
 
             - expression: >- 
                 object.spec.containers.all(container, !has(container.securityContext) ||
                 !has(container.securityContext.seLinuxOptions) ||
                 (!has(container.securityContext.seLinuxOptions.user) && !has(container.securityContext.seLinuxOptions.role)))
+              message: >-
+                Setting the SELinux user or role is forbidden. The fields
+                spec.containers[*].securityContext.seLinuxOptions.user and spec.containers[*].securityContext.seLinuxOptions.role must be unset.
 
             - expression: >- 
                 !has(object.spec.initContainers) ||
                 object.spec.initContainers.all(container, !has(container.securityContext) ||
                 !has(container.securityContext.seLinuxOptions) ||
                 (!has(container.securityContext.seLinuxOptions.user) && !has(container.securityContext.seLinuxOptions.role)))
+              message: >-
+                Setting the SELinux user or role is forbidden. The fields
+                spec.initContainers[*].securityContext.seLinuxOptions.user and spec.initContainers[*].securityContext.seLinuxOptions.role must be unset.
 
             - expression: >- 
                 !has(object.spec.ephemeralContainers) ||
                 object.spec.ephemeralContainers.all(container, !has(container.securityContext) ||
                 !has(container.securityContext.seLinuxOptions) ||
                 (!has(container.securityContext.seLinuxOptions.user) && !has(container.securityContext.seLinuxOptions.role)))
+              message: >-
+                Setting the SELinux user or role is forbidden. The fields
+                spec.ephemeralContainers[*].securityContext.seLinuxOptions.user and spec.ephemeralContainers[*].securityContext.seLinuxOptions.role must be unset.

--- a/pod-security-cel/baseline/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security-cel/baseline/disallow-selinux/disallow-selinux.yaml
@@ -1,0 +1,102 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-selinux
+  annotations:
+    policies.kyverno.io/title: Disallow SELinux in CEL expressions
+    policies.kyverno.io/category: Pod Security Standards (Baseline) in CEL
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.11.0
+    kyverno.io/kubernetes-version: "1.26-1.27"
+    policies.kyverno.io/description: >-
+      SELinux options can be used to escalate privileges and should not be allowed. This policy
+      ensures that the `seLinuxOptions` field is undefined.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: selinux-type
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Setting the SELinux type is restricted. The fields
+          spec.securityContext.seLinuxOptions.type, spec.containers[*].securityContext.seLinuxOptions.type,
+          , spec.initContainers[*].securityContext.seLinuxOptions, and spec.ephemeralContainers[*].securityContext.seLinuxOptions.type
+          must either be unset or set to one of the allowed values (container_t, container_init_t, or container_kvm_t).
+        cel:
+          expressions:
+            - expression: >- 
+                !has(object.spec.securityContext) ||
+                !has(object.spec.securityContext.seLinuxOptions) ||
+                !has(object.spec.securityContext.seLinuxOptions.type) ||
+                object.spec.securityContext.seLinuxOptions.type == 'container_t' ||
+                object.spec.securityContext.seLinuxOptions.type == 'container_init_t' ||
+                object.spec.securityContext.seLinuxOptions.type == 'container_kvm_t'
+
+            - expression: >-
+                object.spec.containers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.seLinuxOptions) ||
+                !has(container.securityContext.seLinuxOptions.type) ||
+                container.securityContext.seLinuxOptions.type == 'container_t' ||
+                container.securityContext.seLinuxOptions.type == 'container_init_t' ||
+                container.securityContext.seLinuxOptions.type == 'container_kvm_t')
+
+            - expression: >- 
+                !has(object.spec.initContainers) ||
+                object.spec.initContainers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.seLinuxOptions) ||
+                !has(container.securityContext.seLinuxOptions.type) ||
+                container.securityContext.seLinuxOptions.type == 'container_t' ||
+                container.securityContext.seLinuxOptions.type == 'container_init_t' ||
+                container.securityContext.seLinuxOptions.type == 'container_kvm_t')
+
+            - expression: >- 
+                !has(object.spec.ephemeralContainers) ||
+                object.spec.ephemeralContainers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.seLinuxOptions) ||
+                !has(container.securityContext.seLinuxOptions.type) ||
+                container.securityContext.seLinuxOptions.type == 'container_t' ||
+                container.securityContext.seLinuxOptions.type == 'container_init_t' ||
+                container.securityContext.seLinuxOptions.type == 'container_kvm_t')
+    - name: selinux-user-role
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Setting the SELinux user or role is forbidden. The fields
+          spec.securityContext.seLinuxOptions.user, spec.securityContext.seLinuxOptions.role,
+          spec.containers[*].securityContext.seLinuxOptions.user, spec.containers[*].securityContext.seLinuxOptions.role,
+          spec.initContainers[*].securityContext.seLinuxOptions.user, spec.initContainers[*].securityContext.seLinuxOptions.role,
+          spec.ephemeralContainers[*].securityContext.seLinuxOptions.user, and spec.ephemeralContainers[*].securityContext.seLinuxOptions.role
+          must be unset.
+        cel:
+          expressions:
+            - expression: >- 
+                !has(object.spec.securityContext) ||
+                !has(object.spec.securityContext.seLinuxOptions) ||
+                (!has(object.spec.securityContext.seLinuxOptions.user) && !has(object.spec.securityContext.seLinuxOptions.role))
+
+            - expression: >- 
+                object.spec.containers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.seLinuxOptions) ||
+                (!has(container.securityContext.seLinuxOptions.user) && !has(container.securityContext.seLinuxOptions.role)))
+
+            - expression: >- 
+                !has(object.spec.initContainers) ||
+                object.spec.initContainers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.seLinuxOptions) ||
+                (!has(container.securityContext.seLinuxOptions.user) && !has(container.securityContext.seLinuxOptions.role)))
+
+            - expression: >- 
+                !has(object.spec.ephemeralContainers) ||
+                object.spec.ephemeralContainers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.seLinuxOptions) ||
+                (!has(container.securityContext.seLinuxOptions.user) && !has(container.securityContext.seLinuxOptions.role)))

--- a/pod-security-cel/baseline/disallow-selinux/kyverno-test.yaml
+++ b/pod-security-cel/baseline/disallow-selinux/kyverno-test.yaml
@@ -1,0 +1,216 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: disallow-selinux
+policies:
+- disallow-selinux.yaml
+resources:
+- ../../../pod-security/baseline/disallow-selinux/resource.yaml
+results:
+- kind: CronJob
+  policy: disallow-selinux
+  resources:
+  - badcronjob01
+  - badcronjob02
+  - badcronjob03
+  - badcronjob04
+  - badcronjob05
+  - badcronjob06
+  - badcronjob07
+  result: fail
+  rule: selinux-type
+- kind: Deployment
+  policy: disallow-selinux
+  resources:
+  - baddeployment01
+  - baddeployment02
+  - baddeployment03
+  - baddeployment04
+  - baddeployment05
+  - baddeployment06
+  - baddeployment07
+  result: fail
+  rule: selinux-type
+- kind: Pod
+  policy: disallow-selinux
+  resources:
+  - badpod01
+  - badpod02
+  - badpod03
+  - badpod04
+  - badpod05
+  - badpod06
+  - badpod07
+  result: fail
+  rule: selinux-type
+- kind: CronJob
+  policy: disallow-selinux
+  resources:
+  - goodcronjob01
+  - goodcronjob02
+  - goodcronjob03
+  - goodcronjob04
+  - goodcronjob05
+  - goodcronjob06
+  - goodcronjob07
+  - goodcronjob08
+  - goodcronjob09
+  - goodcronjob10
+  - goodcronjob11
+  - goodcronjob12
+  - goodcronjob13
+  - goodcronjob14
+  result: pass
+  rule: selinux-type
+- kind: Deployment
+  policy: disallow-selinux
+  resources:
+  - gooddeployment01
+  - gooddeployment02
+  - gooddeployment03
+  - gooddeployment04
+  - gooddeployment05
+  - gooddeployment06
+  - gooddeployment07
+  - gooddeployment08
+  - gooddeployment09
+  - gooddeployment10
+  - gooddeployment11
+  - gooddeployment12
+  - gooddeployment13
+  - gooddeployment14
+  result: pass
+  rule: selinux-type
+- kind: Pod
+  policy: disallow-selinux
+  resources:
+  - goodpod01
+  - goodpod02
+  - goodpod03
+  - goodpod04
+  - goodpod05
+  - goodpod06
+  - goodpod07
+  - goodpod08
+  - goodpod09
+  - goodpod10
+  - goodpod11
+  - goodpod12
+  - goodpod13
+  - goodpod14
+  result: pass
+  rule: selinux-type
+- kind: CronJob
+  policy: disallow-selinux
+  resources:
+  - selur-badcronjob01
+  - selur-badcronjob02
+  - selur-badcronjob03
+  - selur-badcronjob04
+  - selur-badcronjob05
+  - selur-badcronjob06
+  - selur-badcronjob07
+  - selur-badcronjob08
+  - selur-badcronjob09
+  - selur-badcronjob10
+  - selur-badcronjob11
+  - selur-badcronjob12
+  - selur-badcronjob13
+  - selur-badcronjob14
+  - selur-badcronjob15
+  - selur-badcronjob16
+  - selur-badcronjob17
+  result: fail
+  rule: selinux-user-role
+- kind: Deployment
+  policy: disallow-selinux
+  resources:
+  - selur-baddeployment01
+  - selur-baddeployment02
+  - selur-baddeployment03
+  - selur-baddeployment04
+  - selur-baddeployment05
+  - selur-baddeployment06
+  - selur-baddeployment07
+  - selur-baddeployment08
+  - selur-baddeployment09
+  - selur-baddeployment10
+  - selur-baddeployment11
+  - selur-baddeployment12
+  - selur-baddeployment13
+  - selur-baddeployment14
+  - selur-baddeployment15
+  - selur-baddeployment16
+  - selur-baddeployment17
+  result: fail
+  rule: selinux-user-role
+- kind: Pod
+  policy: disallow-selinux
+  resources:
+  - selur-badpod01
+  - selur-badpod02
+  - selur-badpod03
+  - selur-badpod04
+  - selur-badpod05
+  - selur-badpod06
+  - selur-badpod07
+  - selur-badpod08
+  - selur-badpod09
+  - selur-badpod10
+  - selur-badpod11
+  - selur-badpod12
+  - selur-badpod13
+  - selur-badpod14
+  - selur-badpod15
+  - selur-badpod16
+  - selur-badpod17
+  result: fail
+  rule: selinux-user-role
+- kind: CronJob
+  policy: disallow-selinux
+  resources:
+  - selur-goodcronjob01
+  - selur-goodcronjob02
+  - selur-goodcronjob03
+  - selur-goodcronjob04
+  - selur-goodcronjob05
+  - selur-goodcronjob06
+  - selur-goodcronjob07
+  - selur-goodcronjob08
+  - selur-goodcronjob09
+  - selur-goodcronjob10
+  - selur-goodcronjob11
+  result: pass
+  rule: selinux-user-role
+- kind: Deployment
+  policy: disallow-selinux
+  resources:
+  - selur-gooddeployment01
+  - selur-gooddeployment02
+  - selur-gooddeployment03
+  - selur-gooddeployment04
+  - selur-gooddeployment05
+  - selur-gooddeployment06
+  - selur-gooddeployment07
+  - selur-gooddeployment08
+  - selur-gooddeployment09
+  - selur-gooddeployment10
+  - selur-gooddeployment11
+  result: pass
+  rule: selinux-user-role
+- kind: Pod
+  policy: disallow-selinux
+  resources:
+  - selur-goodpod01
+  - selur-goodpod02
+  - selur-goodpod03
+  - selur-goodpod04
+  - selur-goodpod05
+  - selur-goodpod06
+  - selur-goodpod07
+  - selur-goodpod08
+  - selur-goodpod09
+  - selur-goodpod10
+  - selur-goodpod11
+  result: pass
+  rule: selinux-user-role

--- a/pod-security-cel/baseline/kustomization.yaml
+++ b/pod-security-cel/baseline/kustomization.yaml
@@ -5,3 +5,8 @@ resources:
   - disallow-host-ports/disallow-host-ports.yaml
   - disallow-host-ports-range/disallow-host-ports-range.yaml
   - disallow-host-process/disallow-host-process.yaml
+  - disallow-privileged-containers/disallow-privileged-containers.yaml
+  - disallow-proc-mount/disallow-proc-mount.yaml
+  - disallow-selinux/disallow-selinux.yaml
+  - restrict-seccomp/restrict-seccomp.yaml
+  - restrict-sysctls/restrict-sysctls.yaml

--- a/pod-security-cel/baseline/restrict-seccomp/01-assert.yaml
+++ b/pod-security-cel/baseline/restrict-seccomp/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-seccomp
+status:
+  ready: true

--- a/pod-security-cel/baseline/restrict-seccomp/01-enforce.yaml
+++ b/pod-security-cel/baseline/restrict-seccomp/01-enforce.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    sed 's/validationFailureAction: Audit/validationFailureAction: Enforce/' restrict-seccomp.yaml | kubectl create -f -
+ 

--- a/pod-security-cel/baseline/restrict-seccomp/02-manifests.yaml
+++ b/pod-security-cel/baseline/restrict-seccomp/02-manifests.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- file: ../../../pod-security/baseline/restrict-seccomp/pod-good.yaml
+  shouldFail: false
+- file: ../../../pod-security/baseline/restrict-seccomp/pod-bad.yaml
+  shouldFail: true
+- file: ../../../pod-security/baseline/restrict-seccomp/podcontroller-good.yaml
+  shouldFail: false
+- file: ../../../pod-security/baseline/restrict-seccomp/podcontroller-bad.yaml
+  shouldFail: true

--- a/pod-security-cel/baseline/restrict-seccomp/99-delete.yaml
+++ b/pod-security-cel/baseline/restrict-seccomp/99-delete.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  name: restrict-seccomp

--- a/pod-security-cel/baseline/restrict-seccomp/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/restrict-seccomp/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: e3a77f1b737082075994a31468cbd0b8d578c4514d112bda9ee4fb7e0edd8ce6
+digest: 047609777a0e1185127b20051beb2c07c98c8afd584602ecf2d1efd9d830b1c5

--- a/pod-security-cel/baseline/restrict-seccomp/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/restrict-seccomp/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 300e7c36b0fd01c8f70e9ad772b85ef2b4ed6593e6ff1224859bb06b675bfdc2
+digest: e3a77f1b737082075994a31468cbd0b8d578c4514d112bda9ee4fb7e0edd8ce6

--- a/pod-security-cel/baseline/restrict-seccomp/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/restrict-seccomp/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: restrict-seccomp
+version: 1.0.0
+displayName: Restrict Seccomp in CEL expressions
+description: >-
+  The seccomp profile must not be explicitly set to Unconfined. This policy, requiring Kubernetes v1.19 or later, ensures that seccomp is unset or  set to `RuntimeDefault` or `Localhost`.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/pod-security-cel/baseline/restrict-seccomp/restrict-seccomp.yaml
+  ```
+keywords:
+  - kyverno
+  - Pod Security Standards (Baseline)
+  - CEL Expressions
+readme: |
+  The seccomp profile must not be explicitly set to Unconfined. This policy, requiring Kubernetes v1.19 or later, ensures that seccomp is unset or  set to `RuntimeDefault` or `Localhost`.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Pod Security Standards (Baseline) in CEL"
+  kyverno/kubernetesVersion: "1.26-1.27"
+  kyverno/subject: "Pod"
+digest: 300e7c36b0fd01c8f70e9ad772b85ef2b4ed6593e6ff1224859bb06b675bfdc2

--- a/pod-security-cel/baseline/restrict-seccomp/kyverno-test.yaml
+++ b/pod-security-cel/baseline/restrict-seccomp/kyverno-test.yaml
@@ -1,0 +1,93 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-seccomp
+policies:
+- restrict-seccomp.yaml
+resources:
+- ../../../pod-security/baseline/restrict-seccomp/resource.yaml
+results:
+- kind: CronJob
+  policy: restrict-seccomp
+  resources:
+  - badcronjob01
+  - badcronjob02
+  - badcronjob03
+  - badcronjob04
+  - badcronjob05
+  - badcronjob06
+  - badcronjob07
+  result: fail
+  rule: check-seccomp
+- kind: Deployment
+  policy: restrict-seccomp
+  resources:
+  - baddeployment01
+  - baddeployment02
+  - baddeployment03
+  - baddeployment04
+  - baddeployment05
+  - baddeployment06
+  - baddeployment07
+  result: fail
+  rule: check-seccomp
+- kind: Pod
+  policy: restrict-seccomp
+  resources:
+  - badpod01
+  - badpod02
+  - badpod03
+  - badpod04
+  - badpod05
+  - badpod06
+  - badpod07
+  result: fail
+  rule: check-seccomp
+- kind: CronJob
+  policy: restrict-seccomp
+  resources:
+  - goodcronjob01
+  - goodcronjob02
+  - goodcronjob03
+  - goodcronjob04
+  - goodcronjob05
+  - goodcronjob06
+  - goodcronjob07
+  - goodcronjob08
+  - goodcronjob09
+  - goodcronjob10
+  - goodcronjob11
+  result: pass
+  rule: check-seccomp
+- kind: Deployment
+  policy: restrict-seccomp
+  resources:
+  - gooddeployment01
+  - gooddeployment02
+  - gooddeployment03
+  - gooddeployment04
+  - gooddeployment05
+  - gooddeployment06
+  - gooddeployment07
+  - gooddeployment08
+  - gooddeployment09
+  - gooddeployment10
+  - gooddeployment11
+  result: pass
+  rule: check-seccomp
+- kind: Pod
+  policy: restrict-seccomp
+  resources:
+  - goodpod01
+  - goodpod02
+  - goodpod03
+  - goodpod04
+  - goodpod05
+  - goodpod06
+  - goodpod07
+  - goodpod08
+  - goodpod09
+  - goodpod10
+  - goodpod11
+  result: pass
+  rule: check-seccomp

--- a/pod-security-cel/baseline/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security-cel/baseline/restrict-seccomp/restrict-seccomp.yaml
@@ -24,13 +24,6 @@ spec:
             kinds:
               - Pod
       validate:
-        message: >-
-          Use of custom Seccomp profiles is disallowed. The fields
-          spec.securityContext.seccompProfile.type,
-          spec.containers[*].securityContext.seccompProfile.type,
-          spec.initContainers[*].securityContext.seccompProfile.type, and
-          spec.ephemeralContainers[*].securityContext.seccompProfile.type
-          must be unset or set to `RuntimeDefault` or `Localhost`.
         cel:
           expressions:
             - expression: >- 
@@ -39,6 +32,9 @@ spec:
                 !has(object.spec.securityContext.seccompProfile.type) ||
                 object.spec.securityContext.seccompProfile.type == 'RuntimeDefault' ||
                 object.spec.securityContext.seccompProfile.type == 'Localhost'
+              message: >-
+                Use of custom Seccomp profiles is disallowed. The field
+                spec.securityContext.seccompProfile.type must be unset or set to `RuntimeDefault` or `Localhost`.
 
             - expression: >- 
                 object.spec.containers.all(container, !has(container.securityContext) ||
@@ -46,6 +42,9 @@ spec:
                 !has(container.securityContext.seccompProfile.type) ||
                 container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
                 container.securityContext.seccompProfile.type == 'Localhost')
+              message: >-
+                Use of custom Seccomp profiles is disallowed. The field
+                spec.containers[*].securityContext.seccompProfile.type must be unset or set to `RuntimeDefault` or `Localhost`.
 
             - expression: >- 
                 !has(object.spec.initContainers) ||
@@ -54,6 +53,9 @@ spec:
                 !has(container.securityContext.seccompProfile.type) ||
                 container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
                 container.securityContext.seccompProfile.type == 'Localhost')
+              message: >-
+                Use of custom Seccomp profiles is disallowed. The field
+                spec.initContainers[*].securityContext.seccompProfile.type must be unset or set to `RuntimeDefault` or `Localhost`.
 
             - expression: >- 
                 !has(object.spec.ephemeralContainers) ||
@@ -62,3 +64,6 @@ spec:
                 !has(container.securityContext.seccompProfile.type) ||
                 container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
                 container.securityContext.seccompProfile.type == 'Localhost')
+              message: >-
+                Use of custom Seccomp profiles is disallowed. The field
+                spec.ephemeralContainers[*].securityContext.seccompProfile.type must be unset or set to `RuntimeDefault` or `Localhost`.

--- a/pod-security-cel/baseline/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security-cel/baseline/restrict-seccomp/restrict-seccomp.yaml
@@ -1,0 +1,64 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-seccomp
+  annotations:
+    policies.kyverno.io/title: Restrict Seccomp in CEL expressions
+    policies.kyverno.io/category: Pod Security Standards (Baseline) in CEL
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.11.0
+    kyverno.io/kubernetes-version: "1.26-1.27"
+    policies.kyverno.io/description: >-
+      The seccomp profile must not be explicitly set to Unconfined. This policy, 
+      requiring Kubernetes v1.19 or later, ensures that seccomp is unset or 
+      set to `RuntimeDefault` or `Localhost`.
+spec:
+  background: true
+  validationFailureAction: Audit
+  rules:
+    - name: check-seccomp
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Use of custom Seccomp profiles is disallowed. The fields
+          spec.securityContext.seccompProfile.type,
+          spec.containers[*].securityContext.seccompProfile.type,
+          spec.initContainers[*].securityContext.seccompProfile.type, and
+          spec.ephemeralContainers[*].securityContext.seccompProfile.type
+          must be unset or set to `RuntimeDefault` or `Localhost`.
+        cel:
+          expressions:
+            - expression: >- 
+                !has(object.spec.securityContext) ||
+                !has(object.spec.securityContext.seccompProfile) ||
+                !has(object.spec.securityContext.seccompProfile.type) ||
+                object.spec.securityContext.seccompProfile.type == 'RuntimeDefault' ||
+                object.spec.securityContext.seccompProfile.type == 'Localhost'
+
+            - expression: >- 
+                object.spec.containers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.seccompProfile) ||
+                !has(container.securityContext.seccompProfile.type) ||
+                container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
+                container.securityContext.seccompProfile.type == 'Localhost')
+
+            - expression: >- 
+                !has(object.spec.initContainers) ||
+                object.spec.initContainers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.seccompProfile) ||
+                !has(container.securityContext.seccompProfile.type) ||
+                container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
+                container.securityContext.seccompProfile.type == 'Localhost')
+
+            - expression: >- 
+                !has(object.spec.ephemeralContainers) ||
+                object.spec.ephemeralContainers.all(container, !has(container.securityContext) ||
+                !has(container.securityContext.seccompProfile) ||
+                !has(container.securityContext.seccompProfile.type) ||
+                container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
+                container.securityContext.seccompProfile.type == 'Localhost')

--- a/pod-security-cel/baseline/restrict-sysctls/01-assert.yaml
+++ b/pod-security-cel/baseline/restrict-sysctls/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-sysctls
+status:
+  ready: true

--- a/pod-security-cel/baseline/restrict-sysctls/01-enforce.yaml
+++ b/pod-security-cel/baseline/restrict-sysctls/01-enforce.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    sed 's/validationFailureAction: Audit/validationFailureAction: Enforce/' restrict-sysctls.yaml | kubectl create -f - 

--- a/pod-security-cel/baseline/restrict-sysctls/02-manifests.yaml
+++ b/pod-security-cel/baseline/restrict-sysctls/02-manifests.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- file: ../../../pod-security/baseline/restrict-sysctls/pod-good.yaml
+  shouldFail: false
+- file: ../../../pod-security/baseline/restrict-sysctls/pod-bad.yaml
+  shouldFail: true
+- file: ../../../pod-security/baseline/restrict-sysctls/podcontroller-good.yaml
+  shouldFail: false
+- file: ../../../pod-security/baseline/restrict-sysctls/podcontroller-bad.yaml
+  shouldFail: true

--- a/pod-security-cel/baseline/restrict-sysctls/99-delete.yaml
+++ b/pod-security-cel/baseline/restrict-sysctls/99-delete.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: kyverno.io/v1
+  kind: ClusterPolicy
+  name: restrict-sysctls

--- a/pod-security-cel/baseline/restrict-sysctls/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/restrict-sysctls/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 29b9c1bda8c60f61aff4fa1df4a19d9f18eec7376ca9aea202bacc4ab6ab8a11
+digest: 9434617911682d4d4913a417cdc95e1405fd868a0f835d20d8253b0d65760658

--- a/pod-security-cel/baseline/restrict-sysctls/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/restrict-sysctls/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 9434617911682d4d4913a417cdc95e1405fd868a0f835d20d8253b0d65760658
+digest: be45deb93071e4e2e062f431d4c14f404e538c12fa6a387beb9f6053d9d4f535

--- a/pod-security-cel/baseline/restrict-sysctls/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/restrict-sysctls/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: restrict-sysctls
+version: 1.0.0
+displayName: Restrict sysctls in CEL expressions
+description: >-
+  Sysctls can disable security mechanisms or affect all containers on a host, and should be disallowed except for an allowed "safe" subset. A sysctl is considered safe if it is namespaced in the container or the Pod, and it is isolated from other Pods or processes on the same Node. This policy ensures that only those "safe" subsets can be specified in a Pod.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/pod-security-cel/baseline/restrict-sysctls/restrict-sysctls.yaml
+  ```
+keywords:
+  - kyverno
+  - Pod Security Standards (Baseline)
+  - CEL Expressions
+readme: |
+  Sysctls can disable security mechanisms or affect all containers on a host, and should be disallowed except for an allowed "safe" subset. A sysctl is considered safe if it is namespaced in the container or the Pod, and it is isolated from other Pods or processes on the same Node. This policy ensures that only those "safe" subsets can be specified in a Pod.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Pod Security Standards (Baseline) in CEL"
+  kyverno/kubernetesVersion: "1.26-1.27"
+  kyverno/subject: "Pod"
+digest: 29b9c1bda8c60f61aff4fa1df4a19d9f18eec7376ca9aea202bacc4ab6ab8a11

--- a/pod-security-cel/baseline/restrict-sysctls/kyverno-test.yaml
+++ b/pod-security-cel/baseline/restrict-sysctls/kyverno-test.yaml
@@ -1,0 +1,66 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-sysctls
+policies:
+- restrict-sysctls.yaml
+resources:
+- ../../../pod-security/baseline/restrict-sysctls/resource.yaml
+results:
+- kind: CronJob
+  policy: restrict-sysctls
+  resources:
+  - badcronjob01
+  - badcronjob02
+  result: fail
+  rule: check-sysctls
+- kind: Deployment
+  policy: restrict-sysctls
+  resources:
+  - baddeployment01
+  - baddeployment02
+  result: fail
+  rule: check-sysctls
+- kind: Pod
+  policy: restrict-sysctls
+  resources:
+  - badpod01
+  - badpod02
+  result: fail
+  rule: check-sysctls
+- kind: CronJob
+  policy: restrict-sysctls
+  resources:
+  - goodcronjob01
+  - goodcronjob02
+  - goodcronjob03
+  - goodcronjob04
+  - goodcronjob05
+  - goodcronjob06
+  - goodcronjob07
+  result: pass
+  rule: check-sysctls
+- kind: Deployment
+  policy: restrict-sysctls
+  resources:
+  - gooddeployment01
+  - gooddeployment02
+  - gooddeployment03
+  - gooddeployment04
+  - gooddeployment05
+  - gooddeployment06
+  - gooddeployment07
+  result: pass
+  rule: check-sysctls
+- kind: Pod
+  policy: restrict-sysctls
+  resources:
+  - goodpod01
+  - goodpod02
+  - goodpod03
+  - goodpod04
+  - goodpod05
+  - goodpod06
+  - goodpod07
+  result: pass
+  rule: check-sysctls

--- a/pod-security-cel/baseline/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security-cel/baseline/restrict-sysctls/restrict-sysctls.yaml
@@ -27,12 +27,6 @@ spec:
             kinds:
               - Pod
       validate:
-        message: >-
-          Setting additional sysctls above the allowed type is disallowed.
-          The field spec.securityContext.sysctls must be unset or not use any other names
-          than kernel.shm_rmid_forced, net.ipv4.ip_local_port_range,
-          net.ipv4.ip_unprivileged_port_start, net.ipv4.tcp_syncookies and
-          net.ipv4.ping_group_range.
         cel:
           expressions:
             - expression: >- 
@@ -44,3 +38,9 @@ spec:
                 sysctl.name == 'net.ipv4.ip_unprivileged_port_start' ||
                 sysctl.name == 'net.ipv4.tcp_syncookies' ||
                 sysctl.name == 'net.ipv4.ping_group_range')
+              message: >-
+                Setting additional sysctls above the allowed type is disallowed.
+                The field spec.securityContext.sysctls must be unset or not use any other names
+                than kernel.shm_rmid_forced, net.ipv4.ip_local_port_range,
+                net.ipv4.ip_unprivileged_port_start, net.ipv4.tcp_syncookies and
+                net.ipv4.ping_group_range.

--- a/pod-security-cel/baseline/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security-cel/baseline/restrict-sysctls/restrict-sysctls.yaml
@@ -1,0 +1,46 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-sysctls
+  annotations:
+    policies.kyverno.io/title: Restrict sysctls in CEL expressions
+    policies.kyverno.io/category: Pod Security Standards (Baseline) in CEL
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.11.0
+    kyverno.io/kubernetes-version: "1.26-1.27"
+    policies.kyverno.io/description: >-
+      Sysctls can disable security mechanisms or affect all containers on a
+      host, and should be disallowed except for an allowed "safe" subset. A
+      sysctl is considered safe if it is namespaced in the container or the
+      Pod, and it is isolated from other Pods or processes on the same Node.
+      This policy ensures that only those "safe" subsets can be specified in
+      a Pod.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: check-sysctls
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Setting additional sysctls above the allowed type is disallowed.
+          The field spec.securityContext.sysctls must be unset or not use any other names
+          than kernel.shm_rmid_forced, net.ipv4.ip_local_port_range,
+          net.ipv4.ip_unprivileged_port_start, net.ipv4.tcp_syncookies and
+          net.ipv4.ping_group_range.
+        cel:
+          expressions:
+            - expression: >- 
+                !has(object.spec.securityContext) ||
+                !has(object.spec.securityContext.sysctls) ||
+                object.spec.securityContext.sysctls.all(sysctl, !has(sysctl.name) ||
+                sysctl.name == 'kernel.shm_rmid_forced' ||
+                sysctl.name == 'net.ipv4.ip_local_port_range' ||
+                sysctl.name == 'net.ipv4.ip_unprivileged_port_start' ||
+                sysctl.name == 'net.ipv4.tcp_syncookies' ||
+                sysctl.name == 'net.ipv4.ping_group_range')


### PR DESCRIPTION
## Related Issue(s)
https://github.com/kyverno/policies/issues/773

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
This PR adds Kyverno policies written in CEL expressions for pod security standards (baseline).

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
