### PR TITLE
fix: initContainer ordering with server-side apply of image mutation

### DIFF
--- a/other/prepend-image-registry/artifacthub-pkg.yml
+++ b/other/prepend-image-registry/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.21"
   kyverno/subject: "Pod"
-digest: 6325c3d888d0dcba78dcbe2c29f3fe6730addb8c4dda2e3c97b48ff8d3873943
+digest: 1d6897daf13c770973fb025516df1634232eb2e6cd4a38ece24a6af9b146294b

--- a/other/prepend-image-registry/prepend-image-registry.yaml
+++ b/other/prepend-image-registry/prepend-image-registry.yaml
@@ -59,8 +59,7 @@ spec:
     mutate:
       foreach:
       - list: "request.object.spec.initContainers"
-        patchStrategicMerge:
-          spec:
-            initContainers:
-            - name: "{{ element.name }}"           
-              image: registry.io/{{ images.initContainers."{{element.name}}".path}}:{{images.initContainers."{{element.name}}".tag}}
+        patchesJson6902: |-
+          - op: replace
+            path: /spec/initContainers/{{ elementIndex }}/image
+            value: registry.io/{{ images.initContainers."{{element.name}}".path}}:{{images.initContainers."{{element.name}}".tag}}

--- a/other/replace-image-registry/artifacthub-pkg.yml
+++ b/other/replace-image-registry/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Sample"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: 9fde3b8caba3a05c5534b588fcd794975b8c1016004fa4ffdfb5bc4e93997e58
+digest: f6a5950922a961dd04744c808265bd4956c062f36b6941f69dba03c0b75b2d96

--- a/other/replace-image-registry/replace-image-registry.yaml
+++ b/other/replace-image-registry/replace-image-registry.yaml
@@ -52,8 +52,7 @@ spec:
       mutate:
         foreach:
         - list: "request.object.spec.initContainers"
-          patchStrategicMerge:
-            spec:
-              initContainers:
-              - name: "{{ element.name }}"
-                image: "{{ regex_replace_all('^(localhost/|(?:[a-z0-9]+\\.)+[a-z0-9]+/)?(.*)$', '{{element.image}}', 'myregistry.corp.com/$2' )}}"
+          patchesJson6902: |-
+            - op: replace
+              path: /spec/initContainers/{{ elementIndex }}/image
+              value: "{{ regex_replace_all('^(localhost/|(?:[a-z0-9]+\\.)+[a-z0-9]+/)?(.*)$', '{{element.image}}', 'myregistry.corp.com/$2' )}}"


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

This is the closest issue I could find:

https://github.com/kyverno/kyverno/issues/3294#issuecomment-1080628983

## Description

<!--
What does this PR do?
-->

This PR changes the patch method (of the policies I could find) to preserve the ordinality of `initContainers` when mutating their image location.

I'm submitting this PR in the hopes of saving others some pain around mutating the image location of init containers. Specifically, using the `patchStrategicMerge` method can scramble the order of init containers. Using `patchesJson6902` with indexing allows pods with multiple init containers to run in the expected order.

The extant tests seem to pass without any changes needed.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
