### PR TITLE
Replace busybox:v1.35 with busybox:1.35

### DIFF
--- a/best-practices/disallow-default-namespace/deploy-default.yaml
+++ b/best-practices/disallow-default-namespace/deploy-default.yaml
@@ -16,7 +16,7 @@ spec:
         app: busybox
     spec:
       containers:
-      - image: busybox:v1.35
+      - image: busybox:1.35
         name: busybox
         command:
         - "sleep"

--- a/best-practices/disallow-default-namespace/ds-default.yaml
+++ b/best-practices/disallow-default-namespace/ds-default.yaml
@@ -13,7 +13,7 @@ spec:
         name: good-daemonset
     spec:
       containers:
-      - image: busybox:v1.35
+      - image: busybox:1.35
         name: busybox
         command:
         - "sleep"

--- a/best-practices/disallow-default-namespace/good-resources.yaml
+++ b/best-practices/disallow-default-namespace/good-resources.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: "busybox:v1.35"
+    image: "busybox:1.35"
     command:
     - "sleep"
     - "3000"
@@ -29,7 +29,7 @@ spec:
         app: busybox
     spec:
       containers:
-      - image: busybox:v1.35
+      - image: busybox:1.35
         name: busybox
         command:
         - "sleep"
@@ -50,7 +50,7 @@ spec:
         name: good-daemonset
     spec:
       containers:
-      - image: busybox:v1.35
+      - image: busybox:1.35
         name: busybox
         command:
         - "sleep"
@@ -65,7 +65,7 @@ spec:
   template:
     spec:
       containers:
-      - image: busybox:v1.35
+      - image: busybox:1.35
         name: busybox
         command:
         - "sleep"
@@ -90,7 +90,7 @@ spec:
         app: busybox
     spec:
       containers:
-      - image: busybox:v1.35
+      - image: busybox:1.35
         name: busybox
         command:
         - "sleep"

--- a/best-practices/disallow-default-namespace/job-default.yaml
+++ b/best-practices/disallow-default-namespace/job-default.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     spec:
       containers:
-      - image: busybox:v1.35
+      - image: busybox:1.35
         name: busybox
         command:
         - "sleep"

--- a/best-practices/disallow-default-namespace/pod-default.yaml
+++ b/best-practices/disallow-default-namespace/pod-default.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: "busybox:v1.35"
+    image: "busybox:1.35"
     command:
     - "sleep"
     - "3000"

--- a/best-practices/disallow-default-namespace/ss-default.yaml
+++ b/best-practices/disallow-default-namespace/ss-default.yaml
@@ -16,7 +16,7 @@ spec:
         app: busybox
     spec:
       containers:
-      - image: busybox:v1.35
+      - image: busybox:1.35
         name: busybox
         command:
         - "sleep"

--- a/best-practices/disallow-helm-tiller/good-deploy.yaml
+++ b/best-practices/disallow-helm-tiller/good-deploy.yaml
@@ -15,6 +15,6 @@ spec:
         app: busybox
     spec:
       containers:
-      - image: busybox:v1.35
+      - image: busybox:1.35
         name: busybox
         command: ["sleep", "3600"]

--- a/best-practices/disallow-helm-tiller/good-pod.yaml
+++ b/best-practices/disallow-helm-tiller/good-pod.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: busybox:v1.35
+    image: busybox:1.35
   - name: nothelmbox
-    image: busybox:v1.35
+    image: busybox:1.35

--- a/best-practices/disallow-latest-tag/good-pod.yaml
+++ b/best-practices/disallow-latest-tag/good-pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: busybox:v1.35
+    image: busybox:1.35

--- a/best-practices/require-pod-requests-limits/bad-pod-nothing.yaml
+++ b/best-practices/require-pod-requests-limits/bad-pod-nothing.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: busybox:v1.35
+    image: busybox:1.35


### PR DESCRIPTION
## Related Issue(s)

N/A

## Description

Replace busybox:v1.35 with busybox:1.35
See https://hub.docker.com/_/busybox/tags?page=1

## Checklist


- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).

N/A
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.

N/A
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
