### PR TITLE
fix(pdb-minavailable-check): ensure correct handling of 0 replicas workloads

### DIFF
--- a/other/m-q/pdb-minavailable/artifacthub-pkg.yml
+++ b/other/m-q/pdb-minavailable/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "PodDisruptionBudget, Deployment, StatefulSet"
-digest: bcb87ac5337aad2386c47726f85247202cdbaca62e62a6e96085adaddb7159e7
+digest: f6f12d2b34642666ce110807b85756d86012a840a15f236c53e2a4866347b628

--- a/other/m-q/pdb-minavailable/pdb-minavailable.yaml
+++ b/other/m-q/pdb-minavailable/pdb-minavailable.yaml
@@ -32,6 +32,9 @@ spec:
           value:
           - CREATE
           - UPDATE
+        - key: "{{ request.object.spec.replicas || `1` }}"
+          operator: GreaterThan
+          value: 0
       context:
         - name: minavailable
           apiCall:

--- a/other/m-q/pdb-minavailable/ss-good.yaml
+++ b/other/m-q/pdb-minavailable/ss-good.yaml
@@ -6,12 +6,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: busybox
+      app: bb1
   replicas: 2
   template:
     metadata:
       labels:
-        app: busybox
+        app: bb1
     spec:
       terminationGracePeriodSeconds: 10
       containers:
@@ -25,12 +25,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: busybox
+      app: bb2
   replicas: 1
   template:
     metadata:
       labels:
-        app: busybox
+        app: bb2
     spec:
       terminationGracePeriodSeconds: 10
       containers:
@@ -45,12 +45,32 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: bb
+      app: bb3
   replicas: 1
   template:
     metadata:
       labels:
-        app: bb
+        app: bb3
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: busbyox
+        image: busybox:1.35
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: goodss04
+  namespace: pdb-minavailable-ns
+spec:
+  selector:
+    matchLabels:
+      app: bb4
+  replicas: 0
+  template:
+    metadata:
+      labels:
+        app: bb4
     spec:
       terminationGracePeriodSeconds: 10
       containers:


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

Slack-thread: https://kubernetes.slack.com/archives/CLGR9BJU9/p1698916081905549

## Description

<!--
What does this PR do?
-->

This PR adds another precondition to `pdb-minavailable-check` policy - to ensure that 0 replicas workloads are not denied by the policy. We added this policy to our clusters and experienced a lot of false-positives on workloads with `replicas: 0`, and no PDBs in namespace. I think this happens because the context variable defaults to 0.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
