### PR TITLE
Disallow images without Digest

### DIFF
--- a/other/disallow-images-withoutdigest/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other/disallow-images-withoutdigest/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-image-digest
+status:
+  ready: true

--- a/other/disallow-images-withoutdigest/.chainsaw-test/chainsaw-test.yaml
+++ b/other/disallow-images-withoutdigest/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: disallow-images-withoutdigest
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../require-image-digest.yaml
+    - patch:
+        resource:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          metadata:
+            name: require-image-digest
+          spec:
+            validationFailureAction: Enforce
+    - assert:
+        file: chainsaw-step-01-assert-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: pod-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: pod-bad.yaml
+    - apply:
+        file: podcontroller-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: podcontroller-bad.yaml

--- a/other/disallow-images-withoutdigest/.chainsaw-test/pod-bad.yaml
+++ b/other/disallow-images-withoutdigest/.chainsaw-test/pod-bad.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod01
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod02
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod03
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35
+  - name: container02
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod04
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: true
+  - name: container02
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod05
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: busybox:1.35
+  containers:
+  - name: container01
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod06
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: busybox:1.35
+  - name: initcontainer02
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: true
+  containers:
+  - name: container01
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: false
+---

--- a/other/disallow-images-withoutdigest/.chainsaw-test/pod-good.yaml
+++ b/other/disallow-images-withoutdigest/.chainsaw-test/pod-good.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod01
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod02
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+  - name: container02
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod03
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+  containers:
+  - name: container01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod04
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+  - name: initcontainer02
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+  containers:
+  - name: container01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod05
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+  - name: initcontainer02
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+  containers:
+  - name: container01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+  - name: container02
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+---

--- a/other/disallow-images-withoutdigest/.chainsaw-test/podcontroller-bad.yaml
+++ b/other/disallow-images-withoutdigest/.chainsaw-test/podcontroller-bad.yaml
@@ -1,0 +1,250 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment03
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35
+      - name: container02
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment04
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: true
+      - name: container02
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment05
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: busybox:1.35
+      containers:
+      - name: container01
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment06
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: busybox:1.35
+      - name: initcontainer02
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: true
+      containers:
+      - name: container01
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob02
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: true
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob03
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35
+          - name: container02
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob04
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: true
+          - name: container02
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob05
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: busybox:1.35
+          containers:
+          - name: container01
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob06
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: busybox:1.35
+          - name: initcontainer02
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: true
+          containers:
+          - name: container01
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: false
+---

--- a/other/disallow-images-withoutdigest/.chainsaw-test/podcontroller-good.yaml
+++ b/other/disallow-images-withoutdigest/.chainsaw-test/podcontroller-good.yaml
@@ -1,0 +1,246 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: container02
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment03
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+      containers:
+      - name: container01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment04
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: initcontainer02
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+      containers:
+      - name: container01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment05
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: initcontainer02
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+      containers:
+      - name: container01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: container02
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob02
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+          - name: container02
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob03
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+          containers:
+          - name: container01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob04
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+          - name: initcontainer02
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+          containers:
+          - name: container01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob05
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+          - name: initcontainer02
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+          containers:
+          - name: container01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+          - name: container02
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false

--- a/other/disallow-images-withoutdigest/.kyverno-test/kyverno-test.yaml
+++ b/other/disallow-images-withoutdigest/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,72 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: require-image-digest
+policies:
+- ../require-image-digest.yaml
+resources:
+- resource.yaml
+results:
+- kind: CronJob
+  policy: require-image-digest
+  resources:
+  - badcronjob01
+  - badcronjob02
+  - badcronjob03
+  - badcronjob04
+  - badcronjob05
+  - badcronjob06
+  result: fail
+  rule: check-image-digest
+- kind: Deployment
+  policy: require-image-digest
+  resources:
+  - baddeployment01
+  - baddeployment02
+  - baddeployment03
+  - baddeployment04
+  - baddeployment05
+  - baddeployment06
+  result: fail
+  rule: check-image-digest
+- kind: Pod
+  policy: require-image-digest
+  resources:
+  - badpod01
+  - badpod02
+  - badpod03
+  - badpod04
+  - badpod05
+  - badpod06
+  result: fail
+  rule: check-image-digest
+- kind: CronJob
+  policy: require-image-digest
+  resources:
+  - goodcronjob01
+  - goodcronjob02
+  - goodcronjob03
+  - goodcronjob04
+  - goodcronjob05
+  result: pass
+  rule: check-image-digest
+- kind: Deployment
+  policy: require-image-digest
+  resources:
+  - gooddeployment01
+  - gooddeployment02
+  - gooddeployment03
+  - gooddeployment04
+  - gooddeployment05
+  result: pass
+  rule: check-image-digest
+- kind: Pod
+  policy: require-image-digest
+  resources:
+  - goodpod01
+  - goodpod02
+  - goodpod03
+  - goodpod04
+  - goodpod05
+  result: pass
+  rule: check-image-digest

--- a/other/disallow-images-withoutdigest/.kyverno-test/resource.yaml
+++ b/other/disallow-images-withoutdigest/.kyverno-test/resource.yaml
@@ -1,0 +1,668 @@
+###### Pods - Bad
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod01
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod02
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod03
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+  - name: container02
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod04
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: true
+  - name: container02
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod05
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod06
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename
+  - name: initcontainer02
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: true
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: false
+###### Pods - Good
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod01
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod02
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+  - name: container02
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod03
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+  containers:
+  - name: container01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod04
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+  - name: initcontainer02
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+  containers:
+  - name: container01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod05
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+  - name: initcontainer02
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+  containers:
+  - name: container01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+  - name: container02
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+###### Deployments - Bad
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment03
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+      - name: container02
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment04
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: true
+      - name: container02
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment05
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment06
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename
+      - name: initcontainer02
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: true
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+###### Deployments - Good
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: container02
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment03
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+      containers:
+      - name: container01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment04
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: initcontainer02
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+      containers:
+      - name: container01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment05
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: initcontainer02
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+      containers:
+      - name: container01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: container02
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+###### CronJobs - Bad
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob02
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: true
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob03
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+          - name: container02
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob04
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: true
+          - name: container02
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob05
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: dummyimagename
+          containers:
+          - name: container01
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob06
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: dummyimagename
+          - name: initcontainer02
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: true
+          containers:
+          - name: container01
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: false
+###### CronJobs - Good
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob02
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+          - name: container02
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob03
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+          containers:
+          - name: container01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob04
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+          - name: initcontainer02
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+          containers:
+          - name: container01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob05
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+          - name: initcontainer02
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+          containers:
+          - name: container01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+          - name: container02
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false

--- a/other/disallow-images-withoutdigest/artifacthub-pkg.yml
+++ b/other/disallow-images-withoutdigest/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: require-image-digest
+version: 1.0.0
+displayName: Disallow Images Without Digest
+createdAt: "2023-04-10T23:16:53.000Z"
+description: >-
+  Using digests can help in avoiding the pitfalls associated with mutable tags, such as tags being overwritten with different images or potential malicious changes. It effectively prevents pulling unintended or potentially harmful updates to the images. This policy ensures that images without a digest are not allowed.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/disallow-images-withoutdigest/require-image-digest.yaml
+  ```
+keywords:
+- kyverno
+- Other
+readme: |
+  Using digests can help in avoiding the pitfalls associated with mutable tags, such as tags being overwritten with different images or potential malicious changes. It effectively prevents pulling unintended or potentially harmful updates to the images. This policy ensures that images without a digest are not allowed.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.26"
+  kyverno/subject: "Pod"
+digest: 4cb38040213e07324587f36c12903dec5bb90dde4be819cb788e81cdead968e0

--- a/other/disallow-images-withoutdigest/require-image-digest.yaml
+++ b/other/disallow-images-withoutdigest/require-image-digest.yaml
@@ -3,6 +3,11 @@ kind: ClusterPolicy
 metadata:
   name: require-image-digest
   annotations:
+    policies.kyverno.io/title: Disallow Images Without Digest
+    policies.kyverno.io/category: Other 
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kubernetes-version: "1.26"
     policies.kyverno.io/description: >-
       Using digests can help in avoiding the pitfalls associated with mutable tags, 
       such as tags being overwritten with different images or potential malicious changes. 

--- a/other/disallow-images-withoutdigest/require-image-digest.yaml
+++ b/other/disallow-images-withoutdigest/require-image-digest.yaml
@@ -1,0 +1,32 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-image-digest
+  annotations:
+    policies.kyverno.io/description: >-
+      Using digests can help in avoiding the pitfalls associated with mutable tags, 
+      such as tags being overwritten with different images or potential malicious changes. 
+      It effectively prevents pulling unintended or potentially harmful updates to the images.
+      This policy ensures that images without a digest are not allowed. 
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+  - name: check-image-digest
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "Using images without a digest is not allowed."
+      pattern:
+        spec:
+          containers:
+          - (name): "*"
+            image: "*@sha256:*"
+          =(ephemeralContainers):
+            - =(name): "*"
+              image: "*@sha256:*"
+          =(initContainers):
+            - =(name): "*"
+              image: "*@sha256:*"

--- a/other/require-cpu-limits/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other/require-cpu-limits/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-cpu-limits
+status:
+  ready: true

--- a/other/require-cpu-limits/.chainsaw-test/chainsaw-test.yaml
+++ b/other/require-cpu-limits/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: require-cpu-limits
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../require-cpu-limits.yaml
+    - patch:
+        resource:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          metadata:
+            name: require-cpu-limits
+          spec:
+            validationFailureAction: Enforce
+    - assert:
+        file: chainsaw-step-01-assert-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: pod-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: pod-bad.yaml
+    - apply:
+        file: podcontroller-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: podcontroller-bad.yaml

--- a/other/require-cpu-limits/.chainsaw-test/pod-bad.yaml
+++ b/other/require-cpu-limits/.chainsaw-test/pod-bad.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod01
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod02
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod03
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35
+  - name: container02
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod04
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: true
+  - name: container02
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod05
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: busybox:1.35
+  containers:
+  - name: container01
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod06
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: busybox:1.35
+  - name: initcontainer02
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: true
+  containers:
+  - name: container01
+    image: busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: false
+---

--- a/other/require-cpu-limits/.chainsaw-test/pod-good.yaml
+++ b/other/require-cpu-limits/.chainsaw-test/pod-good.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod01
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod02
+spec:
+  containers:
+  - name: container01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"
+  - name: container02
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod03
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"
+  containers:
+  - name: container01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod04
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"
+  - name: initcontainer02
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"
+  containers:
+  - name: container01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod05
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"
+  - name: initcontainer02
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"
+  containers:
+  - name: container01
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"
+  - name: container02
+    image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "50m"

--- a/other/require-cpu-limits/.chainsaw-test/podcontroller-bad.yaml
+++ b/other/require-cpu-limits/.chainsaw-test/podcontroller-bad.yaml
@@ -1,0 +1,250 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment03
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35
+      - name: container02
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment04
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: true
+      - name: container02
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment05
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: busybox:1.35
+      containers:
+      - name: container01
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment06
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: busybox:1.35
+      - name: initcontainer02
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: true
+      containers:
+      - name: container01
+        image: busybox:1.35
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob02
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: true
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob03
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35
+          - name: container02
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob04
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: true
+          - name: container02
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob05
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: busybox:1.35
+          containers:
+          - name: container01
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob06
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: busybox:1.35
+          - name: initcontainer02
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: true
+          containers:
+          - name: container01
+            image: busybox:1.35
+            securityContext:
+              allowPrivilegeEscalation: false
+---

--- a/other/require-cpu-limits/.chainsaw-test/podcontroller-good.yaml
+++ b/other/require-cpu-limits/.chainsaw-test/podcontroller-good.yaml
@@ -1,0 +1,319 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+      - name: container02
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment03
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+      containers:
+      - name: container01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment04
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+      - name: initcontainer02
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+      containers:
+      - name: container01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment05
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+      - name: initcontainer02
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+      containers:
+      - name: container01
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+      - name: container02
+        image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "50m"
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob02
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"
+          - name: container02
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob03
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"
+          containers:
+          - name: container01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob04
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"
+          - name: initcontainer02
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"
+          containers:
+          - name: container01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob05
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"
+          - name: initcontainer02
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"
+          containers:
+          - name: container01
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"
+          - name: container02
+            image: busybox:1.35@sha256:5b6e7aeda43f426b6423f60da863e2e6015c9983c957cf1b068120aea609261d
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "50m"

--- a/other/require-cpu-limits/.kyverno-test/kyverno-test.yaml
+++ b/other/require-cpu-limits/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,72 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: require-cpu-limits
+policies:
+- ../require-cpu-limits.yaml
+resources:
+- resource.yaml
+results:
+- kind: CronJob
+  policy: require-cpu-limits
+  resources:
+  - badcronjob01
+  - badcronjob02
+  - badcronjob03
+  - badcronjob04
+  - badcronjob05
+  - badcronjob06
+  result: fail
+  rule: check-cpu-limits
+- kind: Deployment
+  policy: require-cpu-limits
+  resources:
+  - baddeployment01
+  - baddeployment02
+  - baddeployment03
+  - baddeployment04
+  - baddeployment05
+  - baddeployment06
+  result: fail
+  rule: check-cpu-limits
+- kind: Pod
+  policy: require-cpu-limits
+  resources:
+  - badpod01
+  - badpod02
+  - badpod03
+  - badpod04
+  - badpod05
+  - badpod06
+  result: fail
+  rule: check-cpu-limits
+- kind: CronJob
+  policy: require-cpu-limits
+  resources:
+  - goodcronjob01
+  - goodcronjob02
+  - goodcronjob03
+  - goodcronjob04
+  - goodcronjob05
+  result: pass
+  rule: check-cpu-limits
+- kind: Deployment
+  policy: require-cpu-limits
+  resources:
+  - gooddeployment01
+  - gooddeployment02
+  - gooddeployment03
+  - gooddeployment04
+  - gooddeployment05
+  result: pass
+  rule: check-cpu-limits
+- kind: Pod
+  policy: require-cpu-limits
+  resources:
+  - goodpod01
+  - goodpod02
+  - goodpod03
+  - goodpod04
+  - goodpod05
+  result: pass
+  rule: check-cpu-limits

--- a/other/require-cpu-limits/.kyverno-test/resource.yaml
+++ b/other/require-cpu-limits/.kyverno-test/resource.yaml
@@ -1,0 +1,778 @@
+###### Pods - Bad
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod01
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod02
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod03
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+  - name: container02
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod04
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: true
+  - name: container02
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod05
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod06
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename
+  - name: initcontainer02
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: true
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: false
+###### Pods - Good
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod01
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod02
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+  - name: container02
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod03
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+  containers:
+  - name: container01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod04
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+  - name: initcontainer02
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+  containers:
+  - name: container01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod05
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+  - name: initcontainer02
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+  containers:
+  - name: container01
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+  - name: container02
+    image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+    securityContext:
+      allowPrivilegeEscalation: false
+    resources:
+      limits:
+        cpu: "500m"
+
+###### Deployments - Bad
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment03
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+      - name: container02
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment04
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: true
+      - name: container02
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment05
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment06
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename
+      - name: initcontainer02
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: true
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+###### Deployments - Good
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+      - name: container02
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment03
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+      containers:
+      - name: container01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment04
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+      - name: initcontainer02
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+      containers:
+      - name: container01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment05
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+      - name: initcontainer02
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+      containers:
+      - name: container01
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+      - name: container02
+        image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+        securityContext:
+          allowPrivilegeEscalation: false
+        resources:
+          limits:
+            cpu: "500m"
+
+###### CronJobs - Bad
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob02
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: true
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob03
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+          - name: container02
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob04
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: true
+          - name: container02
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob05
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: dummyimagename
+          containers:
+          - name: container01
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob06
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: dummyimagename
+          - name: initcontainer02
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: true
+          containers:
+          - name: container01
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: false
+###### CronJobs - Good
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob02
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"
+          - name: container02
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob03
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"
+          containers:
+          - name: container01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob04
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"
+          - name: initcontainer02
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"
+          containers:
+          - name: container01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob05
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"
+          - name: initcontainer02
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"
+          containers:
+          - name: container01
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"
+          - name: container02
+            image: dummyimagename@sha256:af21f7f62c57958b7e5f31c334e37fd5e4c4710aeb1e83b7b235a8d9a7d097b7
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              limits:
+                cpu: "500m"

--- a/other/require-cpu-limits/artifacthub-pkg.yml
+++ b/other/require-cpu-limits/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: require-cpu-limits
+version: 1.0.0
+displayName: Require CPU Limits
+createdAt: "2024-05-19T20:30:06.000Z"
+description: >-
+  Setting CPU limits on pods ensures fair distribution of resources, preventing any single pod from monopolizing CPU and impacting the performance of other pods. This practice enhances stability, predictability, and cost control, while also mitigating the noisy neighbor problem and facilitating efficient scaling in Kubernetes clusters. This policy ensures that cpu limits are set on every container.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/require-cpu-limits/require-cpu-limits.yaml
+  ```
+keywords:
+- kyverno
+- Other
+readme: |
+  Setting CPU limits on pods ensures fair distribution of resources, preventing any single pod from monopolizing CPU and impacting the performance of other pods. This practice enhances stability, predictability, and cost control, while also mitigating the noisy neighbor problem and facilitating efficient scaling in Kubernetes clusters. This policy ensures that cpu limits are set on every container.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.26"
+  kyverno/subject: "Pod"
+digest: 85e15b1b0c4aecd72bb5527c750240fd580222b222ff37161cb01cae2048dd8c

--- a/other/require-cpu-limits/require-cpu-limits.yaml
+++ b/other/require-cpu-limits/require-cpu-limits.yaml
@@ -1,0 +1,40 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-cpu-limits
+  annotations:
+    policies.kyverno.io/title: Require CPU Limits
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kubernetes-version: "1.26"
+    policies.kyverno.io/description: >-
+      Setting CPU limits on pods ensures fair distribution of resources, preventing any single pod from monopolizing CPU and impacting the performance of other pods. This practice enhances stability, predictability, and cost control, while also mitigating the noisy neighbor problem and facilitating efficient scaling in Kubernetes clusters. This policy ensures that cpu limits are set on every container.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+  - name: check-cpu-limits
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "CPU limits are required for all containers."
+      pattern:
+        spec:
+          containers:
+          - (name): "*"
+            resources:
+              limits:
+                cpu: "?*"
+          =(ephemeralContainers):
+          - =(name): "*"
+            resources:
+              limits:
+                cpu: "?*"
+          =(initContainers):
+          - =(name): "*"
+            resources:
+              limits:
+                cpu: "?*"


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

This is Kyverno equivalent policy for below checkov policy. Using image digest in the deployment manifest is a security best practice. 
https://github.com/bridgecrewio/checkov/blob/main/checkov/kubernetes/checks/resource/k8s/ImageDigest.py

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
