### PR TITLE
Update OCP policy

### DIFF
--- a/openshift/disallow-self-provisioner-binding/artifacthub-pkg.yml
+++ b/openshift/disallow-self-provisioner-binding/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "OpenShift"
   kyverno/kubernetesVersion: "1.20"
   kyverno/subject: "ClusterRoleBinding, RBAC"
-digest: 2e683ff1c29e1eddbf59b7a8c1fd1848b6292c5d0a9233089603bbd4e1aacf4a
+digest: 1a105716e9a5d2653a6fc6eea9f46c2fa384c00586b9c4148027370e687edfc5

--- a/openshift/disallow-self-provisioner-binding/disallow-self-provisioner-binding.yaml
+++ b/openshift/disallow-self-provisioner-binding/disallow-self-provisioner-binding.yaml
@@ -32,9 +32,8 @@ spec:
         value: UPDATE
     validate:
       message: >-
-        Binding to the self-provisioners cluster role is not allowed.
-      pattern:
-        =(subjects): {}
+        Modifying the self-provisioners ClusterRoleBinding is not allowed.
+      deny: {}
   - name: check-self-provisioner-binding-with-subject
     match:
       any:


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## Related Issue(s)



## Description

PR https://github.com/kyverno/kyverno/pull/9893 was causing this to fail as updates were allowed due to a faulty way of expressing the policy logic. The point of the policy appears to be to forbid updates to this ClusterRoleBinding. This new logic makes that safer and more accurate.

## Checklist


- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
