### PR TITLE
Restrict Auto-Mount of Service Account Tokens in Service Account Object

### DIFF
--- a/other/restrict-sa-automount-sa-token/.chainsaw-test/bad-sa.yaml
+++ b/other/restrict-sa-automount-sa-token/.chainsaw-test/bad-sa.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bad-sa-01
+automountServiceAccountToken: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: 2021-07-07T22:02:39Z
+  name: bad-sa-02
+  namespace: default
+  uid: 052fb0f4-3d50-11e5-b066-42010af0d7b6
+automountServiceAccountToken: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"ServiceAccount","metadata":{"annotations":{},"name":"example-automated-thing","namespace":"examplens"}}      
+  creationTimestamp: "2019-07-21T07:07:07Z"
+  name: bad-sa-03
+  namespace: default
+  resourceVersion: "777"
+  selfLink: /api/v1/namespaces/examplens/serviceaccounts/example-automated-thing
+  uid: f23fd170-66f2-4697-b049-e1e266b7f835
+automountServiceAccountToken: true

--- a/other/restrict-sa-automount-sa-token/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other/restrict-sa-automount-sa-token/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-sa-automount-sa-token
+status:
+  ready: true

--- a/other/restrict-sa-automount-sa-token/.chainsaw-test/chainsaw-test.yaml
+++ b/other/restrict-sa-automount-sa-token/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,30 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: restrict-sa-automount-sa-token
+spec:
+  steps:
+  - name: step-01
+    try:
+    - script:
+        content: |
+          sed 's/validationFailureAction: Audit/validationFailureAction: Enforce/' ../restrict-sa-automount-sa-token.yaml | kubectl create -f -
+    - assert:
+        file: chainsaw-step-01-assert-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: good-sa.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: bad-sa.yaml
+  - name: step-99
+    try:
+    - delete:
+        ref:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          name: restrict-sa-automount-sa-token

--- a/other/restrict-sa-automount-sa-token/.chainsaw-test/good-sa.yaml
+++ b/other/restrict-sa-automount-sa-token/.chainsaw-test/good-sa.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: good-sa
+  namespace: default 
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: 2021-07-07T22:02:39Z
+  name: good-sa-02
+  namespace: default
+  uid: 052fb0f4-3d50-11e5-b066-42010af0d7b6
+automountServiceAccountToken: false

--- a/other/restrict-sa-automount-sa-token/.kyverno-test/kyverno-test.yaml
+++ b/other/restrict-sa-automount-sa-token/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-sa-automount-sa-token
+policies:
+- ../restrict-sa-automount-sa-token.yaml
+resources:
+- resource.yaml
+results:
+- kind: ServiceAccount
+  policy: restrict-sa-automount-sa-token
+  resources:
+  - bad-svc
+  result: fail
+  rule: validate-sa-automountServiceAccountToken
+- kind: ServiceAccount
+  policy: restrict-sa-automount-sa-token
+  resources:
+  - good-svc
+  result: pass
+  rule: validate-sa-automountServiceAccountToken

--- a/other/restrict-sa-automount-sa-token/.kyverno-test/resource.yaml
+++ b/other/restrict-sa-automount-sa-token/.kyverno-test/resource.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: good-svc
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bad-svc
+automountServiceAccountToken: true

--- a/other/restrict-sa-automount-sa-token/artifacthub-pkg.yaml
+++ b/other/restrict-sa-automount-sa-token/artifacthub-pkg.yaml
@@ -1,0 +1,30 @@
+name: restrict-sa-automount-sa-token
+version: 1.0.0
+displayName: Restrict Auto-Mount of Service Account Tokens in Service Account Object
+createdAt: "2024-01-07T16:15:06.000Z"
+description: >-
+      Kubernetes automatically mounts ServiceAccount credentials in each ServiceAccount.
+      The ServiceAccount may be assigned roles allowing Pods to access API resources.
+      Blocking this ability is an extension of the least privilege best practice and should
+      be followed if Pods do not need to speak to the API server to function.
+      This policy ensures that mounting of these ServiceAccount tokens is blocked.  
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/restrict-sa-automount-sa-token/restrict-sa-automount-token.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+readme: |
+      Kubernetes automatically mounts ServiceAccount credentials in each ServiceAccount.
+      The ServiceAccount may be assigned roles allowing Pods to access API resources.
+      Blocking this ability is an extension of the least privilege best practice and should
+      be followed if Pods do not need to speak to the API server to function.
+      This policy ensures that mounting of these ServiceAccount tokens is blocked.  
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.23"
+  kyverno/subject: "ServiceAccount"
+digest: e15fa239153a91d674b5c3ad67a679a6ae0003604750f7ad6eb8ecb7aca49700 

--- a/other/restrict-sa-automount-sa-token/artifacthub-pkg.yaml
+++ b/other/restrict-sa-automount-sa-token/artifacthub-pkg.yaml
@@ -27,4 +27,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "ServiceAccount"
-digest: be39d571b6f0d4a06d7bb31b96529729ac2b8d6fd4ceb42b7432b1dab1963e9b 
+digest: 4d1c1a64dd33096bb5b40a5175b5dcf5f3f0313bb707d85ea0732a213b0d13bb

--- a/other/restrict-sa-automount-sa-token/artifacthub-pkg.yaml
+++ b/other/restrict-sa-automount-sa-token/artifacthub-pkg.yaml
@@ -24,7 +24,7 @@ readme: |
   
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
-  kyverno/category: "Other"
+  kyverno/category: "Security"
   kyverno/kubernetesVersion: "1.27"
   kyverno/subject: "ServiceAccount"
-digest: 4d1c1a64dd33096bb5b40a5175b5dcf5f3f0313bb707d85ea0732a213b0d13bb
+digest: f3ab22501473501edf51568b00c3bbb7c20ba2a1a54671bb4b2d8e705d9b080a 

--- a/other/restrict-sa-automount-sa-token/artifacthub-pkg.yaml
+++ b/other/restrict-sa-automount-sa-token/artifacthub-pkg.yaml
@@ -27,4 +27,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "ServiceAccount"
-digest: e15fa239153a91d674b5c3ad67a679a6ae0003604750f7ad6eb8ecb7aca49700 
+digest: be39d571b6f0d4a06d7bb31b96529729ac2b8d6fd4ceb42b7432b1dab1963e9b 

--- a/other/restrict-sa-automount-sa-token/artifacthub-pkg.yaml
+++ b/other/restrict-sa-automount-sa-token/artifacthub-pkg.yaml
@@ -1,7 +1,7 @@
 name: restrict-sa-automount-sa-token
 version: 1.0.0
-displayName: Restrict Auto-Mount of Service Account Tokens in Service Account Object
-createdAt: "2024-01-07T16:15:06.000Z"
+displayName: Restrict Auto-Mount of Service Account Tokens in Service Account 
+createdAt: "2024-01-13T16:15:06.000Z"
 description: >-
       Kubernetes automatically mounts ServiceAccount credentials in each ServiceAccount.
       The ServiceAccount may be assigned roles allowing Pods to access API resources.
@@ -10,7 +10,7 @@ description: >-
       This policy ensures that mounting of these ServiceAccount tokens is blocked.  
 install: |-
   ```shell
-  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/restrict-sa-automount-sa-token/restrict-sa-automount-token.yaml
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
   ```
 keywords:
   - kyverno
@@ -25,6 +25,6 @@ readme: |
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Other"
-  kyverno/kubernetesVersion: "1.23"
+  kyverno/kubernetesVersion: "1.27"
   kyverno/subject: "ServiceAccount"
 digest: 4d1c1a64dd33096bb5b40a5175b5dcf5f3f0313bb707d85ea0732a213b0d13bb

--- a/other/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
+++ b/other/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
@@ -3,11 +3,12 @@ kind: ClusterPolicy
 metadata:
   name: restrict-sa-automount-sa-token
   annotations:
-    policies.kyverno.io/title: Restrict Auto-Mount of Service Account Tokens in Service Account Object
+    policies.kyverno.io/title: Restrict Auto-Mount of Service Account Tokens in Service Account 
     policies.kyverno.io/category: Security
     kyverno.io/kyverno-version: 1.11.1
     kyverno.io/kubernetes-version: "1.27"
     policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Secret,ServiceAccount
     policies.kyverno.io/description: >-
       Kubernetes automatically mounts ServiceAccount credentials in each ServiceAccount.
       The ServiceAccount may be assigned roles allowing Pods to access API resources.
@@ -25,6 +26,6 @@ spec:
           kinds:
           - ServiceAccount
     validate:
-      message: "Auto-mounting of Service Account tokens is not allowed."
+      message: "ServiceAccounts must set automountServiceAccountToken to false."
       pattern:
-        automountServiceAccountToken: "false"
+        automountServiceAccountToken: false

--- a/other/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
+++ b/other/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-sa-automount-sa-token
+  annotations:
+    policies.kyverno.io/title: Restrict Auto-Mount of Service Account Tokens in Service Account Object
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Kubernetes automatically mounts ServiceAccount credentials in each ServiceAccount.
+      The ServiceAccount may be assigned roles allowing Pods to access API resources.
+      Blocking this ability is an extension of the least privilege best practice and should
+      be followed if Pods do not need to speak to the API server to function.
+      This policy ensures that mounting of these ServiceAccount tokens is blocked.      
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+  - name: validate-sa-automountServiceAccountToken
+    match:
+      any:
+      - resources:
+          kinds:
+          - ServiceAccount
+    validate:
+      message: "Auto-mounting of Service Account tokens is not allowed."
+      pattern:
+        automountServiceAccountToken: "false"

--- a/other/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
+++ b/other/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
@@ -4,7 +4,9 @@ metadata:
   name: restrict-sa-automount-sa-token
   annotations:
     policies.kyverno.io/title: Restrict Auto-Mount of Service Account Tokens in Service Account Object
-    policies.kyverno.io/category: Sample
+    policies.kyverno.io/category: Security
+    kyverno.io/kyverno-version: 1.11.1
+    kyverno.io/kubernetes-version: "1.27"
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       Kubernetes automatically mounts ServiceAccount credentials in each ServiceAccount.


### PR DESCRIPTION
## Related Issue(s)
partially addresses #819 
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
added a policy to Restrict Auto-Mount of Service Account Tokens in Service Account Object
<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
