### PR TITLE
added policy to replace nodeSelector

### DIFF
--- a/other/replace-nodeSelector/.chainsaw-test/chainsaw-test.yaml
+++ b/other/replace-nodeSelector/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: replace-nodeselector
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../replace-nodeselector.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: podcontroller-resources.yaml
+    - apply:
+        file: pod-resources.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: podcontroller-patched.yaml
+    - assert:
+        file: pod-resources-patched.yaml

--- a/other/replace-nodeSelector/.chainsaw-test/pod-resources-patched.yaml
+++ b/other/replace-nodeSelector/.chainsaw-test/pod-resources-patched.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod01
+spec:
+  nodeSelector:
+    node.kubernetes.io/worker-abc: ""
+  containers:
+  - name: bb
+    image: busybox:1.35

--- a/other/replace-nodeSelector/.chainsaw-test/pod-resources.yaml
+++ b/other/replace-nodeSelector/.chainsaw-test/pod-resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod01
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker-abc: ""
+  containers:
+  - name: bb
+    image: busybox:1.35

--- a/other/replace-nodeSelector/.chainsaw-test/podcontroller-patched.yaml
+++ b/other/replace-nodeSelector/.chainsaw-test/podcontroller-patched.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: deployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      nodeSelector:
+        node.kubernetes.io/worker-abc: ""
+      containers:
+      - name: bb
+        image: busybox:1.35

--- a/other/replace-nodeSelector/.chainsaw-test/podcontroller-resources.yaml
+++ b/other/replace-nodeSelector/.chainsaw-test/podcontroller-resources.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: deployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker-abc: ""
+      containers:
+      - name: bb
+        image: busybox:1.35

--- a/other/replace-nodeSelector/.chainsaw-test/policy-ready.yaml
+++ b/other/replace-nodeSelector/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: replace-nodeselector
+status:
+  ready: true

--- a/other/replace-nodeSelector/artifacthub-pkg.yml
+++ b/other/replace-nodeSelector/artifacthub-pkg.yml
@@ -1,0 +1,20 @@
+name: replace-nodeselector
+version: 1.0.0
+displayName: Replace nodeSelector
+description: >-
+  The nodeSelector field, which uses labels to select the node for Pod scheduling based on specific needs, is updated by this policy to replace the label node-role.kubernetes.io/worker-abc with node.kubernetes.io/worker-abc in the Pod spec.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/replace-nodeSelector/replace-nodeselector.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+readme: |
+  The nodeSelector field, which uses labels to select the node for Pod scheduling based on specific needs, is updated by this policy to replace the label node-role.kubernetes.io/worker-abc with node.kubernetes.io/worker-abc in the Pod spec.
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.27"
+  kyverno/subject: "Pod"
+digest: a30803d42ad05cb09eb3fd4e90be391153c4b61a9bfd806978279cd6df2d8c86

--- a/other/replace-nodeSelector/artifacthub-pkg.yml
+++ b/other/replace-nodeSelector/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.27"
   kyverno/subject: "Pod"
-digest: a30803d42ad05cb09eb3fd4e90be391153c4b61a9bfd806978279cd6df2d8c86
+digest: 75bf40deee3885f522b3fd45b5e961e6709b94915e4a87fbc45f781c11cea327

--- a/other/replace-nodeSelector/artifacthub-pkg.yml
+++ b/other/replace-nodeSelector/artifacthub-pkg.yml
@@ -1,6 +1,7 @@
 name: replace-nodeselector
 version: 1.0.0
 displayName: Replace nodeSelector
+createdAt: "2024-07-10T07:30:13.000Z"
 description: >-
   The nodeSelector field, which uses labels to select the node for Pod scheduling based on specific needs, is updated by this policy to replace the label node-role.kubernetes.io/worker-abc with node.kubernetes.io/worker-abc in the Pod spec.
 install: |-

--- a/other/replace-nodeSelector/replace-nodeselector.yaml
+++ b/other/replace-nodeSelector/replace-nodeselector.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: replace-nodeselector
+  annotations:
+    policies.kyverno.io/title: Replace nodeSelector
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.11.1
+    policies.kyverno.io/minversion: 1.9.0
+    kyverno.io/kubernetes-version: "1.27"
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The nodeSelector field, which uses labels to select the node for Pod scheduling based on specific needs, is updated by this policy to replace the label node-role.kubernetes.io/worker-abc with node.kubernetes.io/worker-abc in the Pod spec.
+spec:
+  rules:
+  - name: replace-nodeselector
+    match:
+      resources:
+        kinds:
+        - Pod
+    #Removes the old node selector (node-role.kubernetes.io/worker-abc) by setting its value to null.
+    mutate:
+      patchStrategicMerge:
+        spec:
+          nodeSelector:
+            node.kubernetes.io/worker-abc: ""
+            node-role.kubernetes.io/worker-abc: null


### PR DESCRIPTION
## Description
The nodeSelector field, which uses labels to select the node for Pod scheduling based on specific needs, is updated by this policy to replace the label node-role.kubernetes.io/worker-abc with node.kubernetes.io/worker-abc in the Pod spec.

## Checklist
- [] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
