### PR TITLE
Add disallow-proc-self-fd-workingdir.yaml (CVE-2024-21626)

### DIFF
--- a/other/disallow-proc-self-fd-workingdir/artifacthub-pkg.yml
+++ b/other/disallow-proc-self-fd-workingdir/artifacthub-pkg.yml
@@ -3,8 +3,10 @@ version: 1.0.0
 displayName: Disallow workingDir with self file descriptors
 createdAt: "2024-02-02T00:00:00.000Z" 
 description: >-
-      In order to mitigate CVE-2024-21626, this policy prevent the creation of Pods
-      with workingDir set in /proc/self/fd/*
+      This policy prevents the configuration of a container workingDir with file descriptors
+      that start with /proc/self/fd. This is a partial mitigation for CVE-2024-21626 aka
+      Leaky Vessels Container Breakout. For additional details and mitigation please refer to
+      https://snyk.io/blog/leaky-vessels-docker-runc-container-breakout-vulnerabilities/.
 install: |-
     ```shell
     kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/disallow-proc-self-fd-workingdir/disallow-proc-self-fd-workingdir.yaml
@@ -13,8 +15,10 @@ keywords:
   - runc
   - CVE-2024-21626
 readme: | 
-  In order to mitigate CVE-2024-21626, this policy prevent the creation of Pods
-  with workingDir set in /proc/self/fd/*
+  This policy prevents the configuration of a container workingDir with file descriptors
+  that start with /proc/self/fd. This is a partial mitigation for CVE-2024-21626 aka
+  Leaky Vessels Container Breakout. For additional details and mitigation please refer to
+  https://snyk.io/blog/leaky-vessels-docker-runc-container-breakout-vulnerabilities/.
 
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations: 

--- a/other/disallow-proc-self-fd-workingdir/artifacthub-pkg.yml
+++ b/other/disallow-proc-self-fd-workingdir/artifacthub-pkg.yml
@@ -1,0 +1,23 @@
+name: disallow-proc-self-fd-workingdir
+version: 1.0.0 
+displayName: Disallow workingDir with self file descriptors
+createdAt: "2024-02-02T00:00:00.000Z" 
+description: >-
+      In order to mitigate CVE-2024-21626, this policy prevent the creation of Pods
+      with workingDir set in /proc/self/fd/*
+install: |-
+    ```shell
+    kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/disallow-proc-self-fd-workingdir/disallow-proc-self-fd-workingdir.yaml
+    ```   
+keywords:
+  - runc
+  - CVE-2024-21626
+readme: | 
+  In order to mitigate CVE-2024-21626, this policy prevent the creation of Pods
+  with workingDir set in /proc/self/fd/*
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations: 
+  kyverno/category: "Runc"
+  kyverno/kubernetesVersion: "1.28"
+  kyverno/subject: "Pod"

--- a/other/disallow-proc-self-fd-workingdir/disallow-proc-self-fd-workingdir.yaml
+++ b/other/disallow-proc-self-fd-workingdir/disallow-proc-self-fd-workingdir.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-proc-self-fd-workingdir
+  annotations:
+    policies.kyverno.io/title: Disallow workingDir with self file descriptors
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: Critical
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.11.4
+    kyverno.io/kubernetes-version: "1.28"
+    policies.kyverno.io/description: >-
+      This policy prevents the configuration of a container workingDir with file descriptors
+      that start with /proc/self/fd. This is a partial mitigation for CVE-2024-21626 aka
+      Leaky Vessels Container Breakout. For additional details and mitigation please refer to
+      https://snyk.io/blog/leaky-vessels-docker-runc-container-breakout-vulnerabilities/.
+spec:
+  validationFailureAction: enforce
+  background: true
+  rules:
+    - name: check-workingDir
+      match:
+        resources:
+          kinds:
+            - Pod
+      validate:
+        message: "Using /proc/self/fd in workingDir is not allowed."
+        pattern:
+          spec:
+            containers:
+              - =(workingDir): "!/proc/self/fd*"
+            initContainers:
+              - =(workingDir): "!/proc/self/fd*"
+            ephemeralContainers:
+              - =(workingDir): "!/proc/self/fd*"             

--- a/other/disallow-proc-self-fd-workingdir/disallow-proc-self-fd-workingdir.yaml
+++ b/other/disallow-proc-self-fd-workingdir/disallow-proc-self-fd-workingdir.yaml
@@ -15,21 +15,25 @@ metadata:
       Leaky Vessels Container Breakout. For additional details and mitigation please refer to
       https://snyk.io/blog/leaky-vessels-docker-runc-container-breakout-vulnerabilities/.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Audit
   background: true
   rules:
     - name: check-workingDir
       match:
-        resources:
-          kinds:
+        any:
+        - resources:
+            kinds: 
             - Pod
       validate:
         message: "Using /proc/self/fd in workingDir is not allowed."
         pattern:
           spec:
+            definitions:
+              customCheck: &customCheckAnchor
+                =(workingDir): "!/proc/self/fd*"
             containers:
-              - =(workingDir): "!/proc/self/fd*"
+              - <<: *customCheckAnchor
             initContainers:
-              - =(workingDir): "!/proc/self/fd*"
+              - <<: *customCheckAnchor
             ephemeralContainers:
-              - =(workingDir): "!/proc/self/fd*"             
+              - <<: *customCheckAnchor


### PR DESCRIPTION
Mitigation for CVE-2024-21626

## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
