### PR TITLE
Update disallow-helm-tiller and disallow-latest-tag to include all container types in a pod

### DIFF
--- a/best-practices/disallow-helm-tiller/.chainsaw-test/bad-deploy.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/bad-deploy.yaml
@@ -21,6 +21,6 @@ spec:
         name: helm-tiller
       initContainers:
       - image: busybox
-        name: busybox
+        name: busyboxinit
       - image: docker.io/tiller:latest
-        name: helm-tiller
+        name: helm-tillerinit

--- a/best-practices/disallow-helm-tiller/.chainsaw-test/bad-deploy.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/bad-deploy.yaml
@@ -19,3 +19,8 @@ spec:
         name: busybox
       - image: docker.io/tiller:latest
         name: helm-tiller
+      initContainers:
+      - image: busybox
+        name: busybox
+      - image: docker.io/tiller:latest
+        name: helm-tiller

--- a/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod-fail-first.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod-fail-first.yaml
@@ -8,3 +8,8 @@ spec:
     image: docker.io/tiller:latest
   - name: somebox
     image: busybox:1.35
+  initContainers:
+  - name: helm-tiller
+    image: docker.io/tiller:latest
+  - name: somebox
+    image: busybox:1.35

--- a/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod-fail-first.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod-fail-first.yaml
@@ -9,7 +9,7 @@ spec:
   - name: somebox
     image: busybox:1.35
   initContainers:
-  - name: helm-tiller
+  - name: helm-tillerinit
     image: docker.io/tiller:latest
-  - name: somebox
+  - name: someboxinit
     image: busybox:1.35

--- a/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod-success-first.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod-success-first.yaml
@@ -8,3 +8,8 @@ spec:
     image: busybox:1.35
   - name: helm-tiller
     image: docker.io/tiller:latest
+  initContainers:
+  - name: somebox
+    image: busybox:1.35
+  - name: helm-tiller
+    image: docker.io/tiller:latest

--- a/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod-success-first.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod-success-first.yaml
@@ -9,7 +9,7 @@ spec:
   - name: helm-tiller
     image: docker.io/tiller:latest
   initContainers:
-  - name: somebox
+  - name: someboxinit
     image: busybox:1.35
-  - name: helm-tiller
+  - name: helm-tillerinit
     image: docker.io/tiller:latest

--- a/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod.yaml
@@ -7,5 +7,5 @@ spec:
   - name: helm-tiller
     image: docker.io/tiller:latest
   initContainers:
-  - name: helm-tiller
+  - name: helm-tillerinit
     image: docker.io/tiller:latest

--- a/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/bad-pod.yaml
@@ -6,3 +6,6 @@ spec:
   containers:
   - name: helm-tiller
     image: docker.io/tiller:latest
+  initContainers:
+  - name: helm-tiller
+    image: docker.io/tiller:latest

--- a/best-practices/disallow-helm-tiller/.chainsaw-test/good-deploy.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/good-deploy.yaml
@@ -20,5 +20,5 @@ spec:
         command: ["sleep", "3600"]
       initContainers:
       - image: busybox:v1.35
-        name: busybox
+        name: busyboxinit
         command: ["sleep", "3600"]

--- a/best-practices/disallow-helm-tiller/.chainsaw-test/good-deploy.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/good-deploy.yaml
@@ -18,3 +18,7 @@ spec:
       - image: busybox:v1.35
         name: busybox
         command: ["sleep", "3600"]
+      initContainers:
+      - image: busybox:v1.35
+        name: busybox
+        command: ["sleep", "3600"]

--- a/best-practices/disallow-helm-tiller/.chainsaw-test/good-pod.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/good-pod.yaml
@@ -9,7 +9,7 @@ spec:
   - name: nothelmbox
     image: busybox:v1.35
   initContainers:
-  - name: busybox
+  - name: busyboxinit
     image: busybox:v1.35
-  - name: nothelmbox
+  - name: nothelmboxinit
     image: busybox:v1.35

--- a/best-practices/disallow-helm-tiller/.chainsaw-test/good-pod.yaml
+++ b/best-practices/disallow-helm-tiller/.chainsaw-test/good-pod.yaml
@@ -8,3 +8,8 @@ spec:
     image: busybox:v1.35
   - name: nothelmbox
     image: busybox:v1.35
+  initContainers:
+  - name: busybox
+    image: busybox:v1.35
+  - name: nothelmbox
+    image: busybox:v1.35

--- a/best-practices/disallow-helm-tiller/.kyverno-test/resource.yaml
+++ b/best-practices/disallow-helm-tiller/.kyverno-test/resource.yaml
@@ -6,6 +6,10 @@ spec:
   containers:
   - name: helm-tiller
     image: docker.io/tiller:latest
+  initContainers:
+  - name: helm-tillerinit
+    image: docker.io/tiller:latest
+    
 ---
 apiVersion: v1
 kind: Pod
@@ -17,6 +21,11 @@ spec:
     image: busybox:1.28
   - name: helm-tiller
     image: docker.io/tiller:latest
+  initContainers:
+  - name: busyboxinit
+    image: busybox:1.28
+  - name: helm-tillerinit
+    image: docker.io/tiller:latest
 ---
 apiVersion: v1
 kind: Pod
@@ -25,6 +34,9 @@ metadata:
 spec:
   containers:
   - name: busybox
+    image: busybox
+  initContainers:
+  - name: busyboxinit
     image: busybox
 ---
 apiVersion: v1
@@ -36,6 +48,11 @@ spec:
   - name: busybox
     image: busybox
   - name: nginx
+    image: nginx
+  initContainers:
+  - name: busyboxinit
+    image: busybox
+  - name: nginxinit
     image: nginx
 ---
 apiVersion: apps/v1
@@ -59,6 +76,10 @@ spec:
       - image: busybox:1.28
         name: busybox
         command: ["sleep", "9999"]
+      initContainers:
+      - image: busybox:1.28
+        name: busyboxinit
+        command: ["sleep", "9999"]
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -80,3 +101,6 @@ spec:
       containers:
       - image: docker.io/tiller:latest
         name: helm-tiller
+      initContainers:
+      - image: docker.io/tiller:latest
+        name: helm-tillerinit

--- a/best-practices/disallow-helm-tiller/artifacthub-pkg.yml
+++ b/best-practices/disallow-helm-tiller/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: 6de64a4a8d611c250dc0190b28b6c757db531063161531e4f68202c0fbda5be4
+digest: 31126cee424a796fe9a4078d879a2d650fa6a3efc267d714a90a54604d91a9de

--- a/best-practices/disallow-helm-tiller/artifacthub-pkg.yml
+++ b/best-practices/disallow-helm-tiller/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: 31126cee424a796fe9a4078d879a2d650fa6a3efc267d714a90a54604d91a9de
+digest: 3d92f3a2949283ad6d9baa99565e407c5cd78d015e0220750de522ac40ce1de2

--- a/best-practices/disallow-helm-tiller/disallow-helm-tiller.yaml
+++ b/best-practices/disallow-helm-tiller/disallow-helm-tiller.yaml
@@ -11,7 +11,7 @@ metadata:
     policies.kyverno.io/description: >-
       Tiller, found in Helm v2, has known security challenges. It requires administrative privileges and acts as a shared
       resource accessible to any authenticated user. Tiller can lead to privilege escalation as
-      restricted users can impact other users. It is recommend to use Helm v3+ which does not contain
+      restricted users can impact other users. It is recommended to use Helm v3+ which does not contain
       Tiller for these reasons. This policy validates that there is not an image
       containing the name `tiller`.
 spec:
@@ -26,8 +26,13 @@ spec:
               - Pod
       validate:
         message: "Helm Tiller is not allowed"
-        pattern:
-          spec:
-            containers:
-              - name: "*"
-                image: "!*tiller*"
+        foreach:
+        - list: "request.object.spec.initContainers"
+          pattern:
+            image: "!*tiller*"
+        - list: "request.object.spec.initContainers"
+          pattern:
+            image: "!*tiller*"
+        - list: "request.object.spec.ephemeralContainers"
+          pattern:
+            image: "!*tiller*"

--- a/best-practices/disallow-helm-tiller/disallow-helm-tiller.yaml
+++ b/best-practices/disallow-helm-tiller/disallow-helm-tiller.yaml
@@ -27,7 +27,7 @@ spec:
       validate:
         message: "Helm Tiller is not allowed"
         foreach:
-        - list: "request.object.spec.initContainers"
+        - list: "request.object.spec.containers"
           pattern:
             image: "!*tiller*"
         - list: "request.object.spec.initContainers"

--- a/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-latest-fail-first.yaml
+++ b/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-latest-fail-first.yaml
@@ -8,3 +8,8 @@ spec:
     image: busybox:latest
   - name: nginx
     image: nginx:1.35
+  initContainers:
+  - name: busybox
+    image: busybox:latest
+  - name: nginx
+    image: nginx:1.35

--- a/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-latest-fail-first.yaml
+++ b/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-latest-fail-first.yaml
@@ -9,7 +9,7 @@ spec:
   - name: nginx
     image: nginx:1.35
   initContainers:
-  - name: busybox
+  - name: busyboxinit
     image: busybox:latest
-  - name: nginx
+  - name: nginxinit
     image: nginx:1.35

--- a/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-latest-success-first.yaml
+++ b/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-latest-success-first.yaml
@@ -9,7 +9,7 @@ spec:
   - name: busybox
     image: busybox:latest
   initContainers:
-  - name: nginx
+  - name: nginxinit
     image: nginx:1.35
-  - name: busybox
+  - name: busyboxinit
     image: busybox:latest

--- a/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-latest-success-first.yaml
+++ b/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-latest-success-first.yaml
@@ -8,3 +8,8 @@ spec:
     image: nginx:1.35
   - name: busybox
     image: busybox:latest
+  initContainers:
+  - name: nginx
+    image: nginx:1.35
+  - name: busybox
+    image: busybox:latest

--- a/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-no-tag.yaml
+++ b/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-no-tag.yaml
@@ -9,9 +9,9 @@ spec:
   - name: nginx
     image: nginx:1.35
   initContainers:
-  - name: busybox
+  - name: busyboxinit
     image: busybox
-  - name: nginx
+  - name: nginxinit
     image: nginx:1.35
 ---
 apiVersion: v1
@@ -25,9 +25,9 @@ spec:
   - name: busybox
     image: busybox
   initContainers:
-  - name: nginx
+  - name: nginxinit
     image: nginx:1.35
-  - name: busybox
+  - name: busyboxinit
     image: busybox
 ---
 apiVersion: v1
@@ -41,7 +41,7 @@ spec:
   - name: nginx
     image: nginx:latest
   initContainers:
-  - name: busybox
+  - name: busyboxinit
     image: busybox
-  - name: nginx
+  - name: nginxinit
     image: nginx:latest

--- a/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-no-tag.yaml
+++ b/best-practices/disallow-latest-tag/.chainsaw-test/bad-pod-no-tag.yaml
@@ -8,6 +8,11 @@ spec:
     image: busybox
   - name: nginx
     image: nginx:1.35
+  initContainers:
+  - name: busybox
+    image: busybox
+  - name: nginx
+    image: nginx:1.35
 ---
 apiVersion: v1
 kind: Pod
@@ -19,6 +24,11 @@ spec:
     image: nginx:1.35
   - name: busybox
     image: busybox
+  initContainers:
+  - name: nginx
+    image: nginx:1.35
+  - name: busybox
+    image: busybox
 ---
 apiVersion: v1
 kind: Pod
@@ -26,6 +36,11 @@ metadata:
   name: badpod-no-tag
 spec:
   containers:
+  - name: busybox
+    image: busybox
+  - name: nginx
+    image: nginx:latest
+  initContainers:
   - name: busybox
     image: busybox
   - name: nginx

--- a/best-practices/disallow-latest-tag/.chainsaw-test/good-pod.yaml
+++ b/best-practices/disallow-latest-tag/.chainsaw-test/good-pod.yaml
@@ -6,3 +6,6 @@ spec:
   containers:
   - name: busybox
     image: busybox:v1.35
+  initContainers:
+  - name: busybox
+    image: busybox:v1.35

--- a/best-practices/disallow-latest-tag/.chainsaw-test/good-pod.yaml
+++ b/best-practices/disallow-latest-tag/.chainsaw-test/good-pod.yaml
@@ -7,5 +7,5 @@ spec:
   - name: busybox
     image: busybox:v1.35
   initContainers:
-  - name: busybox
+  - name: busyboxinit
     image: busybox:v1.35

--- a/best-practices/disallow-latest-tag/.kyverno-test/resource.yaml
+++ b/best-practices/disallow-latest-tag/.kyverno-test/resource.yaml
@@ -8,6 +8,9 @@ spec:
   containers:
   - name: nginx
     image: nginx:1.12
+  initContainers:
+  - name: nginxinit
+    image: nginx:1.12
 ---
 apiVersion: v1
 kind: Pod
@@ -18,6 +21,9 @@ metadata:
 spec:
   containers:
   - name: nginx
+    image: nginx
+  initContainers:
+  - name: nginxinit
     image: nginx
 ---
 apiVersion: v1
@@ -32,6 +38,11 @@ spec:
     image: busybox:1.28
   - name: nginx
     image: nginx
+  initContainers:
+  - name: busyboxinit
+    image: busybox:1.28
+  - name: nginxinit
+    image: nginx
 ---
 apiVersion: v1
 kind: Pod
@@ -42,6 +53,9 @@ metadata:
 spec:
   containers:
   - name: nginx
+    image: nginx:latest
+  initContainers:
+  - name: nginxinit
     image: nginx:latest
 ---
 apiVersion: v1
@@ -55,6 +69,11 @@ spec:
   - name: busybox
     image: busybox:1.28
   - name: nginx
+    image: nginx:latest
+  initContainers:
+  - name: busyboxinit
+    image: busybox:1.28
+  - name: nginxinit
     image: nginx:latest
 ---
 apiVersion: apps/v1
@@ -77,6 +96,10 @@ spec:
       - image: busybox:1.28
         name: busybox
         command: ["sleep", "9999"]
+      initContainers:
+      - image: busybox:1.28
+        name: busyboxinit
+        command: ["sleep", "9999"]
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -98,6 +121,10 @@ spec:
       - image: busybox
         name: busybox
         command: ["sleep", "9999"]
+      initContainers:
+      - image: busybox
+        name: busyboxinit
+        command: ["sleep", "9999"]
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -118,4 +145,8 @@ spec:
       containers:
       - image: busybox:latest
         name: busybox
+        command: ["sleep", "9999"]
+      initContainers:
+      - image: busybox:latest
+        name: busyboxinit
         command: ["sleep", "9999"]

--- a/best-practices/disallow-latest-tag/artifacthub-pkg.yml
+++ b/best-practices/disallow-latest-tag/artifacthub-pkg.yml
@@ -1,6 +1,6 @@
 name: disallow-latest-tag
 version: 1.0.0
-displayName: Disallow Latest Tag
+displayName: Disallow Latest Tags
 createdAt: "2023-04-10T19:47:15.000Z"
 description: >-
   The ':latest' tag is mutable and can lead to unexpected errors if the image changes. A best practice is to use an immutable tag that maps to a specific version of an application Pod. This policy validates that the image specifies a tag and that it is not called `latest`.

--- a/best-practices/disallow-latest-tag/artifacthub-pkg.yml
+++ b/best-practices/disallow-latest-tag/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Best Practices"
   kyverno/subject: "Pod"
-digest: 3e299e0f018ff57ee78cfff4119df58d72e11669908eff9dfe8294f3be7a6e60
+digest: 2760272e57d9988ba447f62d23bba382092d00a5e14dbf00555e4170ea90593a

--- a/best-practices/disallow-latest-tag/artifacthub-pkg.yml
+++ b/best-practices/disallow-latest-tag/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Best Practices"
   kyverno/subject: "Pod"
-digest: 3d19e0d8f2637eca9ad1d700f4fbf556aaa31221ff6c40698b9aadda1f41adb4
+digest: 3e299e0f018ff57ee78cfff4119df58d72e11669908eff9dfe8294f3be7a6e60

--- a/best-practices/disallow-latest-tag/artifacthub-pkg.yml
+++ b/best-practices/disallow-latest-tag/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Best Practices"
   kyverno/subject: "Pod"
-digest: 2760272e57d9988ba447f62d23bba382092d00a5e14dbf00555e4170ea90593a
+digest: 3d19e0d8f2637eca9ad1d700f4fbf556aaa31221ff6c40698b9aadda1f41adb4

--- a/best-practices/disallow-latest-tag/disallow-latest-tag.yaml
+++ b/best-practices/disallow-latest-tag/disallow-latest-tag.yaml
@@ -25,10 +25,16 @@ spec:
           - Pod
     validate:
       message: "An image tag is required."
-      pattern:
-        spec:
-          containers:
-          - image: "*:*"
+      foreach:
+        - list: "request.object.spec.initContainers"
+          pattern:
+            image: "*:*"
+        - list: "request.object.spec.initContainers"
+          pattern:
+            image: "*:*"
+        - list: "request.object.spec.ephemeralContainers"
+          pattern:
+            image: "*:*"
   - name: validate-image-tag
     match:
       any:
@@ -37,7 +43,13 @@ spec:
           - Pod
     validate:
       message: "Using a mutable image tag e.g. 'latest' is not allowed."
-      pattern:
-        spec:
-          containers:
-          - image: "!*:latest"
+      foreach:
+        - list: "request.object.spec.initContainers"
+          pattern:
+            image: "!*:latest"
+        - list: "request.object.spec.initContainers"
+          pattern:
+            image: "!*:latest"
+        - list: "request.object.spec.ephemeralContainers"
+          pattern:
+            image: "!*:latest"

--- a/best-practices/disallow-latest-tag/disallow-latest-tag.yaml
+++ b/best-practices/disallow-latest-tag/disallow-latest-tag.yaml
@@ -26,7 +26,7 @@ spec:
     validate:
       message: "An image tag is required."
       foreach:
-        - list: "request.object.spec.initContainers"
+        - list: "request.object.spec.containers"
           pattern:
             image: "*:*"
         - list: "request.object.spec.initContainers"
@@ -44,7 +44,7 @@ spec:
     validate:
       message: "Using a mutable image tag e.g. 'latest' is not allowed."
       foreach:
-        - list: "request.object.spec.initContainers"
+        - list: "request.object.spec.containers"
           pattern:
             image: "!*:latest"
         - list: "request.object.spec.initContainers"


### PR DESCRIPTION
## Related Issue(s)

Partially addresses #951

## Description

Updating disallow-helm-tiller and disallow-latest-tag policies to handle all pod types and  test cases to handle initContainers. 

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
