### PR TITLE
Cleanup rs with timebound 

### DIFF
--- a/cleanup/cleanup-empty-replicasets/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/cleanup/cleanup-empty-replicasets/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,0 +1,5 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: example-797bfc7b6f
+  namespace: default

--- a/cleanup/cleanup-empty-replicasets/.chainsaw-test/chainsaw-test.yaml
+++ b/cleanup/cleanup-empty-replicasets/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,30 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cleanup-pod
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../rbac.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: rs.yaml
+    - assert:
+        file: chainsaw-step-01-assert-1.yaml
+  - name: step-03
+    try:
+    - apply:
+        file: ../cleanup-empty-replicasets.yaml
+    - assert:
+        file: ../cleanup-empty-replicasets.yaml
+  - name: step-04
+    try:
+    - sleep:
+        duration: 1m5s
+  - name: step-05
+    try:
+    - error:
+        file: chainsaw-step-01-assert-1.yaml

--- a/cleanup/cleanup-empty-replicasets/.chainsaw-test/rs.yaml
+++ b/cleanup/cleanup-empty-replicasets/.chainsaw-test/rs.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  labels:
+    app: example
+    pod-template-hash: 797bfc7b6f
+  name: example-797bfc7b6f
+  namespace: default
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: example
+      pod-template-hash: 797bfc7b6f
+  template:
+    metadata:
+      labels:
+        app: example
+        pod-template-hash: 797bfc7b6f
+    spec:
+      containers:
+      - image: httpd
+        imagePullPolicy: Always
+        name: httpd

--- a/cleanup/cleanup-empty-replicasets/artifacthub-pkg.yml
+++ b/cleanup/cleanup-empty-replicasets/artifacthub-pkg.yml
@@ -1,9 +1,9 @@
-name: cleanup-empty-replicasets
-version: 1.0.0
-displayName: Cleanup Empty ReplicaSets
-createdAt: "2023-12-12T17:57:28.000Z"
+name: cleanup-empty-replicasets-with-timebound
+version: 1.0.1
+displayName: Cleanup empty replicasets with timebound
+createdAt: 2023-12-12T17:57:28.000Z
 description: >-
-  ReplicaSets are an intermediary controller to several Pod controllers such as Deployments. When a new version of a Deployment is created, it spawns a new ReplicaSet with the desired number of replicas and scale the current one to zero. This can have the effect of leaving many empty ReplicaSets in the cluster which can create clutter and false positives if policy reports are enabled. This cleanup policy removes all empty ReplicaSets across the cluster. Note that removing empty ReplicaSets may prevent rollbacks.
+  ReplicaSets serve as an intermediate controller for various Pod controllers like Deployments. When a new version of a Deployment is initiated, it generates a new ReplicaSet with the specified number of replicas and scales down the current one to zero. Consequently, numerous empty ReplicaSets may accumulate in the cluster, leading to clutter and potential false positives in policy reports if enabled. This cleanup policy is designed to remove empty ReplicaSets across the cluster within a specified timeframe, for instance, ReplicaSets created one day ago, ensuring the ability to rollback to previous ReplicaSets in case of deployment issues
 install: |-
   ```shell
   kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/cleanup/cleanup-empty-replicasets/cleanup-empty-replicasets.yaml
@@ -13,11 +13,10 @@ keywords:
   - cleanup
   - replicaset
 readme: |
-  ReplicaSets are an intermediary controller to several Pod controllers such as Deployments. When a new version of a Deployment is created, it spawns a new ReplicaSet with the desired number of replicas and scale the current one to zero. This can have the effect of leaving many empty ReplicaSets in the cluster which can create clutter and false positives if policy reports are enabled. This cleanup policy removes all empty ReplicaSets across the cluster. Note that removing empty ReplicaSets may prevent rollbacks.
-  
+  ReplicaSets serve as an intermediate controller for various Pod controllers like Deployments. When a new version of a Deployment is initiated, it generates a new ReplicaSet with the specified number of replicas and scales down the current one to zero. Consequently, numerous empty ReplicaSets may accumulate in the cluster, leading to clutter and potential false positives in policy reports if enabled. This cleanup policy is designed to remove empty ReplicaSets across the cluster within a specified timeframe, for instance, ReplicaSets created one day ago, ensuring the ability to rollback to previous ReplicaSets in case of deployment issues
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.27"
   kyverno/subject: "ReplicaSet"
-digest: 89cc4300938ad7e5c5ad0d649307539f525c35a8107e8661266b144ba1f77c5c
+digest: 10819e402b030472674d9a508812013d83865f41630d15f877cba0ba1d0d88bd

--- a/cleanup/cleanup-empty-replicasets/cleanup-empty-replicasets.yaml
+++ b/cleanup/cleanup-empty-replicasets/cleanup-empty-replicasets.yaml
@@ -1,9 +1,9 @@
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2alpha1
 kind: ClusterCleanupPolicy
 metadata:
-  name: cleanup-empty-replicasets
+  name: cleanup-empty-replicasets-with-timebound
   annotations:
-    policies.kyverno.io/title: Cleanup Empty ReplicaSets
+    policies.kyverno.io/title: Cleanup ReplicaSets 
     policies.kyverno.io/category: Other
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: ReplicaSet
@@ -11,21 +11,25 @@ metadata:
     policies.kyverno.io/minversion: 1.9.0
     kyverno.io/kubernetes-version: "1.27"
     policies.kyverno.io/description: >-
-      ReplicaSets are an intermediary controller to several Pod controllers such as Deployments.
-      When a new version of a Deployment is created, it spawns a new ReplicaSet with the desired
-      number of replicas and scale the current one to zero. This can have the effect of leaving
-      many empty ReplicaSets in the cluster which can create clutter and false positives if policy
-      reports are enabled. This cleanup policy removes all empty ReplicaSets across the cluster.
-      Note that removing empty ReplicaSets may prevent rollbacks.
+      ReplicaSets serve as an intermediate controller for various Pod controllers like Deployments. When a new version of a Deployment is initiated, it generates a new ReplicaSet with the specified number of replicas and scales down the current one to zero. Consequently, numerous empty ReplicaSets may accumulate in the cluster, leading to clutter and potential false positives in policy reports if enabled. This cleanup policy is designed to remove empty ReplicaSets across the cluster within a specified timeframe, for instance, ReplicaSets created one day ago, ensuring the ability to rollback to previous ReplicaSets in case of deployment issues
 spec:
   match:
     any:
     - resources:
         kinds:
           - ReplicaSet
+  exclude:
+    any:
+    - resources:
+        namespaces:
+          - kube-system
   conditions:
     all:
     - key: "{{ target.spec.replicas }}"
       operator: Equals
       value: 0
-  schedule: "*/5 * * * *"
+    - key: "{{ time_diff('{{target.metadata.creationTimestamp}}','{{ time_now_utc() }}') }}"
+      operator: "GreaterThan"
+      value: "0h0m30s"
+  schedule: "*/1 * * * *"
+#The described logic currently deletes the ReplicaSets created 30 seconds ago. You can adjust this timeframe according to your specific requirements.

--- a/cleanup/cleanup-empty-replicasets/cleanup-empty-replicasets.yaml
+++ b/cleanup/cleanup-empty-replicasets/cleanup-empty-replicasets.yaml
@@ -1,9 +1,9 @@
 apiVersion: kyverno.io/v2alpha1
 kind: ClusterCleanupPolicy
 metadata:
-  name: cleanup-empty-replicasets-with-timebound
+  name: cleanup-empty-replicasets
   annotations:
-    policies.kyverno.io/title: Cleanup ReplicaSets 
+    policies.kyverno.io/title: Cleanup Empty ReplicaSets 
     policies.kyverno.io/category: Other
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: ReplicaSet

--- a/cleanup/cleanup-empty-replicasets/rbac.yaml
+++ b/cleanup/cleanup-empty-replicasets/rbac.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: cleanup-controller
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/part-of: kyverno
+  name: kyverno:cleanup-rs
+rules:
+- apiGroups:
+  - "apps"
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyvernocleanup-rs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyverno:cleanup-rs
+subjects:
+- kind: ServiceAccount
+  name: kyverno-cleanup-controller
+  namespace: kyverno


### PR DESCRIPTION
## Description
ReplicaSets serve as an intermediate controller for various Pod controllers like Deployments. When a new version of a Deployment is initiated, it generates a new ReplicaSet with the specified number of replicas and scales down the current one to zero. Consequently, numerous empty ReplicaSets may accumulate in the cluster, leading to clutter and potential false positives in policy reports if enabled. This cleanup policy is designed to remove empty ReplicaSets across the cluster within a specified timeframe, for instance, ReplicaSets created one day ago, ensuring the ability to rollback to previous ReplicaSets in case of deployment issues

## Checklist
- [] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
