### PR TITLE
Update restrict-wildcard-verbs to handle null/empty rules

### DIFF
--- a/other/restrict-wildcard-verbs/.kyverno-test/kyverno-test.yaml
+++ b/other/restrict-wildcard-verbs/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,49 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-verbs
+policies:
+  -  ../restrict-wildcard-verbs.yaml
+resources:
+  - resource.yaml
+results:
+  - policy: restrict-wildcard-verbs
+    rule: wildcard-verbs
+    resource: empty-rules
+    kind: ClusterRole
+    result: pass
+  - policy: restrict-wildcard-verbs
+    rule: wildcard-verbs
+    resource: empty-rules
+    kind: Role
+    result: pass
+  - policy: restrict-wildcard-verbs
+    rule: wildcard-verbs
+    resource: omitted-rules
+    kind: ClusterRole
+    result: pass
+  - policy: restrict-wildcard-verbs
+    rule: wildcard-verbs
+    resource: omitted-rules
+    kind: Role
+    result: pass
+  - policy: restrict-wildcard-verbs
+    rule: wildcard-verbs
+    resource: wildcard-once
+    kind: ClusterRole
+    result: fail
+  - policy: restrict-wildcard-verbs
+    rule: wildcard-verbs
+    resource: wildcard-once
+    kind: Role
+    result: fail
+  - policy: restrict-wildcard-verbs
+    rule: wildcard-verbs
+    resource: wildcard-with-another-verb
+    kind: ClusterRole
+    result: fail
+  - policy: restrict-wildcard-verbs
+    rule: wildcard-verbs
+    resource: wildcard-with-another-verb
+    kind: Role
+    result: fail

--- a/other/restrict-wildcard-verbs/.kyverno-test/resource.yaml
+++ b/other/restrict-wildcard-verbs/.kyverno-test/resource.yaml
@@ -1,0 +1,61 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: empty-rules
+rules:
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: empty-rules
+  namespace: test
+rules:
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: omitted-rules
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: omitted-rules
+  namespace: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wildcard-once
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: wildcard-once
+  namespace: test
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wildcard-with-another-verb
+rules:
+- apiGroups: ["my-arbitrary-group"]
+  resources: ["my-resource"]
+  verbs: ["GET", "*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: wildcard-with-another-verb
+  namespace: test
+rules:
+- apiGroups: ["my-arbitrary-group"]
+  resources: ["my-resource"]
+  verbs: ["GET", "*"]

--- a/other/restrict-wildcard-verbs/artifacthub-pkg.yml
+++ b/other/restrict-wildcard-verbs/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ annotations:
   kyverno/category: "Security, EKS Best Practices"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Role, ClusterRole, RBAC"
-digest: 3107969ac2e467ebca02514dd6c099b05b9294bc863e8e45b0d58e0ec5c1cbb6
+digest: 6c66139e22ed82c0b6d4756b7653136347fdb9575976e13292fbc33e516fe475

--- a/other/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
+++ b/other/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
@@ -32,6 +32,6 @@ spec:
         deny:
           conditions:
             any:
-            - key: "{{ contains(request.object.rules[].verbs[], '*') }}"
+            - key: "{{ contains(to_array(request.object.rules[].verbs[]), '*') }}"
               operator: Equals
               value: true


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

Use the jmespath `to_array` function to better handle nulls on the request.object.rules[] path. In the case of a null a null will be added to an array so the rule can run without error.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
