### PR TITLE
chore: explicitly specify `CREATE` and `UPDATE` operations in CEL policies to prevent policy enforcement on resource deletion

### DIFF
--- a/best-practices-cel/disallow-cri-sock-mount/artifacthub-pkg.yml
+++ b/best-practices-cel/disallow-cri-sock-mount/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Best Practices, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 0b91de77f8a6da0cafea457e0ba9eb14f0b8eb6bbcb56419a4e9de09c860753d
+digest: 535db8906befe485750d0cc9094aca1a064e2738d9f1d60bd1dd72da9d7b6ca2
 createdAt: "2024-03-14T15:59:52Z"
 

--- a/best-practices-cel/disallow-cri-sock-mount/disallow-cri-sock-mount.yaml
+++ b/best-practices-cel/disallow-cri-sock-mount/disallow-cri-sock-mount.yaml
@@ -26,6 +26,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         variables:

--- a/best-practices-cel/disallow-default-namespace/artifacthub-pkg.yml
+++ b/best-practices-cel/disallow-default-namespace/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Multi-Tenancy in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: ab82cba43ef60cf84553fd3119a13db17cc1bc97d8d9a71526b7d3a636c6ce2b
+digest: f2f0202e5f53ea5c446960c2c2467824b3ebb737150b4e9e4a83e700f89c3195
 createdAt: "2024-03-08T06:15:05Z"
 

--- a/best-practices-cel/disallow-default-namespace/disallow-default-namespace.yaml
+++ b/best-practices-cel/disallow-default-namespace/disallow-default-namespace.yaml
@@ -28,6 +28,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:
@@ -42,6 +45,9 @@ spec:
           - Deployment
           - Job
           - StatefulSet
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/best-practices-cel/disallow-empty-ingress-host/artifacthub-pkg.yml
+++ b/best-practices-cel/disallow-empty-ingress-host/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: 9cb3d5814cea4a34de185ce8fd469762a83ef93b910e70b2e6a9ec953e65448c
+digest: 0ffe2735a10b721569cf7139d0d7d51dbc9327beae68e50e4f54f560804548e9
 createdAt: "2024-03-09T14:19:51Z"
 

--- a/best-practices-cel/disallow-empty-ingress-host/disallow-empty-ingress-host.yaml
+++ b/best-practices-cel/disallow-empty-ingress-host/disallow-empty-ingress-host.yaml
@@ -23,6 +23,9 @@ spec:
         - resources:
             kinds:
               - Ingress
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/best-practices-cel/disallow-helm-tiller/artifacthub-pkg.yml
+++ b/best-practices-cel/disallow-helm-tiller/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 68bd8e1cf068759dc436032f3bcb1204992b84ba33498ffd76b744329976769e
+digest: 3ec71460444eda338adc7c96f76d9369275f9b494f9fca8248e240d4424937dc
 createdAt: "2024-03-08T06:30:37Z"
 

--- a/best-practices-cel/disallow-helm-tiller/disallow-helm-tiller.yaml
+++ b/best-practices-cel/disallow-helm-tiller/disallow-helm-tiller.yaml
@@ -25,6 +25,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/best-practices-cel/disallow-latest-tag/artifacthub-pkg.yml
+++ b/best-practices-cel/disallow-latest-tag/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: a477c5213f24a7096495b438a30733d4bbea2da32b2e1f8f71696d72d68d7704
+digest: 46eddb82b6df69bf68894505115899ff2ed833cbe22a05b3c933abf422017110
 createdAt: "2024-03-07T20:17:11Z"
 

--- a/best-practices-cel/disallow-latest-tag/disallow-latest-tag.yaml
+++ b/best-practices-cel/disallow-latest-tag/disallow-latest-tag.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/best-practices-cel/require-drop-all/artifacthub-pkg.yml
+++ b/best-practices-cel/require-drop-all/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: ccf9ef87f6686a93ce044ade6cbe9e68be85679f9a5b315a61eeb0aeafe9ef15
+digest: c3d8959bdc68460e21ff5495994d0bb1a3aa7cb7a5b31740af33638b2dad466c
 createdAt: "2024-03-10T05:05:42Z"
 

--- a/best-practices-cel/require-drop-all/require-drop-all.yaml
+++ b/best-practices-cel/require-drop-all/require-drop-all.yaml
@@ -25,6 +25,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           variables:

--- a/best-practices-cel/require-drop-cap-net-raw/artifacthub-pkg.yml
+++ b/best-practices-cel/require-drop-cap-net-raw/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: a85254bf47f0ec7a3f95139285257228f8f4571f7328ce3652a850d7e901b8c0
+digest: ef4e56b25b29423934e0e21cdea2d6c4e0ae3e67d84a1456f52b3d66fe9fa25a
 createdAt: "2024-03-15T03:05:47Z"
 

--- a/best-practices-cel/require-drop-cap-net-raw/require-drop-cap-net-raw.yaml
+++ b/best-practices-cel/require-drop-cap-net-raw/require-drop-cap-net-raw.yaml
@@ -26,6 +26,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           variables:

--- a/best-practices-cel/require-labels/artifacthub-pkg.yml
+++ b/best-practices-cel/require-labels/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Label"
-digest: 8d6468a51c9a06d26d61874840ff5d0dbda8fe1b4afc9674dcb823a6df0965f7
+digest: cdcd97f2977e45e753975a75184c12d37e297a615f50322be925e64885ffa5e0
 createdAt: "2024-03-06T19:31:45Z"
 

--- a/best-practices-cel/require-labels/require-labels.yaml
+++ b/best-practices-cel/require-labels/require-labels.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/best-practices-cel/require-pod-requests-limits/artifacthub-pkg.yml
+++ b/best-practices-cel/require-pod-requests-limits/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Best Practices, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 9ffe67ea0a581f0373ab2dda4a48f4a3e589301c4a51a1e058494016d1f4228b
+digest: 68eb214fbee5f70f276845c2083cfadc942ed0d45c8237462a152771cdc7c299
 createdAt: "2024-03-15T03:34:10Z"
 

--- a/best-practices-cel/require-pod-requests-limits/require-pod-requests-limits.yaml
+++ b/best-practices-cel/require-pod-requests-limits/require-pod-requests-limits.yaml
@@ -26,6 +26,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/best-practices-cel/require-probes/artifacthub-pkg.yml
+++ b/best-practices-cel/require-probes/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Best Practices, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: bef0d9498ddf0d62aa5fe8671726b4f79cb6c53c7657e48b6fa5a21ded00fefe
+digest: 4c8b625397475449d6c047c78b460ea943ca9753526790bbc725e75163534dd9
 createdAt: "2024-03-10T14:28:37Z"
 

--- a/best-practices-cel/require-probes/require-probes.yaml
+++ b/best-practices-cel/require-probes/require-probes.yaml
@@ -28,6 +28,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/best-practices-cel/require-ro-rootfs/artifacthub-pkg.yml
+++ b/best-practices-cel/require-ro-rootfs/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Best Practices, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 3e33d8d031a0cf31168bd04a0b691520ff01b6dc908554bbc1591700c0e69b0e
+digest: 08e28ef463ea200092f19e279fa3da071b276315f555b579786c564bbb8718c5
 createdAt: "2024-03-07T12:35:00Z"
 

--- a/best-practices-cel/require-ro-rootfs/require-ro-rootfs.yaml
+++ b/best-practices-cel/require-ro-rootfs/require-ro-rootfs.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/best-practices-cel/restrict-image-registries/artifacthub-pkg.yml
+++ b/best-practices-cel/restrict-image-registries/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Best Practices, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 9a431345cee629f64c388e843e39a83ce327d049ac03c02ebad4105abe0c9af5
+digest: cac6e95f5ac6f7d7235349ac935745672c2112a0a5400e8fb1f59c9750850ad0
 createdAt: "2024-03-07T13:35:11Z"
 

--- a/best-practices-cel/restrict-image-registries/restrict-image-registries.yaml
+++ b/best-practices-cel/restrict-image-registries/restrict-image-registries.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         variables:

--- a/best-practices-cel/restrict-node-port/artifacthub-pkg.yml
+++ b/best-practices-cel/restrict-node-port/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Service"
-digest: 5cee0523689e20cc0e5adccc2cf76d725c7f8df2213e7dfdede1fb768fa9a2b9
+digest: 94702e242c40699edeccac5f44c1d481c5b0426396eb3de4ed2ca771aed7868e
 createdAt: "2024-03-06T14:04:34Z"
 

--- a/best-practices-cel/restrict-node-port/restrict-node-port.yaml
+++ b/best-practices-cel/restrict-node-port/restrict-node-port.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - Service
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/best-practices-cel/restrict-service-external-ips/artifacthub-pkg.yml
+++ b/best-practices-cel/restrict-service-external-ips/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Service"
-digest: d03ee8911a09239eb433b737858c9e7eb99da256ab9114a2268537e235817b3c
+digest: dae3c0bf20b0a1a0f3ad7e395d3c05742a4e6ec87813bb16d63eae2ebaa9a744
 createdAt: "2024-03-07T05:48:27Z"
 

--- a/best-practices-cel/restrict-service-external-ips/restrict-service-external-ips.yaml
+++ b/best-practices-cel/restrict-service-external-ips/restrict-service-external-ips.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - Service
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/allowed-annotations/allowed-annotations.yaml
+++ b/other-cel/allowed-annotations/allowed-annotations.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
             - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/allowed-annotations/artifacthub-pkg.yml
+++ b/other-cel/allowed-annotations/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Annotation"
-digest: c917791b2d807cd00117591ba8fa05e7453aa3a8e0c9c1a8d20165ac63150e0c
+digest: e18bedf7d0b6b1b6ac5d723071d78a1594c325620a1ebd28dd8798414da786b2
 createdAt: "2024-03-17T14:04:46Z"
 

--- a/other-cel/allowed-pod-priorities/allowed-pod-priorities.yaml
+++ b/other-cel/allowed-pod-priorities/allowed-pod-priorities.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         paramKind:

--- a/other-cel/allowed-pod-priorities/artifacthub-pkg.yml
+++ b/other-cel/allowed-pod-priorities/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: a017b81b233cd26270cd2d5f74724846c44b9782997545805014a585115bf1f2
+digest: fc3abdb001c9cd666cc784d67eb584800a1a5ab357fbf3616dee2c5752e0f805
 createdAt: "2024-03-19T17:20:47Z"
 

--- a/other-cel/block-ephemeral-containers/artifacthub-pkg.yml
+++ b/other-cel/block-ephemeral-containers/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 13da34209be549d9904eb9142840242db2ae000b1935e8c3c84d23368886fab9
+digest: 9f035b4eb5a4aedeb5c770b03affe6a30a58ee02b79601b2335ead2b0b270f8d
 createdAt: "2024-03-20T08:34:56Z"
 

--- a/other-cel/block-ephemeral-containers/block-ephemeral-containers.yaml
+++ b/other-cel/block-ephemeral-containers/block-ephemeral-containers.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
             - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/check-env-vars/artifacthub-pkg.yml
+++ b/other-cel/check-env-vars/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 3cf38de6f83c3a51ab01548ea6fc0ae1f69538a5c0ed2f163180eaea1c60e4aa
+digest: 4ed73ec1d10a3333d9fd87665880a4645e031de173c08dbda63eecfba2580dbe
 createdAt: "2024-03-21T13:31:53Z"
 

--- a/other-cel/check-env-vars/check-env-vars.yaml
+++ b/other-cel/check-env-vars/check-env-vars.yaml
@@ -25,6 +25,9 @@ spec:
           - resources:
               kinds:
                 - Pod
+              operations:
+              - CREATE
+              - UPDATE
       validate:
         cel:
           expressions:

--- a/other-cel/check-node-for-cve-2022-0185/artifacthub-pkg.yml
+++ b/other-cel/check-node-for-cve-2022-0185/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Node"
-digest: c45321cd579c25bc971467d63d146c6ebef7942b94f72069b6d4d97f332f2df3
+digest: d7eef8bbbe1f7e2a624a93520835944c521838364d020c8b14ecd7c52f1d6107
 createdAt: "2024-03-21T14:21:00Z"
 

--- a/other-cel/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.yaml
+++ b/other-cel/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.yaml
@@ -26,6 +26,9 @@ spec:
       - resources:
           kinds:
             - Node
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/check-serviceaccount-secrets/check-serviceaccount-secrets.yaml
+++ b/other-cel/check-serviceaccount-secrets/check-serviceaccount-secrets.yaml
@@ -26,6 +26,9 @@ spec:
         - resources:
             kinds:
               - ServiceAccount
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/other-cel/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
+++ b/other-cel/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - Secret
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/disallow-all-secrets/artifacthub-pkg.yml
+++ b/other-cel/disallow-all-secrets/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Secret"
-digest: 298fbab361ee9e46721a4afb06212ac6689988f87f257709b82624ef5393ebd5
+digest: 56e5facdefabb17337fca54838bb54025c60d69660091f213ad366ef94f6fd57
 createdAt: "2024-03-23T11:14:09Z"
 

--- a/other-cel/disallow-all-secrets/disallow-all-secrets.yaml
+++ b/other-cel/disallow-all-secrets/disallow-all-secrets.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         variables:

--- a/other-cel/disallow-localhost-services/artifacthub-pkg.yml
+++ b/other-cel/disallow-localhost-services/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Service"
-digest: 6987150bedeaf5bafe4c819cc48b6c2660de1a66b007f24807d88d7a0407a3ba
+digest: 6e294a594d7f369411b8857bfe573822e69dfe6b001fded547fb6edb2c4b7b6a
 createdAt: "2024-03-23T12:17:54Z"
 

--- a/other-cel/disallow-localhost-services/disallow-localhost-services.yaml
+++ b/other-cel/disallow-localhost-services/disallow-localhost-services.yaml
@@ -23,6 +23,9 @@ spec:
       - resources:
           kinds:
           - Service
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/disallow-secrets-from-env-vars/artifacthub-pkg.yml
+++ b/other-cel/disallow-secrets-from-env-vars/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Sample, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Secret"
-digest: 52e12553f5be68f8e155a88f87e81eefeb8008acea66939a570d597afe16184b
+digest: 71ff57f46c814a0971e9fb70f065ca0ab2a4308d9f5d56b1a9f8032eef83782b
 createdAt: "2024-03-24T16:54:45Z"
 

--- a/other-cel/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml
+++ b/other-cel/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml
@@ -23,6 +23,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/docker-socket-requires-label/artifacthub-pkg.yml
+++ b/other-cel/docker-socket-requires-label/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: d577dea5bad5971c21bc1036f97a85c1701a3fdcb2800ee8b4f0708dc2b58101
+digest: b7f8b5251d1670da5514515e7ae4ffde77d8c9cb0d28c0dcaee61ba13adfd035
 createdAt: "2024-03-27T12:13:52Z"
 

--- a/other-cel/docker-socket-requires-label/docker-socket-requires-label.yaml
+++ b/other-cel/docker-socket-requires-label/docker-socket-requires-label.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel: 
         variables:

--- a/other-cel/enforce-pod-duration/artifacthub-pkg.yml
+++ b/other-cel/enforce-pod-duration/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: b2f1fec7c8b199024c813b1ddb3d52f27f889d082c0c94f4824c499cd6b278bb
+digest: 174a456e5d4afd8c8baa9c0c3bdb7da0e09934673f0544d575e5aad6aab5e644
 createdAt: "2024-03-30T18:18:11Z"
 

--- a/other-cel/enforce-pod-duration/enforce-pod-duration.yaml
+++ b/other-cel/enforce-pod-duration/enforce-pod-duration.yaml
@@ -22,6 +22,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         variables:

--- a/other-cel/enforce-readwriteonce-pod/artifacthub-pkg.yml
+++ b/other-cel/enforce-readwriteonce-pod/artifacthub-pkg.yml
@@ -29,6 +29,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "PersistentVolumeClaims"
-digest: de7662c3394731c2de9205ebdda2da9da69e8022b616ca6e4ea9dbfd8ad2b2a8
+digest: c3595da6ec53e127aca4f08c38095764d652aa268ebfde21d3445545c75e1615
 createdAt: "2024-03-31T10:53:27Z"
 

--- a/other-cel/enforce-readwriteonce-pod/enforce-readwriteonce-pod.yaml
+++ b/other-cel/enforce-readwriteonce-pod/enforce-readwriteonce-pod.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - PersistentVolumeClaim
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/ensure-probes-different/artifacthub-pkg.yml
+++ b/other-cel/ensure-probes-different/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: cbafa29e49ec48f7378157f69fa77a53c07fb40dc4c542738a8f31331689f5be
+digest: 95447cdc8a2287d3d0d9f300dd82bd62709d1bbe91c60ba2b11c8ce0a318bbcb
 createdAt: "2024-03-31T11:12:02Z"
 

--- a/other-cel/ensure-probes-different/ensure-probes-different.yaml
+++ b/other-cel/ensure-probes-different/ensure-probes-different.yaml
@@ -27,6 +27,9 @@ spec:
             - Deployment
             - DaemonSet
             - StatefulSet
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/other-cel/ensure-readonly-hostpath/artifacthub-pkg.yml
+++ b/other-cel/ensure-readonly-hostpath/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 5335b84399ed1bb06e70489940d2555cff0c97f7f937aac0fbdf8ee0a188ace1
+digest: 203506a9391a1d4bee3ed42209ab7e964606aee881db2cd93290bd075c98840b
 createdAt: "2024-04-05T17:39:16Z"
 

--- a/other-cel/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
+++ b/other-cel/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
@@ -27,6 +27,9 @@ spec:
       - resources:
           kinds:
             - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         variables:

--- a/other-cel/forbid-cpu-limits/artifacthub-pkg.yml
+++ b/other-cel/forbid-cpu-limits/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 2865e5f92968f90e090aff597937ab7db3e3e5939c32cb84c84f881970dedae6
+digest: 8d8febae3e8acfab78c2ccf8b96d086f7086ea156b0a0ac36611db1c8958c357
 createdAt: "2024-04-01T15:35:47Z"
 

--- a/other-cel/forbid-cpu-limits/forbid-cpu-limits.yaml
+++ b/other-cel/forbid-cpu-limits/forbid-cpu-limits.yaml
@@ -22,6 +22,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/imagepullpolicy-always/artifacthub-pkg.yml
+++ b/other-cel/imagepullpolicy-always/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: a6708df7cd59fcd4dc4f764ff01541940f39eca5d4ddffd9529d83090e511b47
+digest: 48bf801d9acfef85768bf1f9fb3820a6cee3b9f87acb7a4f07f2449d193934cb
 createdAt: "2024-04-03T17:41:38Z"
 

--- a/other-cel/imagepullpolicy-always/imagepullpolicy-always.yaml
+++ b/other-cel/imagepullpolicy-always/imagepullpolicy-always.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/ingress-host-match-tls/artifacthub-pkg.yml
+++ b/other-cel/ingress-host-match-tls/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: 5442acaa90c6a45509015995028e241374b76d60cc700fbf6dd9f61178ba432f
+digest: 4de00322c258919b797101a18afa3fa262ce78b52132f2fd903cfea8f60d1f1e
 createdAt: "2024-04-06T17:22:38Z"
 

--- a/other-cel/ingress-host-match-tls/ingress-host-match-tls.yaml
+++ b/other-cel/ingress-host-match-tls/ingress-host-match-tls.yaml
@@ -26,6 +26,9 @@ spec:
       - resources:
           kinds:
           - Ingress
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         variables:

--- a/other-cel/limit-containers-per-pod/artifacthub-pkg.yml
+++ b/other-cel/limit-containers-per-pod/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 7916672ede794217fb00144785594818cbb66f409c1d2f0d513cfeb944e92ed1
+digest: 6a915cbe21250809e2e9665f9b79dde5f9b1fc77f2538c5f25ec9c5dda86a00b
 createdAt: "2024-04-01T15:48:55Z"
 

--- a/other-cel/limit-containers-per-pod/limit-containers-per-pod.yaml
+++ b/other-cel/limit-containers-per-pod/limit-containers-per-pod.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/limit-hostpath-type-pv/artifacthub-pkg.yml
+++ b/other-cel/limit-hostpath-type-pv/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "PersistentVolume"
-digest: 981a66b5f77de02d3f6623b49c02421dd1adf4e9882d96a2e0219de9dba52672
+digest: 8f2f85798607f78ce3eb794c08df351a8c171629c64481d5d7575c33b8428333
 createdAt: "2024-04-04T17:35:35Z"
 

--- a/other-cel/limit-hostpath-type-pv/limit-hostpath-type-pv.yaml
+++ b/other-cel/limit-hostpath-type-pv/limit-hostpath-type-pv.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - PersistentVolume
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel: 
         expressions:

--- a/other-cel/memory-requests-equal-limits/artifacthub-pkg.yml
+++ b/other-cel/memory-requests-equal-limits/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 176dc9b492d3eee687bc89711d3414f13bf00548b85781e71ccaacd12bbf6f1a
+digest: fc71819c4079262810e06ee768738b1061f46985df61ab688007bfdb7433be70
 createdAt: "2024-04-07T11:13:21Z"
 

--- a/other-cel/memory-requests-equal-limits/memory-requests-equal-limits.yaml
+++ b/other-cel/memory-requests-equal-limits/memory-requests-equal-limits.yaml
@@ -23,6 +23,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         variables:

--- a/other-cel/metadata-match-regex/artifacthub-pkg.yml
+++ b/other-cel/metadata-match-regex/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Label"
-digest: 4f6e2a07df41b3ce83af7ce25a6cdb7bae14f336edfd178bb52b25183f6c580d
+digest: 2957a6e03dec3eab58436ddb3478aca69d41dbe7953c6ecb1ece1a54338856e2
 createdAt: "2024-04-07T10:16:14Z"
 

--- a/other-cel/metadata-match-regex/metadata-match-regex.yaml
+++ b/other-cel/metadata-match-regex/metadata-match-regex.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/pdb-maxunavailable/artifacthub-pkg.yml
+++ b/other-cel/pdb-maxunavailable/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "PodDisruptionBudget"
-digest: 7dff4f3801bce1ca8835c5ebcadaa78e1fa41480a19958eb78aee5bbfcd6b8bf
+digest: 4b452f78ab0ff9715f1454fd3ca827b7aa7a892fa2b2f23aa5c21a12851c526d
 createdAt: "2024-04-07T10:22:03Z"
 

--- a/other-cel/pdb-maxunavailable/pdb-maxunavailable.yaml
+++ b/other-cel/pdb-maxunavailable/pdb-maxunavailable.yaml
@@ -23,6 +23,9 @@ spec:
           - resources:
               kinds:
                 - PodDisruptionBudget
+              operations:
+              - CREATE
+              - UPDATE
       validate:
         cel:
           expressions:

--- a/other-cel/prevent-bare-pods/artifacthub-pkg.yml
+++ b/other-cel/prevent-bare-pods/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Other, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 325e1a068bd771c60a304f121675b9d895bcc8abacc7b48054ae4465d51fd158
+digest: ff8f3288a8e8ea57d91d27785866d0c17b8112b8697d0689e9f324874deb1f3b
 createdAt: "2024-04-07T10:47:32Z"
 

--- a/other-cel/prevent-bare-pods/prevent-bare-pods.yaml
+++ b/other-cel/prevent-bare-pods/prevent-bare-pods.yaml
@@ -26,6 +26,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/prevent-cr8escape/artifacthub-pkg.yml
+++ b/other-cel/prevent-cr8escape/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 84a0f441ce5baec6060606a05f2f7f54847e79b48a38c9edc1655e6f0caf8bbf
+digest: 7a684c2d2747e4ef77b44de44734c74143325757077e8047f3c89d535c5b9dfd
 createdAt: "2024-04-08T10:46:02Z"
 

--- a/other-cel/prevent-cr8escape/prevent-cr8escape.yaml
+++ b/other-cel/prevent-cr8escape/prevent-cr8escape.yaml
@@ -25,6 +25,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/other-cel/require-annotations/artifacthub-pkg.yml
+++ b/other-cel/require-annotations/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Annotation"
-digest: dc8408d4a7a929f2f142b174a2ea06148f4dbd65ab16d70870a2213919dadf9d
+digest: affed5b798321bdaac4b178887ad1a98c4fd00e9e756849dac3f0d70148f6ef1
 createdAt: "2024-04-09T15:56:35Z"
 

--- a/other-cel/require-annotations/require-annotations.yaml
+++ b/other-cel/require-annotations/require-annotations.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/require-deployments-have-multiple-replicas/artifacthub-pkg.yml
+++ b/other-cel/require-deployments-have-multiple-replicas/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Deployment"
-digest: 5c1e1b6bdb837cfba211615438cd50fa38b78c559ae43f4a791f5558f873b5d3
+digest: ee5b95668db9936b32f32f1d8ee167d4adec5c71c214981bbb503c1a5c416356
 createdAt: "2024-04-09T16:03:47Z"
 

--- a/other-cel/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.yaml
+++ b/other-cel/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.yaml
@@ -23,6 +23,9 @@ spec:
         - resources:
             kinds:
             - Deployment
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/other-cel/require-image-checksum/artifacthub-pkg.yml
+++ b/other-cel/require-image-checksum/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: e9c64e577e3f4d255489ce34191ee29c4180fae774a60eceaff1d12c1e716891
+digest: 6a775c3ab5b2c24f6fbe10de35ecca20e967d3d70242403718b55f5a04c07c08
 createdAt: "2024-04-10T18:21:59Z"
 

--- a/other-cel/require-image-checksum/require-image-checksum.yaml
+++ b/other-cel/require-image-checksum/require-image-checksum.yaml
@@ -23,6 +23,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/require-ingress-https/artifacthub-pkg.yml
+++ b/other-cel/require-ingress-https/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: fb50d3603fbd348e84ce2e64c06e313c9c028daa640893f3c95a9e28c27687c0
+digest: 9163d422661aa93c02397bf4f954a40541a9d3bf891b74b50bcc1263e8ae4974
 createdAt: "2024-04-10T18:31:27Z"
 

--- a/other-cel/require-ingress-https/artifacthub-pkg.yml
+++ b/other-cel/require-ingress-https/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: 9163d422661aa93c02397bf4f954a40541a9d3bf891b74b50bcc1263e8ae4974
+digest: 56fca07a343423b529d0cd1e27069ca705b60cc1f590c832b2467c757b1b6957
 createdAt: "2024-04-10T18:31:27Z"
 

--- a/other-cel/require-ingress-https/require-ingress-https.yaml
+++ b/other-cel/require-ingress-https/require-ingress-https.yaml
@@ -41,6 +41,9 @@ spec:
       - resources:
           kinds:
           - Ingress
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/require-ingress-https/require-ingress-https.yaml
+++ b/other-cel/require-ingress-https/require-ingress-https.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - Ingress
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/require-pod-priorityclassname/artifacthub-pkg.yml
+++ b/other-cel/require-pod-priorityclassname/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Multi-Tenancy, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: dad8ffaa48df075faa27733ac7a6a88ac644864bc1a1a5693ddb443775148279
+digest: 10070a8c58969454fde8742cc3c1fdd5c196d98a918e8504f833331dd0a1c03b
 createdAt: "2024-04-11T17:46:06Z"
 

--- a/other-cel/require-pod-priorityclassname/require-pod-priorityclassname.yaml
+++ b/other-cel/require-pod-priorityclassname/require-pod-priorityclassname.yaml
@@ -26,6 +26,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/require-qos-burstable/artifacthub-pkg.yml
+++ b/other-cel/require-qos-burstable/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Other, Multi-Tenancy in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 3e93eb4eee26bb198811f9441bca6ef58dfb848e6446ccb38156b534a16fe16b
+digest: 723f2fd7dcafa80eb362274960a518a13eecc425a96880ef690b7693496cc967
 createdAt: "2024-04-11T17:54:50Z"
 

--- a/other-cel/require-qos-burstable/require-qos-burstable.yaml
+++ b/other-cel/require-qos-burstable/require-qos-burstable.yaml
@@ -27,6 +27,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/require-storageclass/artifacthub-pkg.yml
+++ b/other-cel/require-storageclass/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Other, Multi-Tenancy in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "PersistentVolumeClaim, StatefulSet"
-digest: 3ff19239688cf47b624bbd62d02624153b27059c6bed26ca290599eb2810ccf6
+digest: 6e662335f87b2ebc0545fd30c4e69bfa51bcd19aeddd5905e03ac33c9dde73e5
 createdAt: "2024-04-11T18:06:16Z"
 

--- a/other-cel/require-storageclass/artifacthub-pkg.yml
+++ b/other-cel/require-storageclass/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Other, Multi-Tenancy in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "PersistentVolumeClaim, StatefulSet"
-digest: 6e662335f87b2ebc0545fd30c4e69bfa51bcd19aeddd5905e03ac33c9dde73e5
+digest: 50a19cfd04cb3ffc6cd1d064516042035b64213e16a85aecc891dc5c0806963c
 createdAt: "2024-04-11T18:06:16Z"
 

--- a/other-cel/require-storageclass/require-storageclass.yaml
+++ b/other-cel/require-storageclass/require-storageclass.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - PersistentVolumeClaim
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/require-storageclass/require-storageclass.yaml
+++ b/other-cel/require-storageclass/require-storageclass.yaml
@@ -39,6 +39,9 @@ spec:
       - resources:
           kinds:
           - StatefulSet
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-annotations/artifacthub-pkg.yml
+++ b/other-cel/restrict-annotations/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Annotation"
-digest: 55b4953e1ca6aa6038d407aae539705d9a8c1136d2ffc277df1686a08ac7c9a8
+digest: 5e3188460d595814af4a9287d6af5e42819863d4b619bfc329effb6127c8bf94
 createdAt: "2024-04-12T15:55:04Z"
 

--- a/other-cel/restrict-annotations/restrict-annotations.yaml
+++ b/other-cel/restrict-annotations/restrict-annotations.yaml
@@ -29,6 +29,9 @@ spec:
           - StatefulSet
           - DaemonSet
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-binding-clusteradmin/artifacthub-pkg.yml
+++ b/other-cel/restrict-binding-clusteradmin/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Security in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "RoleBinding, ClusterRoleBinding, RBAC"
-digest: 313ef33ca553700424ca8c1dde5572219a1ef976a78138e78a6c5838f8a11d2c
+digest: 7affbe90144f7d95e86ec9be12e95542296020026dd561cf79cd508b7dbb663d
 createdAt: "2024-04-12T16:00:17Z"
 

--- a/other-cel/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml
+++ b/other-cel/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml
@@ -26,6 +26,9 @@ spec:
             kinds:
               - RoleBinding
               - ClusterRoleBinding
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/other-cel/restrict-binding-system-groups/artifacthub-pkg.yml
+++ b/other-cel/restrict-binding-system-groups/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Security, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "RoleBinding, ClusterRoleBinding, RBAC"
-digest: 9843fd8b6e7357bc01ccbfcd3280bc3bc1d8baa5da4dce46c7d0125906a8efdc
+digest: 8a5fb4bfe55c063b3b14eaed7a81512548ce89cc7057aa5549723fefed670f1f
 createdAt: "2024-04-12T16:28:28Z"
 

--- a/other-cel/restrict-binding-system-groups/restrict-binding-system-groups.yaml
+++ b/other-cel/restrict-binding-system-groups/restrict-binding-system-groups.yaml
@@ -26,6 +26,9 @@ spec:
             kinds:
               - RoleBinding
               - ClusterRoleBinding
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/other-cel/restrict-clusterrole-nodesproxy/artifacthub-pkg.yml
+++ b/other-cel/restrict-clusterrole-nodesproxy/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "ClusterRole, RBAC"
-digest: 5c78dc50201f3223c42e0ac414e23dcc418f487ae76031aa85eb4fbd6fa1a2c1
+digest: 070dd3d53f7c50f1cdbb48643fc69d73ba1af9766f5eba3809e42058d72f885c
 createdAt: "2024-04-13T16:12:56Z"
 

--- a/other-cel/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other-cel/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -27,6 +27,9 @@ spec:
         - resources:
             kinds:
               - ClusterRole
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/other-cel/restrict-controlplane-scheduling/artifacthub-pkg.yml
+++ b/other-cel/restrict-controlplane-scheduling/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 55668531abc1c98763bcfac82efd6bb912c37fbf5b0f8cf68dc09fd0c24b6ce9
+digest: 95c237c7d39fa64b37cf5708d566ca582f7f55770708092cf1e38d0a4e8a0828
 createdAt: "2024-04-13T16:19:01Z"
 

--- a/other-cel/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml
+++ b/other-cel/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-deprecated-registry/artifacthub-pkg.yml
+++ b/other-cel/restrict-deprecated-registry/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Best Practices, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.27-1.28"
   kyverno/subject: "Pod"
-digest: 8973c813a1c65f2137273d66cd871bfbe53d80b30bae87685713ddc1ce96eb32
+digest: b7e1108f954b94f8de8d26c564d37e1a6930648c9bb725ac2d3d3b6456d2ea2d
 createdAt: "2024-04-13T16:21:40Z"
 

--- a/other-cel/restrict-deprecated-registry/restrict-deprecated-registry.yaml
+++ b/other-cel/restrict-deprecated-registry/restrict-deprecated-registry.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         variables:

--- a/other-cel/restrict-escalation-verbs-roles/artifacthub-pkg.yml
+++ b/other-cel/restrict-escalation-verbs-roles/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Security in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Role, ClusterRole, RBAC"
-digest: 145bfa9745d524e77c11d35ea267c3c2323eb6d9d13c3b7c00632eb358da7d75
+digest: 44c62b5989a9e99a591a95db11463125b7a8c0ad172e08881e527cebb3423293
 createdAt: "2024-04-14T15:40:58Z"
 

--- a/other-cel/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
+++ b/other-cel/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
@@ -25,6 +25,9 @@ spec:
             kinds:
               - Role
               - ClusterRole
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           variables:

--- a/other-cel/restrict-ingress-classes/artifacthub-pkg.yml
+++ b/other-cel/restrict-ingress-classes/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: 1619d89eec3ee9bf4de2f76b747b01c885af2c3b42631c3b0ff1e50a6717e9e1
+digest: abbd493cdcdfd2a7ec903027a4b7f56b1d7761e7a0ce2822d1521bb853791455
 createdAt: "2024-04-14T15:43:33Z"
 

--- a/other-cel/restrict-ingress-classes/restrict-ingress-classes.yaml
+++ b/other-cel/restrict-ingress-classes/restrict-ingress-classes.yaml
@@ -26,6 +26,9 @@ spec:
       - resources:
           kinds:
           - Ingress
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions: 

--- a/other-cel/restrict-ingress-defaultbackend/artifacthub-pkg.yml
+++ b/other-cel/restrict-ingress-defaultbackend/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: daed0d8b9b07fa2d102540d7f7204752cc44ace565668469b66ac2d224c87ca4
+digest: b4e07522bb17d990d112a2ba7a472c9662be01358fd8caa9806186246ffa7521
 createdAt: "2024-04-14T15:45:57Z"
 

--- a/other-cel/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.yaml
+++ b/other-cel/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.yaml
@@ -27,6 +27,9 @@ spec:
       - resources:
           kinds:
           - Ingress
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-ingress-wildcard/artifacthub-pkg.yml
+++ b/other-cel/restrict-ingress-wildcard/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: efc9d13e01f12ada9ae55b8cd4ef572c767670d65ca189bdea4857969a3a7365
+digest: 74fa42f42b40f259054e0a4c097e10673bfa977ef0f5451cef18d07222142a5b
 createdAt: "2024-04-15T18:06:41Z"
 

--- a/other-cel/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
+++ b/other-cel/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
@@ -26,6 +26,9 @@ spec:
         - resources:
             kinds:
               - Ingress
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/other-cel/restrict-loadbalancer/artifacthub-pkg.yml
+++ b/other-cel/restrict-loadbalancer/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Service"
-digest: 33b5031b68eb2f05d6dc535516fff514947846c6b64b1944e1546c897afae750
+digest: 2b6dd5c292505f25dd5074052ea247c8febd8686067215033097f045cf8bbe0b
 createdAt: "2024-04-17T17:49:00Z"
 

--- a/other-cel/restrict-loadbalancer/restrict-loadbalancer.yaml
+++ b/other-cel/restrict-loadbalancer/restrict-loadbalancer.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - Service
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-networkpolicy-empty-podselector/artifacthub-pkg.yml
+++ b/other-cel/restrict-networkpolicy-empty-podselector/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Other, Multi-Tenancy in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "NetworkPolicy"
-digest: 3eeb200fc6a3efbfd7855a39e6c39d4d1a9222435b02a81b871a9da523012c63
+digest: c55047723a696dfb02a59fb2d933edabdb4796436c55587588d5a9c40ee08e2c
 createdAt: "2024-04-17T17:51:58Z"
 

--- a/other-cel/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.yaml
+++ b/other-cel/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.yaml
@@ -24,6 +24,9 @@ spec:
       - resources:
           kinds:
           - NetworkPolicy
+          operations:
+          - CREATE
+          - UPDATE
     exclude:
       any:
       - resources:

--- a/other-cel/restrict-node-affinity/artifacthub-pkg.yml
+++ b/other-cel/restrict-node-affinity/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 333f074f29fd324ac79a1fc9a191d39f73cb83d8c2d17f0dbde5668f959584f3
+digest: a148811b16c64d0d77e4d14b4cc368acd90a186276801c2dc4cc7ce4f0fb9b98
 createdAt: "2024-04-18T18:08:24Z"
 

--- a/other-cel/restrict-node-affinity/restrict-node-affinity.yaml
+++ b/other-cel/restrict-node-affinity/restrict-node-affinity.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-sa-automount-sa-token/artifacthub-pkg.yml
+++ b/other-cel/restrict-sa-automount-sa-token/artifacthub-pkg.yml
@@ -27,6 +27,6 @@ annotations:
   kyverno/category: "Security in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "ServiceAccount"
-digest: 8df2f43e524f85ca4d1ba0b5034a821de452c8affb89c6177db70c53e016ad36
+digest: 3401afb861d2b9ca9d53ab5667ac1da3a32ba4af4a421accf65ed8448a63a6f2
 createdAt: "2024-04-18T18:11:04Z"
 

--- a/other-cel/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
+++ b/other-cel/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - ServiceAccount
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-secret-role-verbs/artifacthub-pkg.yml
+++ b/other-cel/restrict-secret-role-verbs/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Security in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Role, ClusterRole, RBAC"
-digest: 87450e9a836bbad32f36134630508ba015ccf9935723807e688cf1e865564163
+digest: b3da9edeb06922d1f3c79a86b009b7bb3f8f5970791fcc839569fd238dfda97b
 createdAt: "2024-04-19T16:41:34Z"
 

--- a/other-cel/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
+++ b/other-cel/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
@@ -28,6 +28,9 @@ spec:
             kinds:
               - Role
               - ClusterRole
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           variables:

--- a/other-cel/restrict-secrets-by-name/artifacthub-pkg.yml
+++ b/other-cel/restrict-secrets-by-name/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Secret"
-digest: 5ea208df44ec2a54705cc73244a374cb2593612182f9d4da8e17749e548e39ad
+digest: 3fb2e5eb878f033fab3259d89763f70cf75d6fb920fed8df25bc31152fb0bab2
 createdAt: "2024-04-20T16:40:34Z"
 

--- a/other-cel/restrict-secrets-by-name/artifacthub-pkg.yml
+++ b/other-cel/restrict-secrets-by-name/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Secret"
-digest: 3fb2e5eb878f033fab3259d89763f70cf75d6fb920fed8df25bc31152fb0bab2
+digest: 9a77d417ab9d59569a5e202ab0cdd73fc95d387b485be0003691b851e0065c50
 createdAt: "2024-04-20T16:40:34Z"
 

--- a/other-cel/restrict-secrets-by-name/restrict-secrets-by-name.yaml
+++ b/other-cel/restrict-secrets-by-name/restrict-secrets-by-name.yaml
@@ -26,6 +26,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         variables:

--- a/other-cel/restrict-secrets-by-name/restrict-secrets-by-name.yaml
+++ b/other-cel/restrict-secrets-by-name/restrict-secrets-by-name.yaml
@@ -46,6 +46,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         variables:
@@ -63,6 +66,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-service-port-range/artifacthub-pkg.yml
+++ b/other-cel/restrict-service-port-range/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Service"
-digest: 3813e2ff29ae51c28c1a9240be2893dc8a6f94e4229402012f587adbc4af7248
+digest: 76e5ca9f8c86c153ff8c31bf8dfe55ad665e0c6bbe3546c9e36edf515fee6965
 createdAt: "2024-04-19T16:44:39Z"
 

--- a/other-cel/restrict-service-port-range/restrict-service-port-range.yaml
+++ b/other-cel/restrict-service-port-range/restrict-service-port-range.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - Service
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-storageclass/artifacthub-pkg.yml
+++ b/other-cel/restrict-storageclass/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Other, Multi-Tenancy in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "StorageClass"
-digest: d210e624e126e2174723ce0b5d7426c641afe8dd45bd79e0380b98714bbb2633
+digest: 1056e484a63b688c416b32d7141a6ab9bd4d46224e9836e96ea80a584a1b0ba4
 createdAt: "2024-04-20T16:43:16Z"
 

--- a/other-cel/restrict-storageclass/restrict-storageclass.yaml
+++ b/other-cel/restrict-storageclass/restrict-storageclass.yaml
@@ -26,6 +26,9 @@ spec:
       - resources:
           kinds:
           - StorageClass
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-usergroup-fsgroup-id/artifacthub-pkg.yml
+++ b/other-cel/restrict-usergroup-fsgroup-id/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 4bc42c97f4d88453876a46d9988365409012bf1d4c864edd90cb11b3779ba2c1
+digest: b709760f5d54a7e1720885c487c7f6ba5db404e0aed99dfabdc093206b42092c
 createdAt: "2024-04-20T16:57:00Z"
 

--- a/other-cel/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml
+++ b/other-cel/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml
@@ -25,6 +25,9 @@ spec:
       - resources:
           kinds:
           - Pod
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-wildcard-resources/artifacthub-pkg.yml
+++ b/other-cel/restrict-wildcard-resources/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Security, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "ClusterRole, Role, RBAC"
-digest: 23a66b076b1ec1a18888c8eefd740e2fcbffd910a0621c0ec5bb99b056c95d6f
+digest: 02918a02f88cd193f14914db60e99be721c738789e063eeb77efe8eb80e1e30c
 createdAt: "2024-04-21T15:05:39Z"
 

--- a/other-cel/restrict-wildcard-resources/restrict-wildcard-resources.yaml
+++ b/other-cel/restrict-wildcard-resources/restrict-wildcard-resources.yaml
@@ -27,6 +27,9 @@ spec:
             kinds:
               - Role
               - ClusterRole
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/other-cel/restrict-wildcard-verbs/artifacthub-pkg.yml
+++ b/other-cel/restrict-wildcard-verbs/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Security, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Role, ClusterRole, RBAC"
-digest: 6d79620ea475c5c6568760c38ce2803679fe0cb0792a5be4acfe9cdc9c2f45bd
+digest: f94aaca4f8e88c242878b4c0ed47e5f3aaec1b1d05ffcb59b551f41a135bc7a7
 createdAt: "2024-04-21T15:09:55Z"
 

--- a/other-cel/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
+++ b/other-cel/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
@@ -27,6 +27,9 @@ spec:
             kinds:
               - Role
               - ClusterRole
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/baseline/disallow-capabilities/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-capabilities/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 6a0ace9b1f5b3f25b34117db4936ba32c4fcbbdfe3d0dba9e61b6152dede3a53
+digest: e5f9cbb8246d36347c0fe62768e6b62b6b323efb7dd1ac60bc8c220e641220fb
 createdAt: "2023-12-03T00:22:33Z"

--- a/pod-security-cel/baseline/disallow-capabilities/disallow-capabilities.yaml
+++ b/pod-security-cel/baseline/disallow-capabilities/disallow-capabilities.yaml
@@ -21,6 +21,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/baseline/disallow-host-namespaces/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-host-namespaces/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 82a3924f4d25ed9bfc8e49395c7b0e8922f5ad0573830747dd3cf96dfb93ad7a
+digest: c57ee3440401887541c2d97727fc268d5cd9eb47faf00bea2f0ca738caffe483
 createdAt: "2023-12-03T00:22:34Z"

--- a/pod-security-cel/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
+++ b/pod-security-cel/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
@@ -24,6 +24,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/baseline/disallow-host-path/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-host-path/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod,Volume"
-digest: 8f309db940eca3692840c78e2662ff0c25fa718cf0f468b58cdfd4c3d1011274
+digest: 7a78c73a64e61e91876d3ee30c99e1b39774ec885e881f4ffa0be11713710031
 createdAt: "2023-12-03T00:22:34Z"

--- a/pod-security-cel/baseline/disallow-host-path/disallow-host-path.yaml
+++ b/pod-security-cel/baseline/disallow-host-path/disallow-host-path.yaml
@@ -23,6 +23,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/baseline/disallow-host-ports-range/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-host-ports-range/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 9ea35edfd0be8b253db73ce38ff124d191df9e34f90b01c70125add602a05ff3
+digest: e48d0f138fc501b4cc8726d2bc56dae5f0230b155744ea36eb08dfd5e51d823b
 createdAt: "2023-12-03T00:22:34Z"

--- a/pod-security-cel/baseline/disallow-host-ports-range/disallow-host-ports-range.yaml
+++ b/pod-security-cel/baseline/disallow-host-ports-range/disallow-host-ports-range.yaml
@@ -24,6 +24,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/baseline/disallow-host-ports/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-host-ports/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: e5c3baa87ccb5cbbaeb6594e12e4781c8fca0d72a5a513b2a6f8efc80e00b200
+digest: b95cfe16e11be0b9507736687bd99b5ea78c455f8fc35194220326ea5ff3913c
 createdAt: "2023-12-03T00:22:34Z"

--- a/pod-security-cel/baseline/disallow-host-ports/disallow-host-ports.yaml
+++ b/pod-security-cel/baseline/disallow-host-ports/disallow-host-ports.yaml
@@ -23,6 +23,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/baseline/disallow-host-process/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-host-process/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 33a4b3765e2a54711df4379c41babb8b92f748d784bc79df049fb4fd225633a1
+digest: e95ea8d0c8cc898714ad067f421d7ba822cb29920f56c0937bd0bfdb1e95ab1e
 createdAt: "2023-12-03T00:22:34Z"

--- a/pod-security-cel/baseline/disallow-host-process/disallow-host-process.yaml
+++ b/pod-security-cel/baseline/disallow-host-process/disallow-host-process.yaml
@@ -24,6 +24,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/baseline/disallow-privileged-containers/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 92aefb85dcf369f46733d0f04d289deddee34eb5d0b46860b41de9f9eeed2805
+digest: 6ef6ef12ea3680c1d610f056ed163539debdf195bed4a3ab688599d7dfaf82e8
 createdAt: "2023-12-03T00:22:34Z"

--- a/pod-security-cel/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
+++ b/pod-security-cel/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
@@ -23,6 +23,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/baseline/disallow-proc-mount/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-proc-mount/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 32dc701fa3d0c360f9e383d7dd149c2406a5a61d3f1f43c65dc61be6623aa904
+digest: b836600d6ae7f490ba39f55df45fa599c88a5c76386ee6faf8a6609ff626179b
 createdAt: "2023-12-03T00:22:33Z"

--- a/pod-security-cel/baseline/disallow-proc-mount/disallow-proc-mount.yaml
+++ b/pod-security-cel/baseline/disallow-proc-mount/disallow-proc-mount.yaml
@@ -25,6 +25,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/baseline/disallow-selinux/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-selinux/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: fc7d48f00d32dc6b04d5ffc453c2749319154ec90ba6309ce030141c6536eb87
+digest: d842a1741805d9480e9a571a80117f4e2c6210b0d984d1c22e54545c3df9dd0d
 createdAt: "2023-12-03T00:22:33Z"

--- a/pod-security-cel/baseline/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security-cel/baseline/disallow-selinux/disallow-selinux.yaml
@@ -23,6 +23,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:
@@ -77,6 +80,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/baseline/restrict-seccomp/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/restrict-seccomp/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: d21b5941cd9dabf326d60c8b6f8ca2fbfbd0ab3358d47e87f6a0d16419cf4213
+digest: ba179d3d3d4435152b80e3aefbae44edd59b2300cd30395cde1c0a015e135f09
 createdAt: "2023-12-03T00:22:34Z"

--- a/pod-security-cel/baseline/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security-cel/baseline/restrict-seccomp/restrict-seccomp.yaml
@@ -24,6 +24,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/baseline/restrict-sysctls/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/restrict-sysctls/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: d2559783b696ce27a5b0684fd65a37cb9cef2e62c6ee39138de27283c5adbeb6
+digest: 97f75f8cdd2e3ee9f9696cdceccc34cf0df5edbca0e3bbab76572494a26ce6e8
 createdAt: "2023-12-03T00:22:33Z"

--- a/pod-security-cel/baseline/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security-cel/baseline/restrict-sysctls/restrict-sysctls.yaml
@@ -27,6 +27,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/restricted/disallow-capabilities-strict/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/disallow-capabilities-strict/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 3ba20799de8e2ff846fc1e064fac7b3e0cf318f2d127161bf9e9f90d76aff4da
+digest: 45c37cb004764c8fa03d95a018511660b1a6dc5b57752bfa8400384bf5c5037e
 createdAt: "2023-12-04T09:04:49Z"

--- a/pod-security-cel/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
+++ b/pod-security-cel/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
@@ -23,6 +23,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         message: >-
           Containers must drop `ALL` capabilities.
@@ -53,6 +56,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/restricted/disallow-privilege-escalation/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/disallow-privilege-escalation/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: a656fbec861a5420caab9ad15abf28edf45b47c6d749c3d3943223dfb4d37d7a
+digest: 6c249b689ee08cc1edcbacf7a00a35cab98d5b1b2bf3fc7ebd8a0dd1e27bb2c1
 createdAt: "2023-12-04T09:04:49Z"

--- a/pod-security-cel/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/pod-security-cel/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -23,6 +23,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/restricted/require-run-as-non-root-user/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/require-run-as-non-root-user/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 4325ec1161eb1a2eb361eaed9618b7fe4605bfa621361064a43b4f056f03da8a
+digest: 9351f7b7a1218dfad02538d36423edd15d7b567cc014833e701d0b1e771f1db1
 createdAt: "2023-12-04T09:04:49Z"

--- a/pod-security-cel/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml
+++ b/pod-security-cel/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml
@@ -23,6 +23,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/restricted/require-run-as-nonroot/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/require-run-as-nonroot/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: e5da00b527052b933dd6e95a5e0cc52c857dad54130cbcc8022ccde1b526fb71
+digest: 91161d7046bc3d1900363fa4f44ab06c5be6aad62f6194f6635d5a7585c0dec7
 createdAt: "2023-12-04T09:04:49Z"

--- a/pod-security-cel/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/pod-security-cel/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -23,6 +23,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/restricted/restrict-seccomp-strict/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/restrict-seccomp-strict/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 4deffb0a892939288dabf65e9af18732036a464ae3611028a96ae02215140e77
+digest: d31a60d3f693829fa8a17272e9f0e4d7cbbe2773a7e1a282bfc426dbe2e17e9e
 createdAt: "2023-12-04T09:04:49Z"

--- a/pod-security-cel/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
+++ b/pod-security-cel/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
@@ -26,6 +26,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel:
           expressions:

--- a/pod-security-cel/restricted/restrict-volume-types/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/restrict-volume-types/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod,Volume"
-digest: d5e29d1e422d57878e74db9bc93f8db1588c6dbb777e13a02d873952a5134d59
+digest: 0b2ded796c6a4ad41059c39be548ec980c64c2adde87119a9290d26ada5628f9
 createdAt: "2024-01-02T15:37:55Z"

--- a/pod-security-cel/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security-cel/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -24,6 +24,9 @@ spec:
         - resources:
             kinds:
               - Pod
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         cel: 
           expressions:


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
PR kyverno/kyverno#10611 causes CEL policies without `operations` field to be enforced when resources are deleted. Therefore, we need to explicitly specify the `CREATE` and `UPDATE` operations. This PR will fix the chainsaw tests for the CEL policies that are currently failing.
<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
