### PR TITLE
Included 'jamespath' in the message to enable this user to view the container name in the policy report.

### DIFF
--- a/pod-security/baseline/disallow-capabilities/artifacthub-pkg.yml
+++ b/pod-security/baseline/disallow-capabilities/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline)"
   kyverno/kubernetesVersion: "1.22-1.23"
   kyverno/subject: "Pod"
-digest: 424f0a6b33686600c40b6658dd67ebd4eb596e0975b01120ea994168a2e065c8
+digest: 23d69586dab79161373395d8f67bc5242d26a64925eac331db0d2de0d1a047e9

--- a/pod-security/baseline/disallow-capabilities/disallow-capabilities.yaml
+++ b/pod-security/baseline/disallow-capabilities/disallow-capabilities.yaml
@@ -28,10 +28,7 @@ spec:
           operator: NotEquals
           value: DELETE
       validate:
-        message: >-
-          Any capabilities added beyond the allowed list (AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER,
-          FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT)
-          are disallowed.
+        message: "Containers: {{ request.object.spec.containers[?securityContext.capabilities.add[?!contains(['AUDIT_WRITE', 'CHOWN', 'DAC_OVERRIDE', 'FOWNER', 'FSETID', 'KILL', 'MKNOD', 'NET_BIND_SERVICE', 'SETFCAP', 'SETGID', 'SETPCAP', 'SETUID', 'SYS_CHROOT' ], @)]].name }}; Init Containers: {{ request.object.spec.initContainers[?securityContext.capabilities.add[?!contains(['AUDIT_WRITE', 'CHOWN', 'DAC_OVERRIDE', 'FOWNER', 'FSETID', 'KILL', 'MKNOD', 'NET_BIND_SERVICE', 'SETFCAP', 'SETGID', 'SETPCAP', 'SETUID', 'SYS_CHROOT' ], @)]].name }} Adding capabilities beyond those listed in the policy rule is disallowed"
         deny:
           conditions:
             all:


### PR DESCRIPTION
## Description

Any capabilities added beyond those specified in the policy must be prohibited. Additionally, ensure that 'containername' is included in the policy report.

## Checklist

- [] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
