### PR TITLE
Fix Artifact Hub metadata on Kasten policy

### DIFF
--- a/kasten/kasten-generate-policy-by-preset-label/artifacthub-pkg.yml
+++ b/kasten/kasten-generate-policy-by-preset-label/artifacthub-pkg.yml
@@ -8,7 +8,6 @@ description: >-
   Use with "kasten-validate-ns-by-preset-label" policy to require "dataprotection" labeling on new namespaces.
 install: |-
   ```shell
-  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/kasten/kasten-generate-policy-by-preset-label/create-kasten-policies-clusterrole.yaml
   kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/kasten/kasten-generate-policy-by-preset-label/kasten-generate-policy-by-preset-label.yaml
   ```
 keywords:


### PR DESCRIPTION
Signed-off-by: Chip Zoller <chipzoller@gmail.com>

## Related Issue(s)


## Description

Fixes an issue with the Artifact Hub metadata file introduced in PR #1002 which was causing linting checks to fail in CI.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
