### PR TITLE
Fix: Correct karpenter do-not-evict description

### DIFF
--- a/karpenter/add-karpenter-donot-evict/add-karpenter-donot-evict.yaml
+++ b/karpenter/add-karpenter-donot-evict/add-karpenter-donot-evict.yaml
@@ -14,7 +14,7 @@ metadata:
       If a Pod exists with the annotation `karpenter.sh/do-not-evict: true` on a Node,
       and a request is made to delete the Node, Karpenter will not drain any Pods from
       that Node or otherwise try to delete the Node. This is useful for Pods that should
-      run interrupted to completion. This policy mutates Jobs and CronJobs
+      run uninterrupted to completion. This policy mutates Jobs and CronJobs
       so that Pods spawned by them will contain the `karpenter.sh/do-not-evict: true` annotation.
 spec:
   rules:

--- a/karpenter/add-karpenter-donot-evict/artifacthub-pkg.yml
+++ b/karpenter/add-karpenter-donot-evict/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ annotations:
   kyverno/category: "Karpenter, EKS Best Practices"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: 14e1fecc09c5d577e29540a58166cff7b0f81f63b5b48b0d6c7dd0afa137c851
+digest: cce9736174afeaba6059a9dc3b577f61a812637e199f0d0f5460caff78472402

--- a/karpenter/add-karpenter-donot-evict/artifacthub-pkg.yml
+++ b/karpenter/add-karpenter-donot-evict/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 1.0.0
 displayName: Add Karpenter Do Not Evict
 createdAt: "2023-04-10T20:11:12.000Z"
 description: >-
-  If a Pod exists with the annotation `karpenter.sh/do-not-evict: true` on a Node, and a request is made to delete the Node, Karpenter will not drain any Pods from that Node or otherwise try to delete the Node. This is useful for Pods that should run interrupted to completion. This policy mutates Jobs and CronJobs so that Pods spawned by them will contain the `karpenter.sh/do-not-evict: true` annotation.
+  If a Pod exists with the annotation `karpenter.sh/do-not-evict: true` on a Node, and a request is made to delete the Node, Karpenter will not drain any Pods from that Node or otherwise try to delete the Node. This is useful for Pods that should run uninterrupted to completion. This policy mutates Jobs and CronJobs so that Pods spawned by them will contain the `karpenter.sh/do-not-evict: true` annotation.
 install: |-
   ```shell
   kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/karpenter/add-karpenter-donot-evict/add-karpenter-donot-evict.yaml
@@ -13,7 +13,7 @@ keywords:
   - Karpenter
   - EKS Best Practices
 readme: |
-  If a Pod exists with the annotation `karpenter.sh/do-not-evict: true` on a Node, and a request is made to delete the Node, Karpenter will not drain any Pods from that Node or otherwise try to delete the Node. This is useful for Pods that should run interrupted to completion. This policy mutates Jobs and CronJobs so that Pods spawned by them will contain the `karpenter.sh/do-not-evict: true` annotation.
+  If a Pod exists with the annotation `karpenter.sh/do-not-evict: true` on a Node, and a request is made to delete the Node, Karpenter will not drain any Pods from that Node or otherwise try to delete the Node. This is useful for Pods that should run uninterrupted to completion. This policy mutates Jobs and CronJobs so that Pods spawned by them will contain the `karpenter.sh/do-not-evict: true` annotation.
   
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:


### PR DESCRIPTION
## Related Issue(s)

Fixes #748 
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

This updates the description for the Karpenter `do-not-evict` policy to clarify that runs that should run uninterrupted to completion will be modified.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
