### PR TITLE
tighten Restrict ClusterRole with Nodes Proxy

### DIFF
--- a/other/restrict-clusterrole-nodesproxy/artifacthub-pkg.yml
+++ b/other/restrict-clusterrole-nodesproxy/artifacthub-pkg.yml
@@ -17,6 +17,6 @@ readme: |
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Sample"
-  kyverno/kubernetesVersion: "1.23"
+  kyverno/kubernetesVersion: "1.27"
   kyverno/subject: "ClusterRole, RBAC"
-digest: e1c5ea5cb9a1834459d8c5de5b52ea487e3a4b716c110f3a64f00d9c72a65c68
+digest: 0d9a0433d58ccb0d102ef757fed015a7bc8fdf128dd3fa4f8526c9608571d92e

--- a/other/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -7,9 +7,9 @@ metadata:
     policies.kyverno.io/category: Sample
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: ClusterRole, RBAC
-    kyverno.io/kyverno-version: 1.7.0
+    kyverno.io/kyverno-version: 1.11.4
     policies.kyverno.io/minversion: 1.6.0
-    kyverno.io/kubernetes-version: "1.23"
+    kyverno.io/kubernetes-version: "1.27"
     policies.kyverno.io/description: >-
       A ClusterRole with nodes/proxy resource access allows a user to
       perform anything the kubelet API allows. It also allows users to bypass
@@ -31,7 +31,10 @@ spec:
         message: "A ClusterRole containing the nodes/proxy resource is not allowed."
         deny:
           conditions:
-            any:
+            all:
             - key: nodes/proxy
               operator: AnyIn
               value: "{{ request.object.rules[].resources[] }}"
+            - key: ""
+              operator: AnyIn
+              value: "{{ request.object.rules[].apiGroups[] }}"


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## Related Issue(s)

Closes #895

## Description

Tightens the Restrict ClusterRole with Nodes Proxy policy by only blocking if the API group is `""` (core).

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
