### PR TITLE
fix: Use Deployment selector for create-default-pdb

### DIFF
--- a/other/b-d/create-default-pdb/artifacthub-pkg.yml
+++ b/other/b-d/create-default-pdb/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: create-default-pdb
-version: 1.0.0
+version: 1.0.1
 displayName: Add Pod Disruption Budget
 createdAt: "2023-04-10T20:30:03.000Z"
 description: >-
@@ -13,9 +13,9 @@ keywords:
   - Sample
 readme: |
   A PodDisruptionBudget limits the number of Pods of a replicated application that are down simultaneously from voluntary disruptions. For example, a quorum-based application would like to ensure that the number of replicas running is never brought below the number needed for a quorum. As an application owner, you can create a PodDisruptionBudget (PDB) for each application. This policy will create a PDB resource whenever a new Deployment is created.
-  
+
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Deployment"
-digest: 70923b5a8374896a7092cdda3effd04d66316bec4e41afc8c46a214806d1158d
+digest: 907d2448433a9e51ebe3836557ab0328ebb928ddd1495e04a86097495d733de2

--- a/other/b-d/create-default-pdb/create-default-pdb.yaml
+++ b/other/b-d/create-default-pdb/create-default-pdb.yaml
@@ -30,6 +30,4 @@ spec:
       data:
         spec:
           minAvailable: 1
-          selector:
-            matchLabels:
-              "{{request.object.metadata.labels}}"
+          selector: "{{request.object.spec.selector}}"

--- a/other/b-d/create-default-pdb/pdb-generated.yaml
+++ b/other/b-d/create-default-pdb/pdb-generated.yaml
@@ -8,4 +8,3 @@ spec:
   selector:
     matchLabels:
       app: busybox
-      foo: bar


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

Fixes #785 

## Description

<!--
What does this PR do?
-->

Copies the Deployment selector into the PDB, instead of assuming the Pod and Deployment labels will be the same

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
