### PR TITLE
Add require-run-as-nonroot policy that use CEL expressions

### DIFF
--- a/pod-security-cel/restricted/require-run-as-nonroot/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-cel/restricted/require-run-as-nonroot/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: require-run-as-nonroot
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../require-run-as-nonroot.yaml
+    - patch:
+        resource:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          metadata:
+            name: require-run-as-nonroot
+          spec:
+            validationFailureAction: Enforce
+    - assert:
+        file: ../../../../pod-security/restricted/require-run-as-nonroot/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: ../../../../pod-security/restricted/require-run-as-nonroot/.chainsaw-test/pod-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: ../../../../pod-security/restricted/require-run-as-nonroot/.chainsaw-test/pod-bad.yaml
+    - apply:
+        file: ../../../../pod-security/restricted/require-run-as-nonroot/.chainsaw-test/podcontroller-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: ../../../../pod-security/restricted/require-run-as-nonroot/.chainsaw-test/podcontroller-bad.yaml

--- a/pod-security-cel/restricted/require-run-as-nonroot/.kyverno-test/kyverno-test.yaml
+++ b/pod-security-cel/restricted/require-run-as-nonroot/.kyverno-test/kyverno-test.yaml
@@ -5,7 +5,7 @@ metadata:
 policies:
 - ../require-run-as-nonroot.yaml
 resources:
-- resource.yaml
+- ../../../../pod-security/restricted/require-run-as-nonroot/.kyverno-test/resource.yaml
 results:
 - kind: CronJob
   policy: require-run-as-nonroot

--- a/pod-security-cel/restricted/require-run-as-nonroot/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/require-run-as-nonroot/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: e943fb0bc9fcccbd9748a8c72155aef3b3d82fcfb760ff09adacdf34240ed84f
+digest: c6b22ebdc93aa05cc97600cdad61b80bf84f8af4354fb68ba0515a67ada5e054
 createdAt: "2023-12-04T09:04:49Z"

--- a/pod-security-cel/restricted/require-run-as-nonroot/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/require-run-as-nonroot/artifacthub-pkg.yml
@@ -1,0 +1,23 @@
+name: require-run-as-nonroot-cel
+version: 1.0.0
+displayName: Require runAsNonRoot in CEL expressions
+description: >-
+  Containers must be required to run as non-root users. This policy ensures `runAsNonRoot` is set to `true`.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/pod-security-cel/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+  ```
+keywords:
+  - kyverno
+  - Pod Security Standards (Restricted)
+  - CEL Expressions
+readme: |
+  Containers must be required to run as non-root users. This policy ensures `runAsNonRoot` is set to `true`.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Pod Security Standards (Restricted)"
+  kyverno/kubernetesVersion: "1.26-1.27"
+  kyverno/subject: "Pod"
+digest: e943fb0bc9fcccbd9748a8c72155aef3b3d82fcfb760ff09adacdf34240ed84f
+createdAt: "2023-12-04T09:04:49Z"

--- a/pod-security-cel/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/pod-security-cel/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -17,7 +17,7 @@ spec:
   validationFailureAction: Audit
   background: true
   rules:
-    - name: run-as-non-root
+    - name: run-as-nonroot
       match:
         any:
         - resources:

--- a/pod-security-cel/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/pod-security-cel/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -1,0 +1,58 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-run-as-nonroot
+  annotations:
+    policies.kyverno.io/title: Require runAsNonRoot in CEL
+    policies.kyverno.io/category: Pod Security Standards (Restricted) in CEL
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.11.0
+    kyverno.io/kyverno-version: 1.11.0
+    kyverno.io/kubernetes-version: "1.26-1.27"
+    policies.kyverno.io/description: >-
+      Containers must be required to run as non-root. This policy ensures
+      `runAsNonRoot` is set to true.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: run-as-non-root
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        cel:
+          expressions:
+            - expression: >-
+                (
+                    (
+                      has(object.spec.securityContext) &&
+                      has(object.spec.securityContext.runAsNonRoot) &&
+                      object.spec.securityContext.runAsNonRoot == true
+                    ) && (
+                      (
+                          object.spec.containers +
+                          (has(object.spec.initContainers) ? object.spec.initContainers : []) +
+                          (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+                      ).all(container,
+                          !has(container.securityContext) ||
+                          !has(container.securityContext.runAsNonRoot) ||
+                          container.securityContext.runAsNonRoot == true)
+                    )
+                ) || (
+                    (
+                        object.spec.containers +
+                        (has(object.spec.initContainers) ? object.spec.initContainers : []) +
+                        (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+                    ).all(container,
+                        has(container.securityContext) &&
+                        has(container.securityContext.runAsNonRoot) &&
+                        container.securityContext.runAsNonRoot == true)
+                )
+              message: >-
+                Running as root is not allowed. Either the field spec.securityContext.runAsNonRoot or all of
+                spec.containers[*].securityContext.runAsNonRoot, spec.initContainers[*].securityContext.runAsNonRoot and
+                spec.ephemeralContainers[*].securityContext.runAsNonRoot, must be set to true.

--- a/pod-security/restricted/require-run-as-nonroot/.chainsaw-test/pod-bad.yaml
+++ b/pod-security/restricted/require-run-as-nonroot/.chainsaw-test/pod-bad.yaml
@@ -211,3 +211,14 @@ spec:
   securityContext:
     runAsNonRoot: false
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod16
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35
+  securityContext:
+    allowPrivilegeEscalation: false
+---

--- a/pod-security/restricted/require-run-as-nonroot/.kyverno-test/resource.yaml
+++ b/pod-security/restricted/require-run-as-nonroot/.kyverno-test/resource.yaml
@@ -213,6 +213,17 @@ spec:
   securityContext:
     runAsNonRoot: false
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod16
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+  securityContext:
+    allowPrivilegeEscalation: false
+---
 ###### Pods - Good
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
## Related Issue(s)
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->
Fixes: #824

## Description
Add require-run-as-nonroot policy using CEL expressions.
With the CEL from https://github.com/kyverno/policies/pull/776/commits/853bff9368a3304ad7f6fd8c936c4cbe3fa95132#diff-3416b7bb0c4cce31c5d5833e936ec552ea9d1426fadb6f2ec3b81bce4cb910a8 tests failed when Pod's `spec.securityContext` was  present but `spec.securityContext.runAsNonRoot` was not.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
