### PR TITLE
Update deprecated validationFailureAction value (audit/enforce)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ metadata:
     policies.kyverno.io/description: >-
       Adding capabilities beyond those listed in the policy must be disallowed.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: my-rule-name

--- a/argo/application-field-validation/application-field-validation.yaml
+++ b/argo/application-field-validation/application-field-validation.yaml
@@ -15,7 +15,7 @@ metadata:
       Path or chart must be specified but never both. And destination.name or
       destination.server must be specified but never both.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: source-path-chart

--- a/argo/application-prevent-default-project/application-prevent-default-project.yaml
+++ b/argo/application-prevent-default-project/application-prevent-default-project.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       This policy prevents the use of the default project in an Application.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: default-project

--- a/argo/application-prevent-updates-project/application-prevent-updates-project.yaml
+++ b/argo/application-prevent-updates-project/application-prevent-updates-project.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       This policy prevents updates to the project field after an Application is created.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: project-updates

--- a/argo/applicationset-name-matches-project/applicationset-name-matches-project.yaml
+++ b/argo/applicationset-name-matches-project/applicationset-name-matches-project.yaml
@@ -14,7 +14,7 @@ metadata:
       This policy ensures that the name of the ApplicationSet is the
       same value provided in the project.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: match-name

--- a/argo/appproject-clusterresourceblacklist/appproject-clusterresourceblacklist.yaml
+++ b/argo/appproject-clusterresourceblacklist/appproject-clusterresourceblacklist.yaml
@@ -17,7 +17,7 @@ metadata:
       enforce that all AppProjects specify clusterResourceBlacklist and that their group
       and kind have wildcards as values.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: has-wildcard

--- a/aws/require-aws-node-irsa/require-aws-node-irsa.yaml
+++ b/aws/require-aws-node-irsa/require-aws-node-irsa.yaml
@@ -19,7 +19,7 @@ metadata:
       the `aws-node` DaemonSet to use IRSA. This policy ensures that the `aws-node` DaemonSet
       running in the `kube-system` Namespace is not still using the `aws-node` ServiceAccount.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-node-daemonset-irsa

--- a/aws/require-encryption-aws-loadbalancers/require-encryption-aws-loadbalancers.yaml
+++ b/aws/require-encryption-aws-loadbalancers/require-encryption-aws-loadbalancers.yaml
@@ -16,7 +16,7 @@ metadata:
       that Services of type LoadBalancer contain the annotation
       service.beta.kubernetes.io/aws-load-balancer-ssl-cert with some value.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: aws-loadbalancer-has-ssl-cert

--- a/best-practices/check-deprecated-apis/check-deprecated-apis.yaml
+++ b/best-practices/check-deprecated-apis/check-deprecated-apis.yaml
@@ -21,7 +21,7 @@ metadata:
       so therefore the validate-v1-25-removals rule may not completely work on 1.25+.
       This policy requires Kyverno v1.7.4+ to function properly.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-v1-25-removals

--- a/best-practices/disallow-cri-sock-mount/disallow-cri-sock-mount.yaml
+++ b/best-practices/disallow-cri-sock-mount/disallow-cri-sock-mount.yaml
@@ -16,7 +16,7 @@ metadata:
       to or replacement of this policy, preventing users from mounting the parent directories
       (/var/run and /var) may be necessary to completely prevent socket bind mounts.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-docker-sock-mount

--- a/best-practices/disallow-default-namespace/disallow-default-namespace.yaml
+++ b/best-practices/disallow-default-namespace/disallow-default-namespace.yaml
@@ -18,7 +18,7 @@ metadata:
       due to Pod controllers need to specify the `namespace` field under the top-level `metadata`
       object and not at the Pod template level.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-namespace

--- a/best-practices/disallow-empty-ingress-host/disallow-empty-ingress-host.yaml
+++ b/best-practices/disallow-empty-ingress-host/disallow-empty-ingress-host.yaml
@@ -13,7 +13,7 @@ metadata:
       in order to be valid. This policy ensures that there is a
       hostname for each rule defined.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
     - name: disallow-empty-ingress-host

--- a/best-practices/disallow-helm-tiller/disallow-helm-tiller.yaml
+++ b/best-practices/disallow-helm-tiller/disallow-helm-tiller.yaml
@@ -15,7 +15,7 @@ metadata:
       Tiller for these reasons. This policy validates that there is not an image
       containing the name `tiller`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: validate-helm-tiller

--- a/best-practices/disallow-latest-tag/disallow-latest-tag.yaml
+++ b/best-practices/disallow-latest-tag/disallow-latest-tag.yaml
@@ -14,7 +14,7 @@ metadata:
       a specific version of an application Pod. This policy validates that the image
       specifies a tag and that it is not called `latest`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: require-image-tag

--- a/best-practices/require-drop-all/require-drop-all.yaml
+++ b/best-practices/require-drop-all/require-drop-all.yaml
@@ -15,7 +15,7 @@ metadata:
       ability. Note that this policy also illustrates how to cover drop entries in any
       case although this may not strictly conform to the Pod Security Standards.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: require-drop-all

--- a/best-practices/require-drop-cap-net-raw/require-drop-cap-net-raw.yaml
+++ b/best-practices/require-drop-cap-net-raw/require-drop-cap-net-raw.yaml
@@ -16,7 +16,7 @@ metadata:
       ability. Note that this policy also illustrates how to cover drop entries in any
       case although this may not strictly conform to the Pod Security Standards.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: require-drop-cap-net-raw

--- a/best-practices/require-labels/require-labels.yaml
+++ b/best-practices/require-labels/require-labels.yaml
@@ -14,7 +14,7 @@ metadata:
       all tools can understand. The recommended labels describe applications in a way that can be
       queried. This policy validates that the label `app.kubernetes.io/name` is specified with some value.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-for-labels

--- a/best-practices/require-pod-requests-limits/require-pod-requests-limits.yaml
+++ b/best-practices/require-pod-requests-limits/require-pod-requests-limits.yaml
@@ -16,7 +16,7 @@ metadata:
       This policy validates that all containers have something specified for memory and CPU
       requests and memory limits.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-resources

--- a/best-practices/require-probes/require-probes.yaml
+++ b/best-practices/require-probes/require-probes.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy validates that all containers have one of livenessProbe, readinessProbe,
       or startupProbe defined.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-probes

--- a/best-practices/require-ro-rootfs/require-ro-rootfs.yaml
+++ b/best-practices/require-ro-rootfs/require-ro-rootfs.yaml
@@ -15,7 +15,7 @@ metadata:
       host system. This policy validates that containers define a securityContext
       with `readOnlyRootFilesystem: true`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-readOnlyRootFilesystem

--- a/best-practices/restrict-image-registries/restrict-image-registries.yaml
+++ b/best-practices/restrict-image-registries/restrict-image-registries.yaml
@@ -16,7 +16,7 @@ metadata:
       policy validates that container images only originate from the registry `eu.foo.io` or
       `bar.io`. Use of this policy requires customization to define your allowable registries.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-registries

--- a/best-practices/restrict-node-port/restrict-node-port.yaml
+++ b/best-practices/restrict-node-port/restrict-node-port.yaml
@@ -15,7 +15,7 @@ metadata:
       with additional upstream security checks. This policy validates that any new Services
       do not use the `NodePort` type.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-nodeport

--- a/best-practices/restrict-service-external-ips/restrict-service-external-ips.yaml
+++ b/best-practices/restrict-service-external-ips/restrict-service-external-ips.yaml
@@ -14,7 +14,7 @@ metadata:
       See: https://github.com/kyverno/kyverno/issues/1367. This policy validates
       that the `externalIPs` field is not set on a Service.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-ips

--- a/cert-manager/limit-dnsnames/limit-dnsnames.yaml
+++ b/cert-manager/limit-dnsnames/limit-dnsnames.yaml
@@ -13,7 +13,7 @@ metadata:
       This policy ensures that each certificate request contains
       only one DNS name entry.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: limit-dnsnames

--- a/cert-manager/limit-duration/limit-duration.yaml
+++ b/cert-manager/limit-duration/limit-duration.yaml
@@ -11,7 +11,7 @@ metadata:
     policies.kyverno.io/description: >-
       Kubernetes managed non-letsencrypt certificates have to be renewed in every 100 days.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: certificate-duration-max-100days 

--- a/cert-manager/restrict-issuer/restrict-issuer.yaml
+++ b/cert-manager/restrict-issuer/restrict-issuer.yaml
@@ -13,7 +13,7 @@ metadata:
       able to create their own issuers and sign certificates for other domains. This policy
       ensures that a certificate request for a specific domain uses a designated ClusterIssuer.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: restrict-corp-cert-issuer

--- a/consul/enforce-min-tls-version/enforce-min-tls-version.yaml
+++ b/consul/enforce-min-tls-version/enforce-min-tls-version.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       This policy will check the TLS Min version to ensure that whenever the mesh is set, there is a minimum version of TLS set for all the service mesh proxies and this enforces that service mesh mTLS traffic uses TLS v1.2 or newer.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: check-for-tls-version

--- a/flux/verify-flux-sources/verify-flux-sources.yaml
+++ b/flux/verify-flux-sources/verify-flux-sources.yaml
@@ -18,7 +18,7 @@ metadata:
       accessing outside sources. This policy verifies that each of the Flux
       sources comes from a trusted location.
 spec:  
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
     - name: flux-github-repositories
       match:

--- a/istio/enforce-sidecar-injection-namespace/enforce-sidecar-injection-namespace.yaml
+++ b/istio/enforce-sidecar-injection-namespace/enforce-sidecar-injection-namespace.yaml
@@ -15,7 +15,7 @@ metadata:
       `istio-injection` must be set to `enabled`. This policy ensures that all new Namespaces
       set `istio-inject` to `enabled`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-istio-injection-enabled

--- a/istio/enforce-strict-mtls/enforce-strict-mtls.yaml
+++ b/istio/enforce-strict-mtls/enforce-strict-mtls.yaml
@@ -18,7 +18,7 @@ metadata:
       This policy prevents disabling strict mTLS in a PeerAuthentication resource by requiring
       the `mode` be set to either `UNSET` or `STRICT`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-mtls

--- a/istio/enforce-tls-hosts-host-subnets/enforce-tls-hosts-host-subnets.yaml
+++ b/istio/enforce-tls-hosts-host-subnets/enforce-tls-hosts-host-subnets.yaml
@@ -16,7 +16,7 @@ metadata:
       to the destination host. This policy enforces that the TLS mode cannot be set to a value
       of `DISABLE`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: destrule

--- a/istio/prevent-disabling-injection-pods/prevent-disabling-injection-pods.yaml
+++ b/istio/prevent-disabling-injection-pods/prevent-disabling-injection-pods.yaml
@@ -16,7 +16,7 @@ metadata:
       thereby reducing visibility. This policy ensures that Pods cannot set the annotation
       `sidecar.istio.io/inject` to a value of `false`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: prohibit-inject-annotation

--- a/istio/require-authorizationpolicy/require-authorizationpolicy.yaml
+++ b/istio/require-authorizationpolicy/require-authorizationpolicy.yaml
@@ -16,7 +16,7 @@ metadata:
       at least one AuthorizationPolicy. This policy, designed to run in background mode for reporting
       purposes, ensures every Namespace has at least one AuthorizationPolicy.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-authz-pol

--- a/istio/restrict-virtual-service-wildcard/restrict-virtual-service-wildcard.yaml
+++ b/istio/restrict-virtual-service-wildcard/restrict-virtual-service-wildcard.yaml
@@ -18,7 +18,7 @@ metadata:
       character and allows for more governance when a single mesh deployment 
       model is used.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: block-virtual-service-wildcard

--- a/kasten/k10-3-2-1-backup/k10-3-2-1-backup.yaml
+++ b/kasten/k10-3-2-1-backup/k10-3-2-1-backup.yaml
@@ -16,7 +16,7 @@ metadata:
       In K8s/K10, this translates to the original StatefulSet (the original PersistentVolumeClaim), a backup (a snapshot of the PVC on prod storage),
       and an export to cloud object storage (a secondary cloud copy of the PVC snapshot).
 spec:
-  validationFailureAction: audit  
+  validationFailureAction: Audit  
   rules:
   - name: k10-3-2-1-backup-policy
     match:

--- a/kasten/k10-data-protection-by-label/k10-data-protection-by-label.yaml
+++ b/kasten/k10-data-protection-by-label/k10-data-protection-by-label.yaml
@@ -13,7 +13,7 @@ metadata:
       Check the 'dataprotection' label that production Deployments and StatefulSet have a named K10 Policy.
       Use in combination with 'generate' ClusterPolicy to 'generate' a specific K10 Policy by name.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: k10-data-protection-by-label
     match:

--- a/kasten/k10-hourly-rpo/k10-hourly-rpo.yaml
+++ b/kasten/k10-hourly-rpo/k10-hourly-rpo.yaml
@@ -13,7 +13,7 @@ metadata:
       K10 Policy resources can be educated to adhere to common Recovery Point Objective (RPO) best practices. 
       This policy is advising to use an RPO frequency that with hourly granularity if it has the appPriority: Mission Critical
 spec:
-  validationFailureAction: audit  
+  validationFailureAction: Audit
   rules:
   - name: k10-policy-hourly-rpo
     match:

--- a/kasten/k10-immutable-location-profile/k10-immutable-location-profile.yaml
+++ b/kasten/k10-immutable-location-profile/k10-immutable-location-profile.yaml
@@ -15,7 +15,7 @@ metadata:
       Immutability is typically not enabled by default due to the increased costs of retaining storage. 
       This policy checks that the Profile contains a 'protectionPeriod' which is the main configuration for immutability. 
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: k10-immutable-location-profile
     match:

--- a/kubevirt/enforce-instancetype/enforce-instancetype.yaml
+++ b/kubevirt/enforce-instancetype/enforce-instancetype.yaml
@@ -11,7 +11,7 @@ metadata:
     kyverno.io/kyverno-version: "1.8.0-rc2"
     kyverno.io/kubernetes-version: "1.24-1.25"
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: k6t-ensure-instance-type-and-preference
     match:

--- a/linkerd/check-linkerd-authorizationpolicy/check-linkerd-authorizationpolicy.yaml
+++ b/linkerd/check-linkerd-authorizationpolicy/check-linkerd-authorizationpolicy.yaml
@@ -17,7 +17,7 @@ metadata:
       AuthorizationPolicy resources to ensure that either a matching Server or HTTPRoute exists
       first.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-server-exists

--- a/linkerd/prevent-linkerd-pod-injection-override/prevent-linkerd-pod-injection-override.yaml
+++ b/linkerd/prevent-linkerd-pod-injection-override/prevent-linkerd-pod-injection-override.yaml
@@ -13,7 +13,7 @@ metadata:
       security and visibility. This policy prevents setting the annotation `linkerd.io/inject`
       to `disabled` for Pods.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: pod-injection-override

--- a/linkerd/prevent-linkerd-port-skipping/prevent-linkerd-port-skipping.yaml
+++ b/linkerd/prevent-linkerd-port-skipping/prevent-linkerd-port-skipping.yaml
@@ -13,7 +13,7 @@ metadata:
       generally should be avoided. This policy prevents Pods from setting
       the annotations `config.linkerd.io/skip-inbound-ports` or `config.linkerd.io/skip-outbound-ports`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: pod-prevent-port-skipping

--- a/linkerd/require-linkerd-mesh-injection/require-linkerd-mesh-injection.yaml
+++ b/linkerd/require-linkerd-mesh-injection/require-linkerd-mesh-injection.yaml
@@ -12,7 +12,7 @@ metadata:
       setting the annotation `linkerd.io/inject` to `enabled`. This policy enforces that
       all Namespaces contain the annotation `linkerd.io/inject` set to `enabled`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: require-mesh-annotation

--- a/linkerd/require-linkerd-server/require-linkerd-server.yaml
+++ b/linkerd/require-linkerd-server/require-linkerd-server.yaml
@@ -17,7 +17,7 @@ metadata:
       Deployments (exposing ports) and Services to ensure a corresponding Server resource
       exists first.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-deployment-has-server

--- a/nginx-ingress/disallow-ingress-nginx-custom-snippets/disallow-ingress-nginx-custom-snippets.yaml
+++ b/nginx-ingress/disallow-ingress-nginx-custom-snippets/disallow-ingress-nginx-custom-snippets.yaml
@@ -16,7 +16,7 @@ metadata:
       blocks *-snippet annotations on an Ingress.
       See: https://github.com/kubernetes/ingress-nginx/issues/7837
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
     - name: check-config-map
       match:

--- a/nginx-ingress/restrict-annotations/restrict-annotations.yaml
+++ b/nginx-ingress/restrict-annotations/restrict-annotations.yaml
@@ -17,7 +17,7 @@ metadata:
       "annotation-value-word-blocklist" configuration setting is also recommended. 
       Please refer to the CVE for details. 
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
     - name: check-ingress
       match:

--- a/nginx-ingress/restrict-ingress-paths/restrict-ingress-paths.yaml
+++ b/nginx-ingress/restrict-ingress-paths/restrict-ingress-paths.yaml
@@ -15,7 +15,7 @@ metadata:
       Additional paths can be added as required. This issue has been fixed in NGINX Ingress v1.2.0. 
       Please refer to the CVE for details.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
     - name: check-paths
       match:

--- a/openshift/check-routes/check-routes.yaml
+++ b/openshift/check-routes/check-routes.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: |-
       HTTP traffic is not encrypted and hence insecure. This policy prevents configuration of OpenShift HTTP routes.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: require-tls-routes

--- a/openshift/disallow-deprecated-apis/disallow-deprecated-apis.yaml
+++ b/openshift/disallow-deprecated-apis/disallow-deprecated-apis.yaml
@@ -17,7 +17,7 @@ metadata:
       Note that checking for some of these resources may require modifying the Kyverno
       ConfigMap to remove filters.      
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: check-deprecated-apis

--- a/openshift/disallow-jenkins-pipeline-strategy/disallow-jenkins-pipeline-strategy.yaml
+++ b/openshift/disallow-jenkins-pipeline-strategy/disallow-jenkins-pipeline-strategy.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       The Jenkins Pipeline Build Strategy has been deprecated. This policy prevents its use. Use OpenShift Pipelines instead.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: check-build-strategy

--- a/openshift/disallow-security-context-constraint-anyuid/disallow-security-context-constraint-anyuid.yaml
+++ b/openshift/disallow-security-context-constraint-anyuid/disallow-security-context-constraint-anyuid.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       Disallow the use of the SecurityContextConstraint (SCC) anyuid which allows a pod to run with the UID as declared in the image instead of a random UID
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: check-security-context-constraint

--- a/openshift/disallow-self-provisioner-binding/disallow-self-provisioner-binding.yaml
+++ b/openshift/disallow-self-provisioner-binding/disallow-self-provisioner-binding.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       This policy prevents binding to the self-provisioners role for strict control of OpenShift project creation.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: check-self-provisioner-binding-no-subject

--- a/openshift/enforce-etcd-encryption/enforce-etcd-encryption.yaml
+++ b/openshift/enforce-etcd-encryption/enforce-etcd-encryption.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       Encryption at rest is a security best practice. This policy ensures encryption is enabled for etcd in OpenShift clusters.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: check-etcd-encryption

--- a/openshift/team-validate-ns-name/team-validate-ns-name.yaml
+++ b/openshift/team-validate-ns-name/team-validate-ns-name.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy denies the creation of a Namespace if the name of the Namespace does
       not follow a specific naming defined by the cluster admins.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: team-validate-ns-name

--- a/openshift/unique-routes/unique-routes.yaml
+++ b/openshift/unique-routes/unique-routes.yaml
@@ -16,7 +16,7 @@ metadata:
       these hosts should be unique across the cluster to ensure no routing conflicts occur.
       This policy checks an incoming Route resource to ensure its hosts are unique to the cluster.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
     - name: require-unique-routes

--- a/other/advanced-restrict-image-registries/advanced-restrict-image-registries.yaml
+++ b/other/advanced-restrict-image-registries/advanced-restrict-image-registries.yaml
@@ -18,7 +18,7 @@ metadata:
       policy which gets a global approved registry from a ConfigMap and, based upon an
       annotation at the Namespace level, gets the registry approved for that Namespace.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: validate-corp-registries

--- a/other/allowed-annotations/allowed-annotations.yaml
+++ b/other/allowed-annotations/allowed-annotations.yaml
@@ -16,7 +16,7 @@ metadata:
       This policy demonstrates how to allow two annotations with a specific key
       name of fluxcd.io/ while denying others that do not meet the pattern.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: allowed-fluxcd-annotations

--- a/other/allowed-base-images/allowed-base-images.yaml
+++ b/other/allowed-base-images/allowed-base-images.yaml
@@ -18,7 +18,7 @@ metadata:
       that a container's base, found in an OCI annotation, is in a cluster-wide
       allow list.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: allowed-base-images
     match:

--- a/other/allowed-image-repos/allowed-image-repos.yaml
+++ b/other/allowed-image-repos/allowed-image-repos.yaml
@@ -16,7 +16,7 @@ metadata:
       image repositories present in a given Pod, across any container type, come from the
       designated list.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: good-repos

--- a/other/allowed-label-changes/allowed-label-changes.yaml
+++ b/other/allowed-label-changes/allowed-label-changes.yaml
@@ -18,7 +18,7 @@ metadata:
       except one with the key `breakglass`. Changing, adding, or deleting
       any other labels is denied.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: safe-label

--- a/other/allowed-pod-priorities/allowed-pod-priorities.yaml
+++ b/other/allowed-pod-priorities/allowed-pod-priorities.yaml
@@ -15,7 +15,7 @@ metadata:
       PriorityClasses for the given Namespace stored in a ConfigMap. If the `priorityClassName` is not
       among them, the Pod is blocked.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-pod-priority

--- a/other/block-ephemeral-containers/block-ephemeral-containers.yaml
+++ b/other/block-ephemeral-containers/block-ephemeral-containers.yaml
@@ -16,7 +16,7 @@ metadata:
       This may potentially be used to gain access to unauthorized information executing inside
       one or more containers in that Pod. This policy blocks the use of ephemeral containers.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: block-ephemeral-containers

--- a/other/block-images-with-volumes/block-images-with-volumes.yaml
+++ b/other/block-images-with-volumes/block-images-with-volumes.yaml
@@ -16,7 +16,7 @@ metadata:
       This may be unexpected and undesirable. This policy checks the contents of every
       container image and inspects them for such VOLUME statements, then blocks if found.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: block-images-with-vols
     match:

--- a/other/block-large-images/block-large-images.yaml
+++ b/other/block-large-images/block-large-images.yaml
@@ -16,7 +16,7 @@ metadata:
       name an image which is unusually large to disrupt operations. This policy
       checks the size of every container image and blocks if it is over 2 Gibibytes.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: block-over-twogi
     match:

--- a/other/block-pod-exec-by-namespace-label/block-pod-exec-by-namespace-label.yaml
+++ b/other/block-pod-exec-by-namespace-label/block-pod-exec-by-namespace-label.yaml
@@ -12,7 +12,7 @@ metadata:
       be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
       This policy blocks Pod exec commands based upon a Namespace label `exec=false`.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: deny-exec-by-ns-label

--- a/other/block-pod-exec-by-namespace/block-pod-exec-by-namespace.yaml
+++ b/other/block-pod-exec-by-namespace/block-pod-exec-by-namespace.yaml
@@ -12,7 +12,7 @@ metadata:
       be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
       This policy blocks Pod exec commands to Pods in a Namespace called `pci`.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: deny-exec-ns-pci

--- a/other/block-pod-exec-by-pod-and-container/block-pod-exec-by-pod-and-container.yaml
+++ b/other/block-pod-exec-by-pod-and-container/block-pod-exec-by-pod-and-container.yaml
@@ -13,7 +13,7 @@ metadata:
       This policy blocks Pod exec commands to containers named `nginx` in Pods starting
       with name `myapp-maintenance`.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: deny-nginx-exec-in-myapp-maintenance

--- a/other/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.yaml
+++ b/other/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.yaml
@@ -12,7 +12,7 @@ metadata:
       be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
       This policy blocks Pod exec commands to Pods having the label `exec=false`.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: deny-exec-by-label

--- a/other/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.yaml
+++ b/other/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.yaml
@@ -13,7 +13,7 @@ metadata:
       This policy blocks Pod exec commands to Pods beginning with the name
       `myapp-maintenance-`.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: deny-exec-myapp-maintenance

--- a/other/block-stale-images/block-stale-images.yaml
+++ b/other/block-stale-images/block-stale-images.yaml
@@ -15,7 +15,7 @@ metadata:
       This policy checks the contents of every container image and inspects them for the create time.
       If it finds any image which was built more than 6 months ago this policy blocks the deployment.
 spec:
-  validationFailureAction: audit 
+  validationFailureAction: Audit
   rules:
     - name: block-stale-images
       match:

--- a/other/block-updates-deletes/block-updates-deletes.yaml
+++ b/other/block-updates-deletes/block-updates-deletes.yaml
@@ -13,7 +13,7 @@ metadata:
       Service resource that contains the label `protected=true` unless by
       a cluster-admin.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: block-updates-deletes

--- a/other/check-env-vars/check-env-vars.yaml
+++ b/other/check-env-vars/check-env-vars.yaml
@@ -17,7 +17,7 @@ metadata:
       `DISABLE_OPA` environment variable is defined, it must not be set to a value of `"true"`.
 spec:
   background: true
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
     - name: check-disable-opa
       match:

--- a/other/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.yaml
+++ b/other/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy runs in background mode and flags an entry in the ClusterPolicyReport
       if any Node is reporting one of the affected kernel versions.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: kernel-validate

--- a/other/check-nvidia-gpu/check-nvidia-gpu.yaml
+++ b/other/check-nvidia-gpu/check-nvidia-gpu.yaml
@@ -17,7 +17,7 @@ metadata:
       request a GPU to ensure they have been authored with this environment
       variable.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: check-nvidia-gpus
     match:

--- a/other/check-serviceaccount/check-serviceaccount.yaml
+++ b/other/check-serviceaccount/check-serviceaccount.yaml
@@ -15,7 +15,7 @@ metadata:
       Pod, if created by a ServiceAccount, and ensures the `serviceAccountName` field
       matches the actual ServiceAccount.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: check-sa

--- a/other/disallow-all-secrets/disallow-all-secrets.yaml
+++ b/other/disallow-all-secrets/disallow-all-secrets.yaml
@@ -16,7 +16,7 @@ metadata:
       this Policy needs a separate Policy or rule to require `automountServiceAccountToken=false`
       at the Pod level or ServiceAccount level since this would otherwise result in a Secret being mounted.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: secrets-not-from-env
     match:

--- a/other/disallow-localhost-services/disallow-localhost-services.yaml
+++ b/other/disallow-localhost-services/disallow-localhost-services.yaml
@@ -13,7 +13,7 @@ metadata:
       vulnerabilities in some Ingress controllers. This policy audits Services of type ExternalName
       if the externalName field refers to localhost.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: no-localhost-service

--- a/other/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml
+++ b/other/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml
@@ -13,7 +13,7 @@ metadata:
       be printed in log output which could be visible to unauthorized people and captured in forwarding
       applications. This policy disallows using Secrets as environment variables.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: secrets-not-from-env-vars

--- a/other/docker-socket-requires-label/docker-socket-requires-label.yaml
+++ b/other/docker-socket-requires-label/docker-socket-requires-label.yaml
@@ -15,7 +15,7 @@ metadata:
       requires that, for any Pod mounting the Docker socket, it must have the label `allow-docker` set
       to `true`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: conditional-anchor-dockersock

--- a/other/enforce-pod-duration/enforce-pod-duration.yaml
+++ b/other/enforce-pod-duration/enforce-pod-duration.yaml
@@ -12,7 +12,7 @@ metadata:
       such as to ensure a Pod lifetime annotation does not exceed some site specific max threshold.
       Pod lifetime annotation can be no greater than 8 hours.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: pods-lifetime

--- a/other/enforce-resources-as-ratio/enforce-resources-as-ratio.yaml
+++ b/other/enforce-resources-as-ratio/enforce-resources-as-ratio.yaml
@@ -16,7 +16,7 @@ metadata:
       or limits may not work and a ratio may be better suited instead. This policy checks every
       container in a Pod and ensures that memory limits are no more than 2.5x its requests.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: check-memory-requests-limits
     match:

--- a/other/ensure-probes-different/ensure-probes-different.yaml
+++ b/other/ensure-probes-different/ensure-probes-different.yaml
@@ -15,7 +15,7 @@ metadata:
       checks that liveness and readiness probes are not equal. Keep in mind that if both the 
       probes are not set, they are considered to be equal and hence fails the check.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: validate-probes

--- a/other/ensure-production-matches-staging/ensure-production-matches-staging.yaml
+++ b/other/ensure-production-matches-staging/ensure-production-matches-staging.yaml
@@ -19,7 +19,7 @@ metadata:
       that a production Deployment uses same image name as its staging counterpart. Third, that
       a production Deployment uses an older or equal image version as its staging counterpart.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
 #######################

--- a/other/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
+++ b/other/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
@@ -19,7 +19,7 @@ metadata:
       explicitly mounted in readOnly mode.
 spec:
   background: false
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: ensure-hostpaths-readonly
     match:

--- a/other/exclude-namespaces-dynamically/exclude-namespaces-dynamically.yaml
+++ b/other/exclude-namespaces-dynamically/exclude-namespaces-dynamically.yaml
@@ -17,7 +17,7 @@ metadata:
       where the ConfigMap stores an array of strings. This policy validates that any Pods created
       outside of the list of Namespaces have the label `foo` applied.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: exclude-namespaces-dynamically

--- a/other/imagepullpolicy-always/imagepullpolicy-always.yaml
+++ b/other/imagepullpolicy-always/imagepullpolicy-always.yaml
@@ -14,7 +14,7 @@ metadata:
       pulls will get the updated image. This policy validates the imagePullPolicy is set to `Always`
       when the `latest` tag is specified explicitly or where a tag is not defined at all.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: imagepullpolicy-always

--- a/other/ingress-host-match-tls/ingress-host-match-tls.yaml
+++ b/other/ingress-host-match-tls/ingress-host-match-tls.yaml
@@ -18,7 +18,7 @@ metadata:
       in the list of TLS hosts.
 spec:
   background: false
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: host-match-tls
     match:

--- a/other/limit-configmap-for-sa/limit-configmap-for-sa.yaml
+++ b/other/limit-configmap-for-sa/limit-configmap-for-sa.yaml
@@ -12,7 +12,7 @@ metadata:
     policies.kyverno.io/description: This policy shows how to restrict certain operations on specific ConfigMaps by ServiceAccounts.
 spec:
   background: false
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: limit-configmap-for-sa-developer
     match:

--- a/other/limit-containers-per-pod/limit-containers-per-pod.yaml
+++ b/other/limit-containers-per-pod/limit-containers-per-pod.yaml
@@ -14,7 +14,7 @@ metadata:
       be applied consistently. This policy checks all Pods to ensure they have
       no more than four containers.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: limit-containers-per-pod

--- a/other/limit-hostpath-type-pv/limit-hostpath-type-pv.yaml
+++ b/other/limit-hostpath-type-pv/limit-hostpath-type-pv.yaml
@@ -15,7 +15,7 @@ metadata:
       the only directory that can be mounted as a hostPath volume is /data.
 spec:
   background: false
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: limit-hostpath-type-pv-to-slash-data
     match:

--- a/other/limit-hostpath-vols/limit-hostpath-vols.yaml
+++ b/other/limit-hostpath-vols/limit-hostpath-vols.yaml
@@ -19,7 +19,7 @@ metadata:
       access is enforced preventing directory escape.
 spec:
   background: false
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: limit-hostpath-to-slash-data
     match:

--- a/other/memory-requests-equal-limits/memory-requests-equal-limits.yaml
+++ b/other/memory-requests-equal-limits/memory-requests-equal-limits.yaml
@@ -13,7 +13,7 @@ metadata:
       they also set CPU limits equal to requests. Guaranteed is the highest schedulable class. 
       This policy checks that all containers in a given Pod have memory requests equal to limits.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: memory-requests-equal-limits

--- a/other/metadata-match-regex/metadata-match-regex.yaml
+++ b/other/metadata-match-regex/metadata-match-regex.yaml
@@ -13,7 +13,7 @@ metadata:
       policy illustrates how to ensure a label with key `corp.org/version` is both present and matches
       a given regex, in this case ensuring semver is met.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: check-for-regex

--- a/other/nfs-subdir-external-provisioner-storage-path/nfs-subdir-external-provisioner-storage-path.yaml
+++ b/other/nfs-subdir-external-provisioner-storage-path/nfs-subdir-external-provisioner-storage-path.yaml
@@ -18,7 +18,7 @@ metadata:
       annotation that it cannot be empty, which may otherwise result in it consuming the root of the designated path.
 spec:
   background: false
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: enforce-storage-path
     match:

--- a/other/only-trustworthy-registries-set-root/only-trustworthy-registries-set-root.yaml
+++ b/other/only-trustworthy-registries-set-root/only-trustworthy-registries-set-root.yaml
@@ -16,7 +16,7 @@ metadata:
       This policy blocks any image that runs as root if it does not come from a trustworthy
       registry, `ghcr.io` in this case.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: only-allow-trusted-images
     match:

--- a/other/pdb-maxunavailable/pdb-maxunavailable.yaml
+++ b/other/pdb-maxunavailable/pdb-maxunavailable.yaml
@@ -14,7 +14,7 @@ metadata:
       This policy enforces that if a PodDisruptionBudget specifies the maxUnavailable field
       it must be greater than zero.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: pdb-maxunavailable

--- a/other/pdb-minavailable/pdb-minavailable.yaml
+++ b/other/pdb-minavailable/pdb-minavailable.yaml
@@ -15,7 +15,7 @@ metadata:
       tasks and disrupt operations. This policy checks incoming Deployments and StatefulSets which have
       a matching PodDisruptionBudget to ensure these two values do not match.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: pdb-minavailable

--- a/other/prevent-bare-pods/prevent-bare-pods.yaml
+++ b/other/prevent-bare-pods/prevent-bare-pods.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy prevents such "bare" Pods from being created unless they originate
       from a higher-level workload controller of some sort.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: bare-pods

--- a/other/prevent-cr8escape/prevent-cr8escape.yaml
+++ b/other/prevent-cr8escape/prevent-cr8escape.yaml
@@ -16,7 +16,7 @@ metadata:
       and gain root access to the host. The recommended remediation is to disallow
       sysctl settings with + or = in their value.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
     - name: restrict-sysctls-cr8escape

--- a/other/protect-node-taints/protect-node-taints.yaml
+++ b/other/protect-node-taints/protect-node-taints.yaml
@@ -17,7 +17,7 @@ metadata:
       requires, at minimum, one of the following versions of Kubernetes:
       v1.18.18, v1.19.10, v1.20.6, or v1.21.0.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: protect-node-taints

--- a/other/record-creation-details/record-creation-details.yaml
+++ b/other/record-creation-details/record-creation-details.yaml
@@ -22,7 +22,7 @@ metadata:
       all kinds ("*") it is highly recommend to more narrowly scope it to only
       the resources which should be labeled.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: add-userinfo

--- a/other/require-annotations/require-annotations.yaml
+++ b/other/require-annotations/require-annotations.yaml
@@ -13,7 +13,7 @@ metadata:
       all tools can understand. The recommended annotations describe applications in a way that can be
       queried. This policy validates that the annotation `corp.org/department` is specified with some value.      
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-for-annotation

--- a/other/require-base-image/require-base-image.yaml
+++ b/other/require-base-image/require-base-image.yaml
@@ -21,7 +21,7 @@ metadata:
       to specify it using metadata or build directives of some sort (ex., Dockerfile FROM
       statements do not automatically expose this information).
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: require-base-image
     match:

--- a/other/require-container-port-names/require-container-port-names.yaml
+++ b/other/require-container-port-names/require-container-port-names.yaml
@@ -16,7 +16,7 @@ metadata:
       the port number to change. This policy requires that for every containerPort defined
       there is also a name specified.      
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: port-name

--- a/other/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.yaml
+++ b/other/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.yaml
@@ -13,7 +13,7 @@ metadata:
       may suffer downtime if that one replica goes down. This policy validates that Deployments
       have more than one replica.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: deployment-has-multiple-replicas

--- a/other/require-image-checksum/require-image-checksum.yaml
+++ b/other/require-image-checksum/require-image-checksum.yaml
@@ -13,7 +13,7 @@ metadata:
       are mutable and can be overwritten. This policy checks to ensure that all images
       use SHA checksums rather than tags.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: require-image-checksum

--- a/other/require-image-source/require-image-source.yaml
+++ b/other/require-image-source/require-image-source.yaml
@@ -18,7 +18,7 @@ metadata:
       either a label `org.opencontainers.image.source` or a newer annotation in the
       manifest of the same name.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: check-source
     match:

--- a/other/require-imagepullsecrets/require-imagepullsecrets.yaml
+++ b/other/require-imagepullsecrets/require-imagepullsecrets.yaml
@@ -12,7 +12,7 @@ metadata:
       from them. This policy checks those images and if they come from a registry
       other than ghcr.io or quay.io an `imagePullSecret` is required.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-for-image-pull-secrets

--- a/other/require-ingress-https/require-ingress-https.yaml
+++ b/other/require-ingress-https/require-ingress-https.yaml
@@ -16,7 +16,7 @@ metadata:
       `"false"` and specify TLS in the spec.
 spec:
   background: true
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: has-annotation
     match:

--- a/other/require-netpol/require-netpol.yaml
+++ b/other/require-netpol/require-netpol.yaml
@@ -15,7 +15,7 @@ metadata:
       traffic. This policy checks incoming Deployments to ensure
       they have a matching, preexisting NetworkPolicy.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: require-network-policy

--- a/other/require-non-root-groups/require-non-root-groups.yaml
+++ b/other/require-non-root-groups/require-non-root-groups.yaml
@@ -16,7 +16,7 @@ metadata:
       greater than zero (i.e., non root). A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: check-runasgroup

--- a/other/require-pdb/require-pdb.yaml
+++ b/other/require-pdb/require-pdb.yaml
@@ -15,7 +15,7 @@ metadata:
       to ensure they have a matching, preexisting PodDisruptionBudget.
       Note: This policy must be run in `enforce` mode to ensure accuracy.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: require-pdb

--- a/other/require-pod-priorityclassname/require-pod-priorityclassname.yaml
+++ b/other/require-pod-priorityclassname/require-pod-priorityclassname.yaml
@@ -15,7 +15,7 @@ metadata:
       scheduling guarantees. This policy requires that a Pod defines the priorityClassName field
       with some value.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: true
   rules:
   - name: check-priorityclassname

--- a/other/require-qos-burstable/require-qos-burstable.yaml
+++ b/other/require-qos-burstable/require-qos-burstable.yaml
@@ -16,7 +16,7 @@ metadata:
       This policy is provided with the intention that users will need to control its scope by using
       exclusions, preconditions, and other policy language mechanisms.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: burstable

--- a/other/require-qos-guaranteed/require-qos-guaranteed.yaml
+++ b/other/require-qos-guaranteed/require-qos-guaranteed.yaml
@@ -17,7 +17,7 @@ metadata:
       intention that users will need to control its scope by using
       exclusions, preconditions, and other policy language mechanisms.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: guaranteed

--- a/other/require-storageclass/require-storageclass.yaml
+++ b/other/require-storageclass/require-storageclass.yaml
@@ -14,7 +14,7 @@ metadata:
       StorageClasses. This policy requires that PVCs and StatefulSets containing
       volumeClaimTemplates define the storageClassName field with some value.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: pvc-storageclass

--- a/other/require-unique-external-dns/require-unique-external-dns.yaml
+++ b/other/require-unique-external-dns/require-unique-external-dns.yaml
@@ -16,7 +16,7 @@ metadata:
       internal DNS, duplicates must be avoided. This policy requires every such Service have a cluster-unique
       hostname present in the value of the annotation.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: ensure-valid-externaldns-annotation

--- a/other/require-unique-service-selector/require-unique-service-selector.yaml
+++ b/other/require-unique-service-selector/require-unique-service-selector.yaml
@@ -14,7 +14,7 @@ metadata:
       consequences. This policy ensures that within the same Namespace a Service has
       a unique set of labels as a selector.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: check-service-selector

--- a/other/require-unique-uid-per-workload/require-unique-uid-per-workload.yaml
+++ b/other/require-unique-uid-per-workload/require-unique-uid-per-workload.yaml
@@ -18,7 +18,7 @@ metadata:
     kyverno.io/kubernetes-version: "1.20"
 spec:
   background: false
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: require-unique-uid
     match:

--- a/other/require-vulnerability-scan/require-vulnerability-scan.yaml
+++ b/other/require-vulnerability-scan/require-vulnerability-scan.yaml
@@ -19,7 +19,7 @@ metadata:
       policy is expected to be customized based upon your signing strategy and applicable to
       the images you designate.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   webhookTimeoutSeconds: 10
   failurePolicy: Fail
   rules:

--- a/other/restrict-annotations/restrict-annotations.yaml
+++ b/other/restrict-annotations/restrict-annotations.yaml
@@ -14,7 +14,7 @@ metadata:
       don't set reserved annotations or to force them to use a newer version of an annotation.
     pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: block-flux-v1

--- a/other/restrict-automount-sa-token/restrict-automount-sa-token.yaml
+++ b/other/restrict-automount-sa-token/restrict-automount-sa-token.yaml
@@ -15,7 +15,7 @@ metadata:
       be followed if Pods do not need to speak to the API server to function.
       This policy ensures that mounting of these ServiceAccount tokens is blocked.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-automountServiceAccountToken

--- a/other/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml
+++ b/other/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml
@@ -16,7 +16,7 @@ metadata:
       policy prevents binding to the cluster-admin ClusterRole in
       RoleBinding or ClusterRoleBinding resources.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: clusteradmin-bindings

--- a/other/restrict-binding-system-groups/restrict-binding-system-groups.yaml
+++ b/other/restrict-binding-system-groups/restrict-binding-system-groups.yaml
@@ -16,7 +16,7 @@ metadata:
       for other users. This policy prevents creating bindings to some of these
       groups including system:anonymous, system:unauthenticated, and system:masters.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: restrict-anonymous

--- a/other/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -18,7 +18,7 @@ metadata:
       for more info. This policy prevents the creation
       of a ClusterRole if it contains the nodes/proxy resource. 
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: clusterrole-nodesproxy

--- a/other/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml
+++ b/other/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml
@@ -14,7 +14,7 @@ metadata:
       in a Pod spec which allows running on control plane nodes
       with the taint key `node-role.kubernetes.io/master`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: restrict-controlplane-scheduling-master

--- a/other/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml
+++ b/other/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml
@@ -18,7 +18,7 @@ metadata:
       to CVE-2021-25740 by ensuring the system:aggregate-to-edit ClusterRole does not have
       the edit permission of Endpoints.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: system-aggregate-to-edit-check

--- a/other/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
+++ b/other/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
@@ -15,7 +15,7 @@ metadata:
       privilege escalation and should be tightly controlled. This policy prevents
       use of these verbs in Role or ClusterRole resources.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: escalate

--- a/other/restrict-ingress-classes/restrict-ingress-classes.yaml
+++ b/other/restrict-ingress-classes/restrict-ingress-classes.yaml
@@ -16,7 +16,7 @@ metadata:
       annotation. This annotation has largely been replaced as of Kubernetes 1.18 with the IngressClass
       resource.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-ingress

--- a/other/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.yaml
+++ b/other/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.yaml
@@ -18,7 +18,7 @@ metadata:
       want users to use explicit hosts, they should not be able to overwrite the global default backend
       service. This policy prohibits the use of the defaultBackend field.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: restrict-ingress-defaultbackend

--- a/other/restrict-ingress-host/restrict-ingress-host.yaml
+++ b/other/restrict-ingress-host/restrict-ingress-host.yaml
@@ -14,7 +14,7 @@ metadata:
       This policy checks an incoming Ingress resource to ensure its hosts are unique to the cluster.
       It also ensures that only a single host may be specified in a given manifest.      
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: check-single-host-create

--- a/other/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
+++ b/other/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
@@ -17,7 +17,7 @@ metadata:
       policy enforces that any Ingress host does not contain a wildcard
       character.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: block-ingress-wildcard

--- a/other/restrict-loadbalancer/restrict-loadbalancer.yaml
+++ b/other/restrict-loadbalancer/restrict-loadbalancer.yaml
@@ -15,7 +15,7 @@ metadata:
       overrun established budgets and security practices set by the organization. This policy restricts
       use of the Service type LoadBalancer.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: no-LoadBalancer

--- a/other/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.yaml
+++ b/other/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.yaml
@@ -13,7 +13,7 @@ metadata:
       more closely control the necessary traffic flows. This policy requires that all NetworkPolicies
       other than that of `default-deny` not use an empty podSelector.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: empty-podselector

--- a/other/restrict-node-affinity/restrict-node-affinity.yaml
+++ b/other/restrict-node-affinity/restrict-node-affinity.yaml
@@ -17,7 +17,7 @@ metadata:
       is not used in a Pod spec.
 spec:
   background: true
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: check-nodeaffinity
     match:

--- a/other/restrict-node-label-changes/restrict-node-label-changes.yaml
+++ b/other/restrict-node-label-changes/restrict-node-label-changes.yaml
@@ -16,7 +16,7 @@ metadata:
       requires, at minimum, one of the following versions of Kubernetes:
       v1.18.18, v1.19.10, v1.20.6, or v1.21.0.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: prevent-label-value-changes

--- a/other/restrict-node-label-creation/restrict-node-label-creation.yaml
+++ b/other/restrict-node-label-creation/restrict-node-label-creation.yaml
@@ -17,7 +17,7 @@ metadata:
       requires, at minimum, one of the following versions of Kubernetes:
       v1.18.18, v1.19.10, v1.20.6, or v1.21.0.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
   - name: prevent-label-set

--- a/other/restrict-node-selection/restrict-node-selection.yaml
+++ b/other/restrict-node-selection/restrict-node-selection.yaml
@@ -16,7 +16,7 @@ metadata:
       this policy is only designed to work on initial creation and not in background
       mode.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: restrict-nodeselector

--- a/other/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.yaml
+++ b/other/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.yaml
@@ -16,7 +16,7 @@ metadata:
       to Pod controllers if those updates modify the serviceAccountName field. Updates to Pods
       directly for this field are not possible as it is immutable once set.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: block-serviceaccount-updates

--- a/other/restrict-pod-count-per-node/restrict-pod-count-per-node.yaml
+++ b/other/restrict-pod-count-per-node/restrict-pod-count-per-node.yaml
@@ -14,7 +14,7 @@ metadata:
       development cases. This policy restricts Pod count on a Node named `minikube` to be no more than 10.
     # pod-policies.kyverno.io/autogen-controllers: none
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: restrict-pod-count

--- a/other/restrict-scale/restrict-scale.yaml
+++ b/other/restrict-scale/restrict-scale.yaml
@@ -18,7 +18,7 @@ metadata:
       of rules which can be used to limit the replica count both upon creation of a Deployment and
       when a scale operation is performed.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   # This rule can be used to limit scale operations based upon Deployment labels assuming the given label

--- a/other/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
+++ b/other/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
@@ -18,7 +18,7 @@ metadata:
       also prevents use of the wildcard ('*') in the verbs list either when explicitly naming Secrets
       or when also using a wildcard in the base API group.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: secret-verbs

--- a/other/restrict-secrets-by-label/restrict-secrets-by-label.yaml
+++ b/other/restrict-secrets-by-label/restrict-secrets-by-label.yaml
@@ -17,7 +17,7 @@ metadata:
       that only Secrets not labeled with `status=protected` can be consumed by Pods.
 spec:
   background: false
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: secrets-lookup-from-env
     match:

--- a/other/restrict-secrets-by-name/restrict-secrets-by-name.yaml
+++ b/other/restrict-secrets-by-name/restrict-secrets-by-name.yaml
@@ -18,7 +18,7 @@ metadata:
       result in a Secret being mounted.
 spec:
   background: false
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: safe-secrets-from-env
     match:

--- a/other/restrict-service-account/restrict-service-account.yaml
+++ b/other/restrict-service-account/restrict-service-account.yaml
@@ -18,7 +18,7 @@ metadata:
       specified is matched based on the image and name of the container. For example:
       'sa-name: ["registry/image-name"]'
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-service-account

--- a/other/restrict-service-port-range/restrict-service-port-range.yaml
+++ b/other/restrict-service-port-range/restrict-service-port-range.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy enforces that only the port range 32000 to 33000 may
       be used for Service resources.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: restrict-port-range
     match:

--- a/other/restrict-storageclass/restrict-storageclass.yaml
+++ b/other/restrict-storageclass/restrict-storageclass.yaml
@@ -15,7 +15,7 @@ metadata:
       a PersistentVolume cannot be reused across Namespaces. This policy requires
       StorageClasses set a reclaimPolicy of `Delete`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: storageclass-delete

--- a/other/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml
+++ b/other/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml
@@ -14,7 +14,7 @@ metadata:
       to make sure any file created in the volume will have the specified groupID.
       This policy validates that these fields are set to the defined values.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: validate-userid

--- a/other/restrict-wildcard-resources/restrict-wildcard-resources.yaml
+++ b/other/restrict-wildcard-resources/restrict-wildcard-resources.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy blocks any Role or ClusterRole that contains a wildcard entry in
       the resources list found in any rule.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: wildcard-resources

--- a/other/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
+++ b/other/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy blocks any Role or ClusterRole that contains a wildcard entry in
       the verbs list found in any rule.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: wildcard-verbs

--- a/other/topologyspreadconstraints-policy/topologyspreadconstraints-policy.yaml
+++ b/other/topologyspreadconstraints-policy/topologyspreadconstraints-policy.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   background: true
   failurePolicy: Ignore
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
     - name: spread-pods
       match:

--- a/other/unique-ingress-host-and-path/unique-ingress-host-and-path.yaml
+++ b/other/unique-ingress-host-and-path/unique-ingress-host-and-path.yaml
@@ -16,7 +16,7 @@ metadata:
       This policy ensures that no Ingress can be created or updated unless it is
       globally unique with respect to host plus path combination.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: check-host-path-combo

--- a/other/unique-ingress-paths/unique-ingress-paths.yaml
+++ b/other/unique-ingress-paths/unique-ingress-paths.yaml
@@ -16,7 +16,7 @@ metadata:
       existing Ingress rule (ex., when blocking /foo/bar /foo must exist by itself and not part of
       /foo/baz).
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: check-path

--- a/other/verify-image-cve-2022-42889/verify-image-cve-2022-42889.yaml
+++ b/other/verify-image-cve-2022-42889/verify-image-cve-2022-42889.yaml
@@ -19,7 +19,7 @@ metadata:
       package. Using this for your own purposes will require customizing the `imageReferences`,
       `subject`, and `issuer` fields based on your image signatures and attestations.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   webhookTimeoutSeconds: 10
   rules:
     - name: cve-2022-42889

--- a/other/verify-image-gcpkms/verify-image-gcpkms.yaml
+++ b/other/verify-image-gcpkms/verify-image-gcpkms.yaml
@@ -16,7 +16,7 @@ metadata:
       its signature against the provided public key. This policy serves as an illustration for
       how to configure a similar rule and will require replacing with your image(s) and keys.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
     - name: verify-image

--- a/other/verify-image-slsa/verify-image-slsa.yaml
+++ b/other/verify-image-slsa/verify-image-slsa.yaml
@@ -18,7 +18,7 @@ metadata:
       when produced through GitHub Actions. It requires configuration based upon
       your own values.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   webhookTimeoutSeconds: 30
   rules:
     - name: check-slsa-keyless

--- a/other/verify-image-with-multi-keys/verify-image-with-multi-keys.yaml
+++ b/other/verify-image-with-multi-keys/verify-image-with-multi-keys.yaml
@@ -18,7 +18,7 @@ metadata:
       key in a ConfigMap called `key` in the `default` Namespace
       and also a Namespace key in the same ConfigMap.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
     - name: check-image-with-two-keys

--- a/other/verify-image/verify-image.yaml
+++ b/other/verify-image/verify-image.yaml
@@ -16,7 +16,7 @@ metadata:
       its signature against the provided public key. This policy serves as an illustration for
       how to configure a similar rule and will require replacing with your image(s) and keys.
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   background: false
   rules:
     - name: verify-image

--- a/other/verify-manifest-integrity/verify-manifest-integrity.yaml
+++ b/other/verify-manifest-integrity/verify-manifest-integrity.yaml
@@ -19,7 +19,7 @@ metadata:
       the expected key but ignores the `spec.replicas` field allowing other teams to change just
       this value.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: verify-deployment-allow-replicas

--- a/other/verify-sbom-cyclonedx/verify-sbom-cyclonedx.yaml
+++ b/other/verify-sbom-cyclonedx/verify-sbom-cyclonedx.yaml
@@ -18,7 +18,7 @@ metadata:
       and was signed by the expected subject and issuer when produced through GitHub Actions
       and using Cosign's keyless signing. It requires configuration based upon your own values.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   webhookTimeoutSeconds: 30
   rules:
     - name: check-sbom

--- a/pod-security/baseline/disallow-capabilities/disallow-capabilities.yaml
+++ b/pod-security/baseline/disallow-capabilities/disallow-capabilities.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       Adding capabilities beyond those listed in the policy must be disallowed.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: adding-capabilities

--- a/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
+++ b/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
@@ -15,7 +15,7 @@ metadata:
       privileges. Pods should not be allowed access to host namespaces. This policy ensures
       fields which make use of these host namespaces are unset or set to `false`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: host-namespaces

--- a/pod-security/baseline/disallow-host-path/disallow-host-path.yaml
+++ b/pod-security/baseline/disallow-host-path/disallow-host-path.yaml
@@ -14,7 +14,7 @@ metadata:
       Using host resources can be used to access shared data or escalate privileges
       and should not be allowed. This policy ensures no hostPath volumes are in use.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: host-path

--- a/pod-security/baseline/disallow-host-ports-range/disallow-host-ports-range.yaml
+++ b/pod-security/baseline/disallow-host-ports-range/disallow-host-ports-range.yaml
@@ -17,7 +17,7 @@ metadata:
       or to a value of zero. This policy is mutually exclusive of the disallow-host-ports policy.
       Note that Kubernetes Pod Security Admission does not support the host port range rule.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: host-port-range

--- a/pod-security/baseline/disallow-host-ports/disallow-host-ports.yaml
+++ b/pod-security/baseline/disallow-host-ports/disallow-host-ports.yaml
@@ -14,7 +14,7 @@ metadata:
       allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
       field is unset or set to `0`. 
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: host-ports-none

--- a/pod-security/baseline/disallow-host-process/disallow-host-process.yaml
+++ b/pod-security/baseline/disallow-host-process/disallow-host-process.yaml
@@ -15,7 +15,7 @@ metadata:
       policy. HostProcess pods are an alpha feature as of Kubernetes v1.22. This policy ensures
       the `hostProcess` field, if present, is set to `false`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: host-process-containers

--- a/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
+++ b/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
@@ -13,7 +13,7 @@ metadata:
       Privileged mode disables most security mechanisms and must not be allowed. This policy
       ensures Pods do not call for privileged mode.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: privileged-containers

--- a/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.yaml
+++ b/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.yaml
@@ -15,7 +15,7 @@ metadata:
       to deviate from the `Default` procMount requires setting a feature gate at the API
       server.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: check-proc-mount

--- a/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
@@ -13,7 +13,7 @@ metadata:
       SELinux options can be used to escalate privileges and should not be allowed. This policy
       ensures that the `seLinuxOptions` field is undefined.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: selinux-type

--- a/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
@@ -16,7 +16,7 @@ metadata:
       overrides to an allowed set of profiles. This policy ensures Pods do not
       specify any other AppArmor profiles than `runtime/default` or `localhost/*`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: app-armor

--- a/pod-security/baseline/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security/baseline/restrict-seccomp/restrict-seccomp.yaml
@@ -15,7 +15,7 @@ metadata:
       set to `RuntimeDefault` or `Localhost`.
 spec:
   background: true
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
     - name: check-seccomp
       match:

--- a/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy ensures that only those "safe" subsets can be specified in
       a Pod.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: check-sysctls

--- a/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
+++ b/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
@@ -14,7 +14,7 @@ metadata:
       Adding capabilities other than `NET_BIND_SERVICE` is disallowed. In addition,
       all containers must explicitly drop `ALL` capabilities.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: require-drop-all

--- a/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -13,7 +13,7 @@ metadata:
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
       This policy ensures the `allowPrivilegeEscalation` field is set to `false`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: privilege-escalation

--- a/pod-security/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml
+++ b/pod-security/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml
@@ -13,7 +13,7 @@ metadata:
       Containers must be required to run as non-root users. This policy ensures
       `runAsUser` is either unset or set to a number greater than zero.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: run-as-non-root-user

--- a/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -14,7 +14,7 @@ metadata:
       `runAsNonRoot` is set to `true`. A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: run-as-non-root

--- a/pod-security/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
+++ b/pod-security/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
@@ -17,7 +17,7 @@ metadata:
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
 spec:
   background: true
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
     - name: check-seccomp-strict
       match:

--- a/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -15,7 +15,7 @@ metadata:
       limits usage of non-core volume types to those defined through PersistentVolumes.
       This policy blocks any other type of volume other than those in the allow list.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: restricted-volumes

--- a/pod-security/subrule/podsecurity-subrule-baseline/podsecurity-subrule-baseline.yaml
+++ b/pod-security/subrule/podsecurity-subrule-baseline/podsecurity-subrule-baseline.yaml
@@ -18,7 +18,7 @@ metadata:
       version of the Pod Security Standards cluster wide.
 spec:
   background: true
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: baseline
     match:

--- a/pod-security/subrule/restricted/restricted-exclude-capabilities/restricted-exclude-capabilities.yaml
+++ b/pod-security/subrule/restricted/restricted-exclude-capabilities/restricted-exclude-capabilities.yaml
@@ -20,7 +20,7 @@ metadata:
       exempting `nginx` and `redis` container images from the Capabilities control check.
 spec:
   background: true
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: restricted-exempt-capabilities
     match:

--- a/pod-security/subrule/restricted/restricted-exclude-seccomp/restricted-exclude-seccomp.yaml
+++ b/pod-security/subrule/restricted/restricted-exclude-seccomp/restricted-exclude-seccomp.yaml
@@ -20,7 +20,7 @@ metadata:
       completely exempting Seccomp control check.
 spec:
   background: true
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   rules:
   - name: restricted-exempt-seccomp
     match:

--- a/pod-security/subrule/restricted/restricted-latest/restricted-latest.yaml
+++ b/pod-security/subrule/restricted/restricted-latest/restricted-latest.yaml
@@ -18,7 +18,7 @@ metadata:
       restricted profile through the latest version of the Pod Security Standards cluster wide.
 spec:
   background: true
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: restricted
     match:

--- a/psa/add-psa-namespace-reporting/add-psa-namespace-reporting.yaml
+++ b/psa/add-psa-namespace-reporting/add-psa-namespace-reporting.yaml
@@ -22,7 +22,7 @@ metadata:
       organization's security practices and take appropriate action to rectify the 
       situation.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-namespace-labels

--- a/psa/deny-privileged-profile/deny-privileged-profile.yaml
+++ b/psa/deny-privileged-profile/deny-privileged-profile.yaml
@@ -20,7 +20,7 @@ metadata:
       the cluster-admin ClusterRole may create Namespaces which assign the label
       `pod-security.kubernetes.io/enforce=privileged`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: check-privileged

--- a/psp-migration/check-supplemental-groups/check-supplemental-groups.yaml
+++ b/psp-migration/check-supplemental-groups/check-supplemental-groups.yaml
@@ -17,7 +17,7 @@ metadata:
       may only specify supplementalGroup IDs between 100-200 or 500-600.
 spec:
   background: false
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: supplementalgroup-ranges
     match:

--- a/psp-migration/restrict-adding-capabilities/restrict-adding-capabilities.yaml
+++ b/psp-migration/restrict-adding-capabilities/restrict-adding-capabilities.yaml
@@ -18,7 +18,7 @@ metadata:
       ephemeralContainers, initContainers, and containers to ensure the only
       capabilities that can be added are either NET_BIND_SERVICE or CAP_CHOWN.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
     - name: allowed-capabilities

--- a/tekton/block-tekton-task-runs/block-tekton-task-runs.yaml
+++ b/tekton/block-tekton-task-runs/block-tekton-task-runs.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       Restrict creation of TaskRun resources to the Tekton pipelines controller.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: check-taskrun-user

--- a/tekton/require-tekton-bundle/require-tekton-bundle.yaml
+++ b/tekton/require-tekton-bundle/require-tekton-bundle.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       PipelineRun and TaskRun resources must be executed from a bundle
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-bundle-pipelinerun

--- a/tekton/require-tekton-namespace-pipelinerun/require-tekton-namespace-pipelinerun.yaml
+++ b/tekton/require-tekton-namespace-pipelinerun/require-tekton-namespace-pipelinerun.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >- 
       A Namespace is required for a PipelineRun and may not be set to `default`.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-pipelinerun-namespace

--- a/tekton/require-tekton-securitycontext/require-tekton-securitycontext.yaml
+++ b/tekton/require-tekton-securitycontext/require-tekton-securitycontext.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >- 
       A securityContext is required for each TaskRun step.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: true
   rules:
   - name: check-step-securitycontext

--- a/tekton/verify-tekton-pipeline-bundle-signatures/verify-tekton-pipeline-bundle-signatures.yaml
+++ b/tekton/verify-tekton-pipeline-bundle-signatures/verify-tekton-pipeline-bundle-signatures.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >- 
       A signed bundle is required
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Enforce
   webhookTimeoutSeconds: 30
   rules:
   - name: check-signature

--- a/tekton/verify-tekton-taskrun-signatures/verify-tekton-taskrun-signatures.yaml
+++ b/tekton/verify-tekton-taskrun-signatures/verify-tekton-taskrun-signatures.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       A signed bundle is required.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   webhookTimeoutSeconds: 30
   rules:
   - name: check-signature

--- a/tekton/verify-tekton-taskrun-vuln-scan/verify-tekton-taskrun-vuln-scan.yaml
+++ b/tekton/verify-tekton-taskrun-vuln-scan/verify-tekton-taskrun-vuln-scan.yaml
@@ -14,7 +14,7 @@ metadata:
       A signed bundle is required and a vulnerability scan made by Grype must
       return no vulnerabilities greater than 8.0.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   webhookTimeoutSeconds: 30
   rules:
   - name: check-signature

--- a/traefik/disallow-default-tlsoptions/disallow-default-tlsoptions.yaml
+++ b/traefik/disallow-default-tlsoptions/disallow-default-tlsoptions.yaml
@@ -15,7 +15,7 @@ metadata:
       creating the `default` TLSOption is a restricted operation. This policy ensures that
       only a cluster-admin can create the `default` TLSOption resource.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: disallow-default-tlsoptions

--- a/velero/block-velero-restore/block-velero-restore.yaml
+++ b/velero/block-velero-restore/block-velero-restore.yaml
@@ -13,7 +13,7 @@ metadata:
       It checks the Restore CRD object and its namespaceMapping field. If destination match protected namespace
       then operation fails and warning message is throw.
 spec:
-  validationFailureAction: audit
+  validationFailureAction: Audit
   background: false
   rules:
   - name: block-velero-restore-to-protected-namespace

--- a/velero/validate-cron-schedule/validate-cron-schedule.yaml
+++ b/velero/validate-cron-schedule/validate-cron-schedule.yaml
@@ -11,7 +11,7 @@ metadata:
       operation. This policy validates that the schedule is a valid Cron format.
 spec:
   background: true
-  validationFailureAction: audit
+  validationFailureAction: Audit
   rules:
   - name: validate-cron
     match:


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
Policies that are documented on the Kyverno site are using a deprecated values, `audit` and `enforce` for `validationFailureAction` attribute in the policies. The correct values should be `Audit` and `Enforce`

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
