### PR TITLE
fix the name field in artifacthub-pkg.yml for PSS CEL policies

### DIFF
--- a/pod-security-cel/baseline/disallow-capabilities/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-capabilities/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-name: disallow-capabilities
+name: disallow-capabilities-cel
 version: 1.0.0
 displayName: Disallow Capabilities in CEL expressions
 description: >-

--- a/pod-security-cel/baseline/disallow-host-namespaces/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-host-namespaces/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-name: disallow-host-namespaces
+name: disallow-host-namespaces-cel
 version: 1.0.0
 displayName: Disallow Host Namespaces in CEL expressions
 description: >-

--- a/pod-security-cel/baseline/disallow-host-path/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-host-path/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-name: disallow-host-path
+name: disallow-host-path-cel
 version: 1.0.0
 displayName: Disallow hostPath in CEL expressions
 description: >-

--- a/pod-security-cel/baseline/disallow-host-ports-range/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-host-ports-range/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-name: disallow-host-ports-range
+name: disallow-host-ports-range-cel
 version: 1.0.0
 displayName: Disallow hostPorts Range (Alternate) in CEL expressions
 description: >-

--- a/pod-security-cel/baseline/disallow-host-ports/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-host-ports/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-name: disallow-host-ports
+name: disallow-host-ports-cel
 version: 1.0.0
 displayName: Disallow hostPorts in CEL expressions
 description: >-

--- a/pod-security-cel/baseline/disallow-host-process/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-host-process/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-name: disallow-host-process
+name: disallow-host-process-cel
 version: 1.0.0
 displayName: Disallow hostProcess in CEL expressions
 description: >-

--- a/pod-security-cel/baseline/disallow-privileged-containers/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-name: disallow-privileged-containers
+name: disallow-privileged-containers-cel
 version: 1.0.0
 displayName: Disallow Privileged Containers in CEL expressions
 description: >-

--- a/pod-security-cel/baseline/disallow-proc-mount/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-proc-mount/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-name: disallow-proc-mount
+name: disallow-proc-mount-cel
 version: 1.0.0
 displayName: Disallow procMount in CEL expressions
 description: >-

--- a/pod-security-cel/baseline/disallow-selinux/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-selinux/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-name: disallow-selinux
+name: disallow-selinux-cel
 version: 1.0.0
 displayName: Disallow SELinux in CEL expressions
 description: >-

--- a/pod-security-cel/baseline/restrict-seccomp/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/restrict-seccomp/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-name: restrict-seccomp
+name: restrict-seccomp-cel
 version: 1.0.0
 displayName: Restrict Seccomp in CEL expressions
 description: >-

--- a/pod-security-cel/baseline/restrict-sysctls/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/restrict-sysctls/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-name: restrict-sysctls
+name: restrict-sysctls-cel
 version: 1.0.0
 displayName: Restrict sysctls in CEL expressions
 description: >-


### PR DESCRIPTION
## Related Issue(s)
None
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
CEL PSS policies aren't showing in Artifact Hub because of the duplicate names in the artifacthub-pkg.yml files. This PR adds `-cel` to the name.
<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
