### PR TITLE
chore: use v2beta1 in policy exceptions

### DIFF
--- a/other/e-l/expiration-for-policyexceptions/artifacthub-pkg.yml
+++ b/other/e-l/expiration-for-policyexceptions/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "PolicyException"
-digest: d460ec5a86554ec9e47781e23188598fb71b4e574910493757860f2757c801a1
+digest: 47af946fa7dde4c75c13b3edb3f3ff0bf1c2e481f4e6b34dd443f38500c9a438

--- a/other/e-l/expiration-for-policyexceptions/expiration-for-policyexceptions.yaml
+++ b/other/e-l/expiration-for-policyexceptions/expiration-for-policyexceptions.yaml
@@ -27,7 +27,7 @@ spec:
           kinds:
           - PolicyException
     generate:
-      apiVersion: kyverno.io/v2alpha1
+      apiVersion: kyverno.io/v2beta1
       kind: ClusterCleanupPolicy
       name: polex-{{ request.namespace }}-{{ request.object.metadata.name }}-{{ random('[0-9a-z]{8}') }}
       synchronize: false

--- a/other/m-q/policy-for-exceptions/policy-bad.yaml
+++ b/other/m-q/policy-for-exceptions/policy-bad.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: badpe01
@@ -12,7 +12,7 @@ spec:
     - rule02
   match: {}
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: badpe02
@@ -33,7 +33,7 @@ spec:
         namespace: some-ns
         name: kube-admin
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: badpe03
@@ -54,7 +54,7 @@ spec:
         namespace: some-ns
         name: kube-admin
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: badpe04
@@ -77,7 +77,7 @@ spec:
         namespace: some-ns
         name: kube-admin
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: badpe05
@@ -96,7 +96,7 @@ spec:
         namespaces:
         - policy-exceptions-ns
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: badpe06

--- a/other/m-q/policy-for-exceptions/policy-good.yaml
+++ b/other/m-q/policy-for-exceptions/policy-good.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: goodpe01
@@ -9,7 +9,7 @@ spec:
     - rule01
   match: {}
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: goodpe02
@@ -33,7 +33,7 @@ spec:
         namespace: some-ns
         name: kube-admin
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: goodpe03
@@ -58,7 +58,7 @@ spec:
         namespace: some-ns
         name: kube-admin
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: goodpe04


### PR DESCRIPTION
## Related Issue(s)
None
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
As a result of [removing the support of v2alpha1 in policy exceptions](https://github.com/kyverno/kyverno/pull/8606), v2beta1 must be used instead.
<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
