### PR TITLE
Remove hardcoded test namespace from restrict-volume-types tests

### DIFF
--- a/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/chainsaw-test.yaml
@@ -11,8 +11,6 @@ spec:
   - name: step-01
     try:
     - apply:
-        file: ns.yaml
-    - apply:
         file: ../restrict-volume-types.yaml
     - patch:
         resource:
@@ -43,5 +41,8 @@ spec:
   - name: step-99
     try:
     - script:
-        content: kubectl delete all --all --force --grace-period=0 -n restrict-voltypes-ns
+        env:
+        - name: NAMESPACE
+          value: $namespace
+        content: kubectl delete all --all --force --grace-period=0 -n $NAMESPACE
 

--- a/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/ns.yaml
+++ b/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/ns.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: restrict-voltypes-ns

--- a/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/pod-good.yaml
+++ b/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/pod-good.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod01
 spec:
   containers:
@@ -11,7 +10,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod02
 spec:
   containers:
@@ -27,7 +25,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod03
 spec:
   containers:
@@ -44,7 +41,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod04
 spec:
   containers:
@@ -63,7 +59,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod05
   labels:
     foo: bar
@@ -85,7 +80,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod06
 spec:
   containers:
@@ -111,7 +105,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod07
 spec:
   containers:
@@ -129,7 +122,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod08
 spec:
   containers:
@@ -150,7 +142,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod09
 spec:
   containers:

--- a/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/podcontroller-good.yaml
+++ b/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/podcontroller-good.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment01
 spec:
   replicas: 1
@@ -20,7 +19,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment02
 spec:
   replicas: 1
@@ -45,7 +43,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment05
 spec:
   replicas: 1
@@ -75,7 +72,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment06
 spec:
   replicas: 1
@@ -110,7 +106,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment07
 spec:
   replicas: 1
@@ -137,7 +132,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment08
 spec:
   replicas: 1
@@ -167,7 +161,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob01
 spec:
   schedule: "*/1 * * * *"
@@ -183,7 +176,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob02
 spec:
   schedule: "*/1 * * * *"
@@ -205,7 +197,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob03
 spec:
   schedule: "*/1 * * * *"
@@ -228,7 +219,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob04
 spec:
   schedule: "*/1 * * * *"
@@ -253,7 +243,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob05
 spec:
   schedule: "*/1 * * * *"
@@ -282,7 +271,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob06
 spec:
   schedule: "*/1 * * * *"
@@ -314,7 +302,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob07
 spec:
   schedule: "*/1 * * * *"
@@ -338,7 +325,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob08
 spec:
   schedule: "*/1 * * * *"
@@ -365,7 +351,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob09
 spec:
   schedule: "*/1 * * * *"

--- a/pod-security/restricted/restrict-volume-types/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security/restricted/restrict-volume-types/.chainsaw-test/chainsaw-test.yaml
@@ -9,8 +9,6 @@ spec:
   - name: step-01
     try:
     - apply:
-        file: ns.yaml
-    - apply:
         file: ../restrict-volume-types.yaml
     - patch:
         resource:
@@ -41,5 +39,8 @@ spec:
   - name: step-99
     try:
     - script:
-        content: kubectl delete all --all --force --grace-period=0 -n restrict-voltypes-ns
+        env:
+        - name: NAMESPACE
+          value: $namespace
+        content: kubectl delete all --all --force --grace-period=0 -n $NAMESPACE
 

--- a/pod-security/restricted/restrict-volume-types/.chainsaw-test/ns.yaml
+++ b/pod-security/restricted/restrict-volume-types/.chainsaw-test/ns.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: restrict-voltypes-ns

--- a/pod-security/restricted/restrict-volume-types/.chainsaw-test/pod-good.yaml
+++ b/pod-security/restricted/restrict-volume-types/.chainsaw-test/pod-good.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod01
 spec:
   containers:
@@ -11,7 +10,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod02
 spec:
   containers:
@@ -27,7 +25,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod03
 spec:
   containers:
@@ -44,7 +41,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod04
 spec:
   containers:
@@ -63,7 +59,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod05
   labels:
     foo: bar
@@ -85,7 +80,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod06
 spec:
   containers:
@@ -111,7 +105,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod07
 spec:
   containers:
@@ -129,7 +122,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod08
 spec:
   containers:
@@ -150,7 +142,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodpod09
 spec:
   containers:

--- a/pod-security/restricted/restrict-volume-types/.chainsaw-test/podcontroller-good.yaml
+++ b/pod-security/restricted/restrict-volume-types/.chainsaw-test/podcontroller-good.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment01
 spec:
   replicas: 1
@@ -20,7 +19,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment02
 spec:
   replicas: 1
@@ -45,7 +43,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment05
 spec:
   replicas: 1
@@ -75,7 +72,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment06
 spec:
   replicas: 1
@@ -110,7 +106,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment07
 spec:
   replicas: 1
@@ -137,7 +132,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: restrict-voltypes-ns
   name: gooddeployment08
 spec:
   replicas: 1
@@ -167,7 +161,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob01
 spec:
   schedule: "*/1 * * * *"
@@ -183,7 +176,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob02
 spec:
   schedule: "*/1 * * * *"
@@ -205,7 +197,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob03
 spec:
   schedule: "*/1 * * * *"
@@ -228,7 +219,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob04
 spec:
   schedule: "*/1 * * * *"
@@ -253,7 +243,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob05
 spec:
   schedule: "*/1 * * * *"
@@ -282,7 +271,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob06
 spec:
   schedule: "*/1 * * * *"
@@ -314,7 +302,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob07
 spec:
   schedule: "*/1 * * * *"
@@ -338,7 +325,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob08
 spec:
   schedule: "*/1 * * * *"
@@ -365,7 +351,6 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  namespace: restrict-voltypes-ns
   name: goodcronjob09
 spec:
   schedule: "*/1 * * * *"


### PR DESCRIPTION
## Description

pod-secuity policies used to hardcode the test namespace as restrict-voltypes-ns to be able to properly delete test resources. This change removes the need to hardcode the namespace name by using the build in namespace binding.

## Checklist
- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
  - not applicable
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
  - not applicable