### PR TITLE
[Chainsaw Tests] Add Chainsaw Test for Pod Security Disallow ProcMount Cluster Policy

### DIFF
--- a/pod-security/baseline/disallow-proc-mount/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/pod-security/baseline/disallow-proc-mount/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-proc-mount
+status:
+  ready: true

--- a/pod-security/baseline/disallow-proc-mount/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security/baseline/disallow-proc-mount/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,38 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: disallow-proc-mount
+spec:
+  steps:
+  - name: step-01
+    try:
+      - apply:
+          file: ../disallow-proc-mount.yaml
+      - patch:
+          resource:
+            apiVersion: kyverno.io/v1
+            kind: ClusterPolicy
+            metadata:
+              name: disallow-proc-mount
+            spec:
+              validationFailureAction: Enforce
+      - assert:
+          file: chainsaw-step-01-assert-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: valid-pod.yaml
+  - name: step-03
+    try:
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: invalid-pod-containers.yaml
+  - name: step-04
+    try:
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: invalid-pod-initcontainers.yaml

--- a/pod-security/baseline/disallow-proc-mount/.chainsaw-test/invalid-pod-containers.yaml
+++ b/pod-security/baseline/disallow-proc-mount/.chainsaw-test/invalid-pod-containers.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: invalid-pod-containers
+spec:
+  containers:
+    - name: invalid-container
+      image: nginx:1.14.1
+      securityContext:
+        procMount: Unmasked
+  initContainers:
+    - name: valid-init-container
+      image: busybox:1.35
+      securityContext:
+        procMount: Default

--- a/pod-security/baseline/disallow-proc-mount/.chainsaw-test/invalid-pod-initcontainers.yaml
+++ b/pod-security/baseline/disallow-proc-mount/.chainsaw-test/invalid-pod-initcontainers.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: invalid-pod-initcontainers
+spec:
+  containers:
+    - name: valid-container
+      image: nginx:1.14.1
+      securityContext:
+        procMount: Default
+  initContainers:
+    - name: invalid-init-container
+      image: busybox:1.35
+      securityContext:
+        procMount: Unmasked

--- a/pod-security/baseline/disallow-proc-mount/.chainsaw-test/valid-pod.yaml
+++ b/pod-security/baseline/disallow-proc-mount/.chainsaw-test/valid-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: valid-pod
+spec:
+  containers:
+    - name: valid-container
+      image: nginx:1.14.1
+      securityContext:
+        procMount: Default
+  initContainers:
+    - name: valid-init-container
+      image: busybox:1.35
+      securityContext:
+        procMount: Default


### PR DESCRIPTION
## Related Issue(s)

Partial Fix for Issue #950

## Description

Chainsaw test the [disallow-proc-mount.yaml](https://github.com/kyverno/policies/blob/main/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.yaml) Cluster Policy with valid and invalid containers & init containers as test manifests.

## Additional Context

Kubernetes Pod Security Standards Docs:
https://kubernetes.io/docs/concepts/security/pod-security-standards/

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [ ] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.