### PR TITLE
add Artifact Hub linter as a job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
   artifacthub-lint:
     runs-on: ubuntu-latest
     container:
-      image: artifacthub/ah:latest
+      image: artifacthub/ah
+      options: --user root
     steps:
       - name: Checkout code
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          path: policies
       - name: Run ah lint
         working-directory: .
         run: ah lint -k kyverno

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  artifacthub-lint:
+    runs-on: ubuntu-latest
+    container:
+      image: artifacthub/ah:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Run ah lint
+        working-directory: .
+        run: ah lint -k kyverno
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

## Related Issue(s)


## Description

Adds a job to the existing "Policy Test" CI which performs Artifact Hub linting using the official `ah` CLI tool (via container). Job is expected to fail until #1045 is merged.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
