### PR TITLE
enhancement: use optionals in CEL policies to remove redundant expressions

### DIFF
--- a/argo-cel/application-prevent-default-project/application-prevent-default-project.yaml
+++ b/argo-cel/application-prevent-default-project/application-prevent-default-project.yaml
@@ -28,6 +28,6 @@ spec:
       validate:
         cel:
           expressions:
-            - expression: "has(object.spec.project) && object.spec.project != 'default'"
+            - expression: "object.spec.?project.orValue('') != 'default'"
               message: "The default project may not be used in an Application."
 

--- a/argo-cel/application-prevent-default-project/artifacthub-pkg.yml
+++ b/argo-cel/application-prevent-default-project/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Argo in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Application"
-digest: aeb2bc00375b7c44bb36ca7a3cd2f5f80ed17548abf98529d4617803be71196d
+digest: 30a66468036d5a7d5f63e5581d7a4dbb33f6d93ecdfca566f9a465b11d441acb
 createdAt: "2024-04-30T16:03:57Z"
 

--- a/aws-cel/require-encryption-aws-loadbalancers/artifacthub-pkg.yml
+++ b/aws-cel/require-encryption-aws-loadbalancers/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "AWS, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Service"
-digest: 0a2c4fcb1a4aa5900aef0abba83625024def643c47ccfe1c6e0d1314c484f6f5
+digest: e2320be39a69521f5420e33890a87b1195a3658022e1e23909387e9dc0937c2e
 createdAt: "2024-05-11T16:01:13Z"
 

--- a/aws-cel/require-encryption-aws-loadbalancers/require-encryption-aws-loadbalancers.yaml
+++ b/aws-cel/require-encryption-aws-loadbalancers/require-encryption-aws-loadbalancers.yaml
@@ -34,7 +34,6 @@ spec:
       cel:
         expressions:
           - expression: >-
-              has(object.metadata.annotations) && 
-              'service.beta.kubernetes.io/aws-load-balancer-ssl-cert' in object.metadata.annotations && object.metadata.annotations['service.beta.kubernetes.io/aws-load-balancer-ssl-cert'] != ''
+              object.metadata.?annotations[?'service.beta.kubernetes.io/aws-load-balancer-ssl-cert'].orValue('') != ''
             message: "Service of type LoadBalancer must carry the annotation service.beta.kubernetes.io/aws-load-balancer-ssl-cert."
 

--- a/best-practices-cel/disallow-empty-ingress-host/artifacthub-pkg.yml
+++ b/best-practices-cel/disallow-empty-ingress-host/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: 0ffe2735a10b721569cf7139d0d7d51dbc9327beae68e50e4f54f560804548e9
+digest: e07447adca26bd41cf44f7cced9f50fef4d6293d142a5092d0a95f4473747043
 createdAt: "2024-03-09T14:19:51Z"
 

--- a/best-practices-cel/disallow-empty-ingress-host/disallow-empty-ingress-host.yaml
+++ b/best-practices-cel/disallow-empty-ingress-host/disallow-empty-ingress-host.yaml
@@ -30,7 +30,6 @@ spec:
         cel:
           expressions:
             - expression: >-
-                !has(object.spec.rules) || 
-                object.spec.rules.all(rule, has(rule.host) && has(rule.http))
+                object.spec.?rules.orValue([]).all(rule, has(rule.host) && has(rule.http))
               message: "The Ingress host name must be defined, not empty."
         

--- a/best-practices-cel/require-drop-all/artifacthub-pkg.yml
+++ b/best-practices-cel/require-drop-all/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: c3d8959bdc68460e21ff5495994d0bb1a3aa7cb7a5b31740af33638b2dad466c
+digest: e30e0e6e98ad92017d641eddc650335cb688873b2c14c666fda925f3e809ae40
 createdAt: "2024-03-10T05:05:42Z"
 

--- a/best-practices-cel/require-drop-all/require-drop-all.yaml
+++ b/best-practices-cel/require-drop-all/require-drop-all.yaml
@@ -32,13 +32,10 @@ spec:
         cel:
           variables:
             - name: allContainers
-              expression: "(object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : []))"
+              expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
           expressions:
             - expression: >-
                 variables.allContainers.all(container, 
-                has(container.securityContext) &&
-                has(container.securityContext.capabilities) &&
-                has(container.securityContext.capabilities.drop) &&
-                container.securityContext.capabilities.drop.exists(capability, capability.upperAscii() == 'ALL'))
+                container.?securityContext.?capabilities.?drop.orValue([]).exists(capability, capability.upperAscii() == 'ALL'))
               message: "Containers must drop `ALL` capabilities."
 

--- a/best-practices-cel/require-drop-cap-net-raw/artifacthub-pkg.yml
+++ b/best-practices-cel/require-drop-cap-net-raw/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: ef4e56b25b29423934e0e21cdea2d6c4e0ae3e67d84a1456f52b3d66fe9fa25a
+digest: 28cac97e2c441528f12158cc0c6d3c8c07067537831a88d5445a2128b42746b4
 createdAt: "2024-03-15T03:05:47Z"
 

--- a/best-practices-cel/require-drop-cap-net-raw/require-drop-cap-net-raw.yaml
+++ b/best-practices-cel/require-drop-cap-net-raw/require-drop-cap-net-raw.yaml
@@ -33,14 +33,11 @@ spec:
         cel:
           variables:
             - name: allContainers
-              expression: "(object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : []))"
+              expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
           expressions:
             - expression: >-
                 variables.allContainers.all(container, 
-                has(container.securityContext) &&
-                has(container.securityContext.capabilities) &&
-                has(container.securityContext.capabilities.drop) &&
-                container.securityContext.capabilities.drop.exists(capability, capability.upperAscii() == 'CAP_NET_RAW'))
+                container.?securityContext.?capabilities.?drop.orValue([]).exists(capability, capability.upperAscii() == 'CAP_NET_RAW'))
               message: >-
                 Containers must drop the `CAP_NET_RAW` capability.
         

--- a/best-practices-cel/require-labels/artifacthub-pkg.yml
+++ b/best-practices-cel/require-labels/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Label"
-digest: cdcd97f2977e45e753975a75184c12d37e297a615f50322be925e64885ffa5e0
+digest: 90e1ceb1c27f70169fcd448cb48df4c7694d8252e060da24c7b2e9bb16a4fc88
 createdAt: "2024-03-06T19:31:45Z"
 

--- a/best-practices-cel/require-labels/require-labels.yaml
+++ b/best-practices-cel/require-labels/require-labels.yaml
@@ -31,7 +31,6 @@ spec:
       cel:
         expressions:
           - expression: >-
-              has(object.metadata.labels) && 
-              'app.kubernetes.io/name' in object.metadata.labels && object.metadata.labels['app.kubernetes.io/name'] != ""
+              object.metadata.?labels[?'app.kubernetes.io/name'].orValue('') != ""
             message: "The label `app.kubernetes.io/name` is required." 
 

--- a/best-practices-cel/require-ro-rootfs/artifacthub-pkg.yml
+++ b/best-practices-cel/require-ro-rootfs/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Best Practices, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 08e28ef463ea200092f19e279fa3da071b276315f555b579786c564bbb8718c5
+digest: fe244b770ce2bc266f6af712404255b2968f26448614498fdf2f103ae82a1343
 createdAt: "2024-03-07T12:35:00Z"
 

--- a/best-practices-cel/require-ro-rootfs/require-ro-rootfs.yaml
+++ b/best-practices-cel/require-ro-rootfs/require-ro-rootfs.yaml
@@ -33,7 +33,6 @@ spec:
         expressions:
           - expression: >-
               object.spec.containers.all(container,
-              has(container.securityContext) &&
-              container.securityContext.readOnlyRootFilesystem == true)
+              container.?securityContext.?readOnlyRootFilesystem.orValue(false) == true)
             message: "Root filesystem must be read-only."
           

--- a/best-practices-cel/restrict-image-registries/artifacthub-pkg.yml
+++ b/best-practices-cel/restrict-image-registries/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Best Practices, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: cac6e95f5ac6f7d7235349ac935745672c2112a0a5400e8fb1f59c9750850ad0
+digest: 8fbe80e4d4b26e2a2acc2160d52bf5b88c4f137567ea569e086439fc1fe1bd49
 createdAt: "2024-03-07T13:35:11Z"
 

--- a/best-practices-cel/restrict-image-registries/restrict-image-registries.yaml
+++ b/best-practices-cel/restrict-image-registries/restrict-image-registries.yaml
@@ -32,7 +32,7 @@ spec:
       cel:
         variables:
           - name: allContainers
-            expression: "(object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : []))"
+            expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
         expressions:
           - expression: "variables.allContainers.all(container, container.image.startsWith('eu.foo.io/') || container.image.startsWith('bar.io/'))"
             message: "Unknown image registry."

--- a/consul-cel/enforce-min-tls-version/artifacthub-pkg.yml
+++ b/consul-cel/enforce-min-tls-version/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Consul in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Mesh"
-digest: 076a14dd5d7a4b4b69d9b7c1c53deab6e8b2c0ce0ed570f3cf07b661fca92aef
+digest: ef025b5a358ed684ffe008b5a251e743289f5e2f28e72e49df10c895b1539260
 createdAt: "2024-05-02T17:47:54Z"
 

--- a/consul-cel/enforce-min-tls-version/enforce-min-tls-version.yaml
+++ b/consul-cel/enforce-min-tls-version/enforce-min-tls-version.yaml
@@ -29,7 +29,6 @@ spec:
       cel:
         expressions:
           - expression: >-
-              has(object.spec) && has(object.spec.tls) && has(object.spec.tls.incoming) && 
-              has(object.spec.tls.incoming.tlsMinVersion) && object.spec.tls.incoming.tlsMinVersion == 'TLSv1_2'
+              object.?spec.?tls.?incoming.?tlsMinVersion.orValue('') == 'TLSv1_2'
             message: The minimum version of TLS is TLS v1_2
 

--- a/flux-cel/verify-flux-sources/artifacthub-pkg.yml
+++ b/flux-cel/verify-flux-sources/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Flux in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "GitRepository, Bucket, HelmRepository, ImageRepository"
-digest: bf6f3413334accaa083d0b203909b82f74b0131e862799124b940afd86e4372d
+digest: 0199445c867ee1e79d766a18fcd11b14b5107e7c2c541645f6ceea8df4e34dac
 createdAt: "2024-05-11T15:02:04Z"
 

--- a/flux-cel/verify-flux-sources/verify-flux-sources.yaml
+++ b/flux-cel/verify-flux-sources/verify-flux-sources.yaml
@@ -56,7 +56,7 @@ spec:
       validate:
         cel:
           expressions:
-            - expression: "has(object.spec.endpoint) && object.spec.endpoint.endsWith('.myorg.com')"
+            - expression: "object.spec.?endpoint.orValue('').endsWith('.myorg.com')"
               message: ".spec.endpoint must reference an address within the myorg organization."
     - name: flux-helm-repositories
       match:
@@ -94,6 +94,6 @@ spec:
       validate:
         cel:
           expressions:
-            - expression: "has(object.spec.image) && object.spec.image.startsWith('ghcr.io/myorg/')"
+            - expression: "object.spec.?image.orValue('').startsWith('ghcr.io/myorg/')"
               message: ".spec.image must be from an image repository within the myorg organization."
 

--- a/istio-cel/enforce-sidecar-injection-namespace/artifacthub-pkg.yml
+++ b/istio-cel/enforce-sidecar-injection-namespace/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Istio in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Namespace"
-digest: 123feb2a8d1b2743e33b1f91ddf7291c47eedcf2c24ae537a1d3afe6c503338d
+digest: 9738fe6b1278148191239c380c074c197841a4926c7ffc1e23cd9a2b22f1175f
 createdAt: "2024-05-12T04:38:32Z"
 

--- a/istio-cel/enforce-sidecar-injection-namespace/enforce-sidecar-injection-namespace.yaml
+++ b/istio-cel/enforce-sidecar-injection-namespace/enforce-sidecar-injection-namespace.yaml
@@ -29,6 +29,6 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "has(object.metadata.labels) && 'istio-injection' in object.metadata.labels && object.metadata.labels['istio-injection'] == 'enabled'"
+          - expression: "object.metadata.?labels[?'istio-injection'].orValue('') == 'enabled'"
             message: "All new Namespaces must have Istio sidecar injection enabled."
 

--- a/istio-cel/prevent-disabling-injection-pods/artifacthub-pkg.yml
+++ b/istio-cel/prevent-disabling-injection-pods/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Istio in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 5de03c078273ce913a6ebf9064a85be4255b82e36f74bda822984e261363fe8b
+digest: 97408c8377b12760f93ab481284a80e6ac7b78f3d04bc89bb44ab55e32054f5c
 createdAt: "2024-05-12T04:48:58Z"
 

--- a/istio-cel/prevent-disabling-injection-pods/prevent-disabling-injection-pods.yaml
+++ b/istio-cel/prevent-disabling-injection-pods/prevent-disabling-injection-pods.yaml
@@ -32,7 +32,6 @@ spec:
       cel:
         expressions:
           - expression: >-
-              !has(object.metadata.annotations) || !('sidecar.istio.io/inject' in object.metadata.annotations) ||
-              object.metadata.annotations['sidecar.istio.io/inject'] != 'false'
+              object.metadata.?annotations[?'sidecar.istio.io/inject'].orValue('') != 'false'
             message: "Pods may not disable sidecar injection by setting the annotation sidecar.istio.io/inject to a value of false."
 

--- a/kasten-cel/k10-data-protection-by-label/artifacthub-pkg.yml
+++ b/kasten-cel/k10-data-protection-by-label/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Kasten K10 by Veeam in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Deployment, StatefulSet"
-digest: e3a088a52aac74e16f9b2776df78891344edd6dc03ee6456dc71d71c34519325
+digest: 8717e4f433a73aa59f79c557f17b75d8d7b5ac22839b4993975bba9cf8fb551b
 createdAt: "2024-05-12T07:05:48Z"
 

--- a/kasten-cel/k10-data-protection-by-label/k10-data-protection-by-label.yaml
+++ b/kasten-cel/k10-data-protection-by-label/k10-data-protection-by-label.yaml
@@ -31,6 +31,6 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "has(object.metadata.labels) && has(object.metadata.labels.dataprotection) && object.metadata.labels.dataprotection.startsWith('k10-')"
+          - expression: "object.metadata.?labels.?dataprotection.orValue('').startsWith('k10-')"
             message: "Deployments and StatefulSets that specify 'dataprotection' label must have a valid k10-?* name (use labels: dataprotection: k10-<policyname>)"
 

--- a/kasten-cel/k10-validate-ns-by-preset-label/artifacthub-pkg.yml
+++ b/kasten-cel/k10-validate-ns-by-preset-label/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Kasten K10 by Veeam in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Namespace"
-digest: e58ab4c2018542a6acd5e97446b09cf04cec26425b9a29f0207c518310c449f3
+digest: c277cd02118d9e63dc9e7b842ac27f261c1cd48a3d79a67660e8742d06af62f1
 createdAt: "2024-05-12T07:09:08Z"
 

--- a/kasten-cel/k10-validate-ns-by-preset-label/k10-validate-ns-by-preset-label.yaml
+++ b/kasten-cel/k10-validate-ns-by-preset-label/k10-validate-ns-by-preset-label.yaml
@@ -32,7 +32,7 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "has(object.metadata.labels) && has(object.metadata.labels.dataprotection) && object.metadata.labels.dataprotection in ['gold', 'silver', 'bronze', 'none']"
+          - expression: "object.metadata.?labels.?dataprotection.orValue('') in ['gold', 'silver', 'bronze', 'none']"
             message: >-
               Namespaces must specify a "dataprotection" label with a value corresponding to a Kasten K10 SLA:
 

--- a/kubecost-cel/require-kubecost-labels/artifacthub-pkg.yml
+++ b/kubecost-cel/require-kubecost-labels/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Kubecost in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod,Label"
-digest: e7dc12ab8d4fa467c23bc117db5c9e33e5e0d804c597ee0d88fb9f55f11ab535
+digest: 5b50102fc3a29abc915d2a81baee4335a505b3dc749057a310197b0442409a88
 createdAt: "2024-05-12T06:59:59Z"
 

--- a/kubecost-cel/require-kubecost-labels/require-kubecost-labels.yaml
+++ b/kubecost-cel/require-kubecost-labels/require-kubecost-labels.yaml
@@ -33,11 +33,10 @@ spec:
       cel:  
         expressions:
           - expression: >-
-              has(object.metadata.labels) && 
-              has(object.metadata.labels.owner) && object.metadata.labels.owner != '' && 
-              has(object.metadata.labels.team) && object.metadata.labels.team != '' &&
-              has(object.metadata.labels.department) && object.metadata.labels.department != '' &&
-              has(object.metadata.labels.app) && object.metadata.labels.app != '' &&
-              has(object.metadata.labels.env) && object.metadata.labels.env != ''
+              object.metadata.?labels.?owner.orValue('') != '' && 
+              object.metadata.?labels.?team.orValue('') != '' &&
+              object.metadata.?labels.?department.orValue('') != '' &&
+              object.metadata.?labels.?app.orValue('') != '' &&
+              object.metadata.?labels.?env.orValue('') != ''
             message: "The Kubecost labels `owner`, `team`, `department`, `app`, and `env` are all required for Pods."
 

--- a/linkerd-cel/prevent-linkerd-pod-injection-override/artifacthub-pkg.yml
+++ b/linkerd-cel/prevent-linkerd-pod-injection-override/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Linkerd in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 795a7d5ae06f9720bdbcc00ced965d1f7a28540c965628a47abc5621fb8d0033
+digest: 5b12ec5eb44fb90ffd0656f835ecb3ed7a119e6304230929eea4cbd5d222d4a1
 createdAt: "2024-05-21T15:39:18Z"

--- a/linkerd-cel/prevent-linkerd-pod-injection-override/prevent-linkerd-pod-injection-override.yaml
+++ b/linkerd-cel/prevent-linkerd-pod-injection-override/prevent-linkerd-pod-injection-override.yaml
@@ -30,6 +30,6 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "!has(object.metadata.annotations) || !('linkerd.io/inject' in object.metadata.annotations) || object.metadata.annotations['linkerd.io/inject'] != 'disabled'"
+          - expression: "object.metadata.?annotations[?'linkerd.io/inject'].orValue('') != 'disabled'"
             message: "Pods may not disable sidecar injection."
 

--- a/linkerd-cel/require-linkerd-mesh-injection/artifacthub-pkg.yml
+++ b/linkerd-cel/require-linkerd-mesh-injection/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Linkerd in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Namespace, Annotation"
-digest: 54785b725fde31418dffca17c8b9eb619c64db8351743d370b5f628e5235fd93
+digest: 35eeae221b613fe7c3ddff2006d6f38e43c2ec6300ec89e7c44ac53ed93e0b62
 createdAt: "2024-05-21T16:06:15Z"

--- a/linkerd-cel/require-linkerd-mesh-injection/require-linkerd-mesh-injection.yaml
+++ b/linkerd-cel/require-linkerd-mesh-injection/require-linkerd-mesh-injection.yaml
@@ -29,6 +29,6 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "has(object.metadata.annotations) && 'linkerd.io/inject' in object.metadata.annotations && object.metadata.annotations['linkerd.io/inject'] == 'enabled'"
+          - expression: "object.metadata.?annotations[?'linkerd.io/inject'].orValue('') == 'enabled'"
             message: "All Namespaces must set the annotation `linkerd.io/inject` to `enabled`."
 

--- a/nginx-ingress-cel/disallow-ingress-nginx-custom-snippets/artifacthub-pkg.yml
+++ b/nginx-ingress-cel/disallow-ingress-nginx-custom-snippets/artifacthub-pkg.yml
@@ -20,5 +20,5 @@ annotations:
   kyverno/category: "Security, NGINX Ingress in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "ConfigMap, Ingress"
-digest: aaf1d6d140eb40ced231f9b1c1e58c76eb89c1974def85df5f0152b72b8d398b
+digest: 461b5ea917b380efcf272d0ac6ab2d8f4ceaa6d8c3b0b71efad5a7b23d10ae99
 createdAt: "2024-05-21T16:14:12Z"

--- a/nginx-ingress-cel/disallow-ingress-nginx-custom-snippets/disallow-ingress-nginx-custom-snippets.yaml
+++ b/nginx-ingress-cel/disallow-ingress-nginx-custom-snippets/disallow-ingress-nginx-custom-snippets.yaml
@@ -30,7 +30,7 @@ spec:
       validate:
         cel:
           expressions:
-            - expression: "!has(object.data) || !('allow-snippet-annotations' in object.data) || object.data['allow-snippet-annotations'] == 'false'"
+            - expression: "object.?data[?'allow-snippet-annotations'].orValue('false') == 'false'"
               message: "ingress-nginx allow-snippet-annotations must be set to false"
     - name: check-ingress-annotations
       match:
@@ -44,6 +44,6 @@ spec:
       validate:
         cel:
           expressions:
-            - expression: "!has(object.metadata.annotations) || !object.metadata.annotations.exists(annotation, annotation.endsWith('-snippet'))"
+            - expression: "!object.metadata.?annotations.orValue([]).exists(annotation, annotation.endsWith('-snippet'))"
               message: "ingress-nginx custom snippets are not allowed"
 

--- a/nginx-ingress-cel/restrict-ingress-paths/artifacthub-pkg.yml
+++ b/nginx-ingress-cel/restrict-ingress-paths/artifacthub-pkg.yml
@@ -20,5 +20,5 @@ annotations:
   kyverno/category: "Security, NGINX Ingress in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: 1c95fe0afc73a2e5e30376d7594d98b4e58cfd21378e3ea10035742eb960220f
+digest: 27e33a96f483688a088cd64017dd8c69ab2677e53f7a66b95a804c897f104755
 createdAt: "2024-05-22T07:13:08Z"

--- a/nginx-ingress-cel/restrict-ingress-paths/restrict-ingress-paths.yaml
+++ b/nginx-ingress-cel/restrict-ingress-paths/restrict-ingress-paths.yaml
@@ -30,9 +30,8 @@ spec:
         cel:
           expressions:
             - expression: >-
-                !has(object.spec.rules) ||
-                object.spec.rules.all(rule, !has(rule.http) || !has(rule.http.paths) ||
-                rule.http.paths.all(p, 
+                object.spec.?rules.orValue([]).all(rule, 
+                rule.?http.?paths.orValue([]).all(p, 
                 !p.path.contains('/etc') && !p.path.contains('/var/run/secrets') &&
                 !p.path.contains('/root') && !p.path.contains('/var/run/kubernetes/serviceaccount') &&
                 !p.path.contains('/etc/kubernetes/admin.conf')))

--- a/openshift-cel/disallow-security-context-constraint-anyuid/artifacthub-pkg.yml
+++ b/openshift-cel/disallow-security-context-constraint-anyuid/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Security in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Role,ClusterRole,RBAC"
-digest: a12e5cbb7ee88722774bf06d5c086804b4e3151811088be926470b12b8920cf0
+digest: 13d430a48c1a18ee97f2e86ad48f5e97f9a188ea3551c6884ff9ee8f1f81e2a6
 createdAt: "2024-05-22T09:53:47Z"

--- a/openshift-cel/disallow-security-context-constraint-anyuid/disallow-security-context-constraint-anyuid.yaml
+++ b/openshift-cel/disallow-security-context-constraint-anyuid/disallow-security-context-constraint-anyuid.yaml
@@ -29,7 +29,7 @@ spec:
     validate: 
       cel:
         expressions:
-          - expression: "!has(object.rules) || !object.rules.exists(rule, 'anyuid' in rule.resourceNames && ('use' in rule.verbs || '*' in rule.verbs))"
+          - expression: "!object.?rules.orValue([]).exists(rule, 'anyuid' in rule.resourceNames && ('use' in rule.verbs || '*' in rule.verbs))"
             message: >-
               Use of the SecurityContextConstraint (SCC) anyuid is not allowed
   - name: check-security-context-roleref

--- a/other-cel/advanced-restrict-image-registries/advanced-restrict-image-registries.yaml
+++ b/other-cel/advanced-restrict-image-registries/advanced-restrict-image-registries.yaml
@@ -41,13 +41,12 @@ spec:
             parameterNotFoundAction: Deny
           variables:
             - name: allContainers
-              expression: "(object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : []))"
+              expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
             - name: nsregistries
               expression: >-
-                (has(namespaceObject.metadata.annotations) && 'corp.com/allowed-registries' in namespaceObject.metadata.annotations) ?
-                namespaceObject.metadata.annotations['corp.com/allowed-registries'] : ' '
+                namespaceObject.metadata.?annotations[?'corp.com/allowed-registries'].orValue(' ')
             - name: clusterregistries
-              expression: "'registries' in params.data ? params.data['registries'] : ' '"
+              expression: "params.data[?'registries'].orValue(' ')"
           expressions:
             - expression: "variables.allContainers.all(container, container.image.startsWith(variables.nsregistries) || container.image.startsWith(variables.clusterregistries))"
               message: This Pod names an image that is not from an approved registry.

--- a/other-cel/advanced-restrict-image-registries/artifacthub-pkg.yml
+++ b/other-cel/advanced-restrict-image-registries/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: ada2e1e0dd2db1d27d973c07375812e415fb1592c9d1ea26a89850c090520ce4
+digest: affd33e654245f8e62ad872c2ce58b60776ab9b472123c19c6524c1790be414b
 createdAt: "2024-04-21T11:03:06Z"
 

--- a/other-cel/allowed-annotations/allowed-annotations.yaml
+++ b/other-cel/allowed-annotations/allowed-annotations.yaml
@@ -32,7 +32,6 @@ spec:
       cel:
         expressions:
           - expression: >-
-              !has(object.metadata.annotations) ||
-              object.metadata.annotations.all(annotation, !annotation.contains('fluxcd.io/') || annotation in ['fluxcd.io/cow', 'fluxcd.io/dog'])
+              object.metadata.?annotations.orValue([]).all(annotation, !annotation.contains('fluxcd.io/') || annotation in ['fluxcd.io/cow', 'fluxcd.io/dog'])
             message: The only approved FluxCD annotations are `fluxcd.io/cow` and `fluxcd.io/dog`.
       

--- a/other-cel/allowed-annotations/artifacthub-pkg.yml
+++ b/other-cel/allowed-annotations/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Annotation"
-digest: e18bedf7d0b6b1b6ac5d723071d78a1594c325620a1ebd28dd8798414da786b2
+digest: 5853c229a0d206b7b5faa55b55f6b871a3afb0da597d3dcd8c7ea88cf20d83d2
 createdAt: "2024-03-17T14:04:46Z"
 

--- a/other-cel/check-env-vars/artifacthub-pkg.yml
+++ b/other-cel/check-env-vars/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 4ed73ec1d10a3333d9fd87665880a4645e031de173c08dbda63eecfba2580dbe
+digest: f44af22c70df6dfca262ce23ad5812d1a65d38073a86f47b8ed3a1d625dcc915
 createdAt: "2024-03-21T13:31:53Z"
 

--- a/other-cel/check-env-vars/check-env-vars.yaml
+++ b/other-cel/check-env-vars/check-env-vars.yaml
@@ -32,7 +32,7 @@ spec:
         cel:
           expressions:
             - expression: >-  
-                !object.spec.containers.exists(container, has(container.env) &&
-                container.env.exists(e, e.name == 'DISABLE_OPA' && e.value == 'true'))
+                !object.spec.containers.exists(container, 
+                container.?env.orValue([]).exists(e, e.name == 'DISABLE_OPA' && e.value == 'true'))
               message: "DISABLE_OPA must not be set to true."
 

--- a/other-cel/deny-commands-in-exec-probe/artifacthub-pkg.yml
+++ b/other-cel/deny-commands-in-exec-probe/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: af3cef475e79cc67105ba3a2be80f0692ea3744f14a9ccd3917d8de8d251e5d0
+digest: b6ed61532ebe13187f90525265d4c4b54875dab4300a54fed6f5cc7e826d470d
 createdAt: "2024-04-25T18:27:10Z"
 

--- a/other-cel/deny-commands-in-exec-probe/deny-commands-in-exec-probe.yaml
+++ b/other-cel/deny-commands-in-exec-probe/deny-commands-in-exec-probe.yaml
@@ -30,16 +30,13 @@ spec:
       celPreconditions:
         - name: "check-liveness-probes-commands-exist"
           expression: >-
-            object.spec.containers.exists(container, 
-            has(container.livenessProbe) && has(container.livenessProbe.exec) && 
-            size(container.livenessProbe.exec.command) > 0)
+            object.spec.containers.exists(container, size(container.?livenessProbe.?exec.?command.orValue([])) > 0)
       validate:
         cel:
           expressions:
             - expression: >-
                 object.spec.containers.all(container, 
-                !has(container.livenessProbe) || !has(container.livenessProbe.exec) || 
-                !container.livenessProbe.exec.command.exists(command, 
+                !container.?livenessProbe.?exec.?command.orValue([]).exists(command, 
                 command.matches('\\bjcmd\\b') || command.matches('\\bps\\b') || command.matches('\\bls\\b')))
               message: Cannot use commands `jcmd`, `ps`, or `ls` in liveness probes.
 

--- a/other-cel/disallow-all-secrets/artifacthub-pkg.yml
+++ b/other-cel/disallow-all-secrets/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Secret"
-digest: 56e5facdefabb17337fca54838bb54025c60d69660091f213ad366ef94f6fd57
+digest: 31ee726bea089a0ea870feb4859b497d51cd976e316571d4b9af08fe81a74785
 createdAt: "2024-03-23T11:14:09Z"
 

--- a/other-cel/disallow-all-secrets/disallow-all-secrets.yaml
+++ b/other-cel/disallow-all-secrets/disallow-all-secrets.yaml
@@ -32,22 +32,20 @@ spec:
         variables:
           - name: allContainers
             expression: >-
-              object.spec.containers +
-              (has(object.spec.initContainers) ? object.spec.initContainers : []) +
-              (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
+              object.spec.containers + 
+              object.spec.?initContainers.orValue([]) + 
+              object.spec.?ephemeralContainers.orValue([])
         expressions:
           - expression: >-
               variables.allContainers.all(container, 
-              !has(container.env) || 
-              container.env.all(env, !has(env.valueFrom) || !has(env.valueFrom.secretKeyRef)))
+              container.?env.orValue([]).all(env, env.?valueFrom.?secretKeyRef.orValue(true)))
             message: "No Secrets from env."
 
           - expression: >-
               variables.allContainers.all(container, 
-              !has(container.envFrom) || 
-              container.envFrom.all(envFrom, !has(envFrom.secretRef)))
+              container.?envFrom.orValue([]).all(envFrom, !has(envFrom.secretRef)))
             message: "No Secrets from envFrom."
 
-          - expression: "!has(object.spec.volumes) || object.spec.volumes.all(volume, !has(volume.secret))"
+          - expression: "object.spec.?volumes.orValue([]).all(volume, !has(volume.secret))"
             message: "No Secrets from volumes."
             

--- a/other-cel/disallow-secrets-from-env-vars/artifacthub-pkg.yml
+++ b/other-cel/disallow-secrets-from-env-vars/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Sample, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Secret"
-digest: 71ff57f46c814a0971e9fb70f065ca0ab2a4308d9f5d56b1a9f8032eef83782b
+digest: 06a74b9ecec7d3c4bc3adef91fdb8ba33125f3b81c9432bc819505523de24746
 createdAt: "2024-03-24T16:54:45Z"
 

--- a/other-cel/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml
+++ b/other-cel/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml
@@ -29,8 +29,8 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "object.spec.containers.all(container, !has(container.env) || container.env.all(env, !has(env.valueFrom) || !has(env.valueFrom.secretKeyRef)))"
+          - expression: "object.spec.containers.all(container, container.?env.orValue([]).all(env, env.?valueFrom.?secretKeyRef.orValue(true)))"
             message: "Secrets must be mounted as volumes, not as environment variables."
-          - expression: "object.spec.containers.all(container, !has(container.envFrom) || container.envFrom.all(envFrom, !has(envFrom.secretRef)))"
+          - expression: "object.spec.containers.all(container, container.?envFrom.orValue([]).all(envFrom, !has(envFrom.secretRef)))"
             message: "Secrets must not come from envFrom statements."
                 

--- a/other-cel/docker-socket-requires-label/artifacthub-pkg.yml
+++ b/other-cel/docker-socket-requires-label/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: b7f8b5251d1670da5514515e7ae4ffde77d8c9cb0d28c0dcaee61ba13adfd035
+digest: 6a042d293db3309de274b97414451ed620b19a9972d8a53b001f34b4daa67dff
 createdAt: "2024-03-27T12:13:52Z"
 

--- a/other-cel/docker-socket-requires-label/docker-socket-requires-label.yaml
+++ b/other-cel/docker-socket-requires-label/docker-socket-requires-label.yaml
@@ -31,9 +31,9 @@ spec:
       cel: 
         variables:
           - name: hasDockerSocket
-            expression: "has(object.spec.volumes) && object.spec.volumes.exists(volume, has(volume.hostPath) && volume.hostPath.path == '/var/run/docker.sock')"
+            expression: "object.spec.?volumes.orValue([]).exists(volume, volume.?hostPath.?path.orValue('') == '/var/run/docker.sock')"
           - name: isAllowDockerLabelTrue
-            expression: "has(object.metadata.labels) && 'allow-docker' in object.metadata.labels && object.metadata.labels['allow-docker'] == 'true'"
+            expression: "object.metadata.?labels[?'allow-docker'].orValue('false') == 'true'"
         expressions:
           - expression: "!variables.hasDockerSocket || variables.isAllowDockerLabelTrue"
             message: "If a hostPath volume exists and is set to `/var/run/docker.sock`, the label `allow-docker` must equal `true`."

--- a/other-cel/enforce-pod-duration/artifacthub-pkg.yml
+++ b/other-cel/enforce-pod-duration/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 174a456e5d4afd8c8baa9c0c3bdb7da0e09934673f0544d575e5aad6aab5e644
+digest: 9cdc75a57a1cf01caa6895123ccfd94ad42ffb7deb46614d6ee55a35a8c4d519
 createdAt: "2024-03-30T18:18:11Z"
 

--- a/other-cel/enforce-pod-duration/enforce-pod-duration.yaml
+++ b/other-cel/enforce-pod-duration/enforce-pod-duration.yaml
@@ -29,7 +29,7 @@ spec:
       cel:
         variables:
           - name: hasLifetimeAnnotation
-            expression: "has(object.metadata.annotations) && 'pod.kubernetes.io/lifetime' in object.metadata.annotations"
+            expression: "object.metadata.?annotations[?'pod.kubernetes.io/lifetime'].hasValue()"
           - name: lifetimeAnnotationValue
             expression: "variables.hasLifetimeAnnotation ? object.metadata.annotations['pod.kubernetes.io/lifetime'] : '0s'"
         expressions:

--- a/other-cel/ensure-readonly-hostpath/artifacthub-pkg.yml
+++ b/other-cel/ensure-readonly-hostpath/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 203506a9391a1d4bee3ed42209ab7e964606aee881db2cd93290bd075c98840b
+digest: c0acb4aa284ff94ed26e343502b35bc959bbe45d2d8f3d7b4fbb6780e0e27828
 createdAt: "2024-04-05T17:39:16Z"
 

--- a/other-cel/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
+++ b/other-cel/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
@@ -34,13 +34,12 @@ spec:
       cel:
         variables:
           - name: allContainers
-            expression: "(object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : []))"
+            expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
           - name: hostPathVolumes
-            expression: "has(object.spec.volumes) ? object.spec.volumes.filter(volume, has(volume.hostPath)) : []"
+            expression: "object.spec.?volumes.orValue([]).filter(volume, has(volume.hostPath))"
         expressions:
           - expression: >-
               variables.hostPathVolumes.all(hostPath, variables.allContainers.all(container, 
-              !has(container.volumeMounts) || 
-              container.volumeMounts.all(volume, (hostPath.name != volume.name) || has(volume.readOnly) && volume.readOnly == true)))
+              container.volumeMounts.orValue([]).all(volume, (hostPath.name != volume.name) || volume.?readOnly.orValue(false) == true)))
             message: All hostPath volumes must be mounted as readOnly.
       

--- a/other-cel/forbid-cpu-limits/artifacthub-pkg.yml
+++ b/other-cel/forbid-cpu-limits/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 8d8febae3e8acfab78c2ccf8b96d086f7086ea156b0a0ac36611db1c8958c357
+digest: a3034659b216823d9f4c30bab521e3148817f7d21236e6ee755c94eef2b792a5
 createdAt: "2024-04-01T15:35:47Z"
 

--- a/other-cel/forbid-cpu-limits/forbid-cpu-limits.yaml
+++ b/other-cel/forbid-cpu-limits/forbid-cpu-limits.yaml
@@ -30,6 +30,6 @@ spec:
         expressions:
           - expression: >-
               !object.spec.containers.exists(container, 
-              has(container.resources) && has(container.resources.limits) && has(container.resources.limits.cpu))
+              container.?resources.?limits.?cpu.hasValue())
             message: Containers may not define CPU limits.
 

--- a/other-cel/ingress-host-match-tls/artifacthub-pkg.yml
+++ b/other-cel/ingress-host-match-tls/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: 4de00322c258919b797101a18afa3fa262ce78b52132f2fd903cfea8f60d1f1e
+digest: 026f0c19f0c775abfc9887a91f1b323c327f73dfe68a360ef566ee208fec55bb
 createdAt: "2024-04-06T17:22:38Z"
 

--- a/other-cel/ingress-host-match-tls/ingress-host-match-tls.yaml
+++ b/other-cel/ingress-host-match-tls/ingress-host-match-tls.yaml
@@ -33,11 +33,11 @@ spec:
       cel:
         variables:
           - name: tls
-            expression: "has(object.spec.tls) ? object.spec.tls : []"
+            expression: "object.spec.?tls.orValue([])"
         expressions:
           - expression: >-
               object.spec.rules.all(rule, 
               !has(rule.host) || 
-              variables.tls.exists(tls, has(tls.hosts) && tls.hosts.exists(tlsHost, tlsHost == rule.host)))
+              variables.tls.exists(tls, tls.?hosts.orValue([]).exists(tlsHost, tlsHost == rule.host)))
             message: "The host(s) in spec.rules[].host must match those in spec.tls[].hosts[]."
 

--- a/other-cel/limit-hostpath-vols/artifacthub-pkg.yml
+++ b/other-cel/limit-hostpath-vols/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 8ae23309c8e49ca3e3abe72f406e9ae186564ab24468ea4e772b6f3097793892
+digest: 51afea296e6c4aeb11d29750b5733c36fa841da72841ecf78e74c1e3cb5c268b
 createdAt: "2024-04-26T15:52:10Z"
 

--- a/other-cel/limit-hostpath-vols/limit-hostpath-vols.yaml
+++ b/other-cel/limit-hostpath-vols/limit-hostpath-vols.yaml
@@ -32,7 +32,7 @@ spec:
           - UPDATE
     celPreconditions:
       - name: "has-host-path-volume"
-        expression: "has(object.spec.volumes) && object.spec.volumes.exists(volume, has(volume.hostPath))"
+        expression: "object.spec.?volumes.orValue([]).exists(volume, has(volume.hostPath))"
     validate:
       cel:
         expressions:

--- a/other-cel/memory-requests-equal-limits/artifacthub-pkg.yml
+++ b/other-cel/memory-requests-equal-limits/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: fc71819c4079262810e06ee768738b1061f46985df61ab688007bfdb7433be70
+digest: 2d7d94485cd5c5b19ae666afb28a3b52ce7d861ffe571eb8d2d4636bca1a685d
 createdAt: "2024-04-07T11:13:21Z"
 

--- a/other-cel/memory-requests-equal-limits/memory-requests-equal-limits.yaml
+++ b/other-cel/memory-requests-equal-limits/memory-requests-equal-limits.yaml
@@ -28,14 +28,10 @@ spec:
           - UPDATE
     validate:
       cel:
-        variables:
-          - name: containersWithResources
-            expression: object.spec.containers.filter(container, has(container.resources))
         expressions:
         - expression: >-
-            variables.containersWithResources.all(container, 
-            !has(container.resources.requests) ||
-            !has(container.resources.requests.memory) ||
+            object.spec.containers.all(container, 
+            !container.?resources.?requests.?memory.hasValue() ||
             container.resources.requests.memory == container.resources.?limits.?memory.orValue('-1'))
           message: "resources.requests.memory must be equal to resources.limits.memory"
 

--- a/other-cel/metadata-match-regex/artifacthub-pkg.yml
+++ b/other-cel/metadata-match-regex/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Label"
-digest: 2957a6e03dec3eab58436ddb3478aca69d41dbe7953c6ecb1ece1a54338856e2
+digest: 13f10d84ba859ce67122144d257a77024a781a292b6777cfbf88f191f003d85f
 createdAt: "2024-04-07T10:16:14Z"
 

--- a/other-cel/metadata-match-regex/metadata-match-regex.yaml
+++ b/other-cel/metadata-match-regex/metadata-match-regex.yaml
@@ -31,8 +31,7 @@ spec:
       cel:
         expressions:
           - expression: >-
-              has(object.metadata.labels) && 'corp.org/version' in object.metadata.labels && 
-              object.metadata.labels['corp.org/version'].matches('^v[0-9].[0-9].[0-9]$')
+              object.metadata.?labels[?'corp.org/version'].orValue('default').matches('^v[0-9].[0-9].[0-9]$')
             message: >-
               The label `corp.org/version` is required and must match the specified regex: ^v[0-9].[0-9].[0-9]$
 

--- a/other-cel/pdb-maxunavailable/artifacthub-pkg.yml
+++ b/other-cel/pdb-maxunavailable/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "PodDisruptionBudget"
-digest: 4b452f78ab0ff9715f1454fd3ca827b7aa7a892fa2b2f23aa5c21a12851c526d
+digest: e8a5e187db61953889fcfa1bcc5b0c24893508bbfb47aeb7c73b5c1a274337b7
 createdAt: "2024-04-07T10:22:03Z"
 

--- a/other-cel/pdb-maxunavailable/pdb-maxunavailable.yaml
+++ b/other-cel/pdb-maxunavailable/pdb-maxunavailable.yaml
@@ -29,6 +29,6 @@ spec:
       validate:
         cel:
           expressions:
-            - expression: "!has(object.spec.maxUnavailable) || int(object.spec.maxUnavailable) > 0"
+            - expression: "int(object.spec.?maxUnavailable.orValue(1)) > 0"
               message: "The value of maxUnavailable must be greater than zero."
 

--- a/other-cel/prevent-cr8escape/artifacthub-pkg.yml
+++ b/other-cel/prevent-cr8escape/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 7a684c2d2747e4ef77b44de44734c74143325757077e8047f3c89d535c5b9dfd
+digest: ac2beb2d3eae9cea07feee4eadfd94e4a584e03ccb62cc84401038ffde0e6241
 createdAt: "2024-04-08T10:46:02Z"
 

--- a/other-cel/prevent-cr8escape/prevent-cr8escape.yaml
+++ b/other-cel/prevent-cr8escape/prevent-cr8escape.yaml
@@ -32,7 +32,7 @@ spec:
         cel:
           expressions:
             - expression: >-
-                !has(object.spec.securityContext) || !has(object.spec.securityContext.sysctls) || 
-                object.spec.securityContext.sysctls.all(sysctl, !has(sysctl.value) || (!sysctl.value.contains('+') && !sysctl.value.contains('='))) 
+                object.spec.?securityContext.?sysctls.orValue([]).all(sysctl, 
+                !has(sysctl.value) || (!sysctl.value.contains('+') && !sysctl.value.contains('='))) 
               message: "characters '+' or '=' are not allowed in sysctls values"      
 

--- a/other-cel/require-annotations/artifacthub-pkg.yml
+++ b/other-cel/require-annotations/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Annotation"
-digest: affed5b798321bdaac4b178887ad1a98c4fd00e9e756849dac3f0d70148f6ef1
+digest: daf07a7c0e54bab1c25e2831feba7f3e9a0fd6e1f5e60b2bc043418a2d4f7c5d
 createdAt: "2024-04-09T15:56:35Z"
 

--- a/other-cel/require-annotations/require-annotations.yaml
+++ b/other-cel/require-annotations/require-annotations.yaml
@@ -31,7 +31,6 @@ spec:
       cel:
         expressions:
           - expression: >-
-              has(object.metadata.annotations) && 
-              'corp.org/department' in object.metadata.annotations && object.metadata.annotations['corp.org/department'] != ''
+              object.metadata.?annotations[?'corp.org/department'].orValue('') != ''
             message: "The annotation `corp.org/department` is required."
 

--- a/other-cel/require-container-port-names/artifacthub-pkg.yml
+++ b/other-cel/require-container-port-names/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 62488bb402289ddbffe291c61acb14a50347e476e99d4f79ba035b4d3297403e
+digest: 769749ee4aefe260c950c0f36f7c966ef3f9c432469e342014660992b35c475d
 createdAt: "2024-04-27T16:37:39Z"
 

--- a/other-cel/require-container-port-names/require-container-port-names.yaml
+++ b/other-cel/require-container-port-names/require-container-port-names.yaml
@@ -31,6 +31,6 @@ spec:
       validate:
         cel:
           expressions:
-            - expression: "object.spec.containers.all(container, !has(container.ports) || container.ports.all(port, has(port.name)))"
+            - expression: "object.spec.containers.all(container, container.?ports.orValue([]).all(port, has(port.name)))"
               message: Name is required for every containerPort.
 

--- a/other-cel/require-emptydir-requests-limits/artifacthub-pkg.yml
+++ b/other-cel/require-emptydir-requests-limits/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 8915013155bfb12e6414848c9dec66a9e95ab7318f5da7d0c64bc621143e5383
+digest: 532dc08b43aa1027bd893d6e21e7d3310e537a212cebedead22608e0c94e2dc5
 createdAt: "2024-05-19T10:11:00Z"

--- a/other-cel/require-emptydir-requests-limits/require-emptydir-requests-limits.yaml
+++ b/other-cel/require-emptydir-requests-limits/require-emptydir-requests-limits.yaml
@@ -30,12 +30,12 @@ spec:
               - UPDATE
       celPreconditions:
         - name: "has-emptydir-volume"
-          expression: "has(object.spec.volumes) && object.spec.volumes.exists(volume, has(volume.emptyDir))"
+          expression: "object.spec.?volumes.orValue([]).exists(volume, has(volume.emptyDir))"
       validate:
         cel:
           variables:
             - name: containers
-              expression: "object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : [])"
+              expression: "object.spec.containers + object.spec.?initContainers.orValue([])"
             - name: emptydirnames
               expression: >-
                 has(object.spec.volumes) ? 
@@ -43,8 +43,7 @@ spec:
           expressions:
             - expression: >-
                 variables.containers.all(container,
-                !has(container.volumeMounts) || 
-                !container.volumeMounts.exists(mount, mount.name in variables.emptydirnames) || 
+                !container.?volumeMounts.orValue([]).exists(mount, mount.name in variables.emptydirnames) || 
                 container.resources.?requests[?'ephemeral-storage'].hasValue() &&
                 container.resources.?limits[?'ephemeral-storage'].hasValue())
               message: Containers mounting emptyDir volumes must specify requests and limits for ephemeral-storage.

--- a/other-cel/require-ingress-https/artifacthub-pkg.yml
+++ b/other-cel/require-ingress-https/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: 56fca07a343423b529d0cd1e27069ca705b60cc1f590c832b2467c757b1b6957
+digest: b30bc5463846fae38c141a57722099c05614db0da4b3a1f88a1bb7812a572b81
 createdAt: "2024-04-10T18:31:27Z"
 

--- a/other-cel/require-ingress-https/require-ingress-https.yaml
+++ b/other-cel/require-ingress-https/require-ingress-https.yaml
@@ -31,9 +31,7 @@ spec:
       cel:
         expressions:
           - expression: >-
-              has(object.metadata.annotations) && 
-              'kubernetes.io/ingress.allow-http' in object.metadata.annotations && 
-              object.metadata.annotations['kubernetes.io/ingress.allow-http'] == 'false'
+              object.metadata.?annotations[?'kubernetes.io/ingress.allow-http'].orValue('default') == 'false'
             message: "The kubernetes.io/ingress.allow-http annotation must be set to false."
   - name: has-tls
     match:

--- a/other-cel/require-non-root-groups/artifacthub-pkg.yml
+++ b/other-cel/require-non-root-groups/artifacthub-pkg.yml
@@ -20,5 +20,5 @@ annotations:
   kyverno/category: "Sample, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: b2f00c69719c2f91584551c65a0809e4d2d2e691030b41aa3bf80cdcb6e45320
+digest: 5b8983536f5922194a9ea86212f5ac316f396eefc1de09d4043947510b96ea16
 createdAt: "2024-05-19T10:49:49Z"

--- a/other-cel/require-non-root-groups/require-non-root-groups.yaml
+++ b/other-cel/require-non-root-groups/require-non-root-groups.yaml
@@ -32,15 +32,15 @@ spec:
         cel:
           variables:
             - name: allContainers
-              expression: "(object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : []))"
+              expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
           expressions:
             - expression: >-
                 (
-                  has(object.spec.securityContext) && has(object.spec.securityContext.runAsGroup) && (object.spec.securityContext.runAsGroup > 0) &&
-                  variables.allContainers.all(container, !has(container.securityContext) || !has(container.securityContext.runAsGroup) || container.securityContext.runAsGroup > 0)
+                  object.spec.?securityContext.?runAsGroup.orValue(-1) > 0 &&
+                  variables.allContainers.all(container, container.?securityContext.?runAsGroup.orValue(1) > 0)
                 ) ||
                 (
-                  variables.allContainers.all(container, has(container.securityContext) && has(container.securityContext.runAsGroup) && container.securityContext.runAsGroup > 0) 
+                  variables.allContainers.all(container, container.?securityContext.?runAsGroup.orValue(-1) > 0) 
                 )
               message: >-
                 Running with root group IDs is disallowed. The fields
@@ -61,8 +61,7 @@ spec:
         cel:
           expressions:
             - expression: >-
-                !has(object.spec.securityContext) || !has(object.spec.securityContext.supplementalGroups) || 
-                object.spec.securityContext.supplementalGroups.all(group, group > 0)
+                object.spec.?securityContext.?supplementalGroups.orValue([]).all(group, group > 0)
               message: >-
                 Containers cannot run with a root primary or supplementary GID. The field
                 spec.securityContext.supplementalGroups must be unset or
@@ -80,8 +79,7 @@ spec:
         cel:
           expressions:
             - expression: >-
-                !has(object.spec.securityContext) || !has(object.spec.securityContext.fsGroup) || 
-                object.spec.securityContext.fsGroup > 0
+                object.spec.?securityContext.?fsGroup.orValue(1) > 0
               message: >-
                 Containers cannot run with a root primary or supplementary GID. The field
                 spec.securityContext.fsGroup must be unset or set to a value greater than zero.

--- a/other-cel/require-pod-priorityclassname/artifacthub-pkg.yml
+++ b/other-cel/require-pod-priorityclassname/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Multi-Tenancy, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 10070a8c58969454fde8742cc3c1fdd5c196d98a918e8504f833331dd0a1c03b
+digest: 252b3acff35bbfdb60bfdb57be947b8e983d65fbaa4c143bf8e9f714d6f54e04
 createdAt: "2024-04-11T17:46:06Z"
 

--- a/other-cel/require-pod-priorityclassname/require-pod-priorityclassname.yaml
+++ b/other-cel/require-pod-priorityclassname/require-pod-priorityclassname.yaml
@@ -32,6 +32,6 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "has(object.spec.priorityClassName) && object.spec.priorityClassName != ''"
+          - expression: "object.spec.?priorityClassName.orValue('') != ''"
             message: "Pods must define the priorityClassName field."
 

--- a/other-cel/require-storageclass/artifacthub-pkg.yml
+++ b/other-cel/require-storageclass/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Other, Multi-Tenancy in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "PersistentVolumeClaim, StatefulSet"
-digest: 50a19cfd04cb3ffc6cd1d064516042035b64213e16a85aecc891dc5c0806963c
+digest: e7471108f222c8a533a02a8c3b956ac0762d0f1b5522b1a27c95d90b2aa5080e
 createdAt: "2024-04-11T18:06:16Z"
 

--- a/other-cel/require-storageclass/require-storageclass.yaml
+++ b/other-cel/require-storageclass/require-storageclass.yaml
@@ -31,7 +31,7 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "has(object.spec.storageClassName) && object.spec.storageClassName != ''"
+          - expression: "object.spec.?storageClassName.orValue('') != ''"
             message: "PersistentVolumeClaims must define a storageClassName."
   - name: ss-storageclass
     match:
@@ -48,6 +48,6 @@ spec:
           - expression: >-
               !has(object.spec.volumeClaimTemplates) || 
               object.spec.volumeClaimTemplates.all(volumeClaimTemplate, 
-              has(volumeClaimTemplate.spec.storageClassName) && volumeClaimTemplate.spec.storageClassName  != '')
+              volumeClaimTemplate.spec.?storageClassName.orValue('')  != '')
             message: "StatefulSets must define a storageClassName."
 

--- a/other-cel/restrict-annotations/artifacthub-pkg.yml
+++ b/other-cel/restrict-annotations/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Annotation"
-digest: 5e3188460d595814af4a9287d6af5e42819863d4b619bfc329effb6127c8bf94
+digest: cf1c58fd51dd74ce5fe3369919c7885c5a2f54bcd9c8d4ca38ee872662b8376f
 createdAt: "2024-04-12T15:55:04Z"
 

--- a/other-cel/restrict-annotations/restrict-annotations.yaml
+++ b/other-cel/restrict-annotations/restrict-annotations.yaml
@@ -35,6 +35,6 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "!has(object.metadata.annotations) || !object.metadata.annotations.exists(annotation, annotation.startsWith('fluxcd.io/'))"
+          - expression: "!object.metadata.?annotations.orValue([]).exists(annotation, annotation.startsWith('fluxcd.io/'))"
             message: Cannot use Flux v1 annotation.
 

--- a/other-cel/restrict-controlplane-scheduling/artifacthub-pkg.yml
+++ b/other-cel/restrict-controlplane-scheduling/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 95c237c7d39fa64b37cf5708d566ca582f7f55770708092cf1e38d0a4e8a0828
+digest: e170af87f00d51c0a020dc88bf48c1aa1c213f7890f517dbeb898c9456722a46
 createdAt: "2024-04-13T16:19:01Z"
 

--- a/other-cel/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml
+++ b/other-cel/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml
@@ -32,6 +32,6 @@ spec:
         expressions:
           - expression: >-
               !has(object.spec.tolerations) || 
-              !object.spec.tolerations.exists(toleration, has(toleration.key) && toleration.key in ['node-role.kubernetes.io/master', 'node-role.kubernetes.io/control-plane'])
+              !object.spec.tolerations.exists(toleration, toleration.?key.orValue('') in ['node-role.kubernetes.io/master', 'node-role.kubernetes.io/control-plane'])
             message: Pods may not use tolerations which schedule on control plane nodes.
 

--- a/other-cel/restrict-deprecated-registry/artifacthub-pkg.yml
+++ b/other-cel/restrict-deprecated-registry/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Best Practices, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.27-1.28"
   kyverno/subject: "Pod"
-digest: b7e1108f954b94f8de8d26c564d37e1a6930648c9bb725ac2d3d3b6456d2ea2d
+digest: 467f0243c9c131c5328e87edcd39a3f2831d3adc2ec5037c547a053ba304f6ee
 createdAt: "2024-04-13T16:21:40Z"
 

--- a/other-cel/restrict-deprecated-registry/restrict-deprecated-registry.yaml
+++ b/other-cel/restrict-deprecated-registry/restrict-deprecated-registry.yaml
@@ -32,7 +32,7 @@ spec:
       cel:
         variables:
           - name: allContainers
-            expression: "(object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : []))"
+            expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
         expressions:
           - expression: "variables.allContainers.all(container, !container.image.startsWith('k8s.gcr.io/'))"
             message: "The \"k8s.gcr.io\" image registry is deprecated. \"registry.k8s.io\" should now be used."

--- a/other-cel/restrict-ingress-classes/artifacthub-pkg.yml
+++ b/other-cel/restrict-ingress-classes/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: abbd493cdcdfd2a7ec903027a4b7f56b1d7761e7a0ce2822d1521bb853791455
+digest: 669b46277fefe37d17931a7c5ef66ab297dbe9c7881390ad7f0b75c8891ac303
 createdAt: "2024-04-14T15:43:33Z"
 

--- a/other-cel/restrict-ingress-classes/restrict-ingress-classes.yaml
+++ b/other-cel/restrict-ingress-classes/restrict-ingress-classes.yaml
@@ -33,8 +33,6 @@ spec:
       cel:
         expressions: 
           - expression: >-
-              has(object.metadata.annotations) && 
-              'kubernetes.io/ingress.class' in object.metadata.annotations && 
-              object.metadata.annotations['kubernetes.io/ingress.class'] in ['HAProxy', 'nginx']      
+              object.metadata.?annotations[?'kubernetes.io/ingress.class'].orValue('') in ['HAProxy', 'nginx']      
             message: "Unknown ingress class."
 

--- a/other-cel/restrict-ingress-wildcard/artifacthub-pkg.yml
+++ b/other-cel/restrict-ingress-wildcard/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Ingress"
-digest: 74fa42f42b40f259054e0a4c097e10673bfa977ef0f5451cef18d07222142a5b
+digest: 4a41226fe1301a55f1f7dfadbc3ee87ee05ae981500b5b956dd44d62718eed2f
 createdAt: "2024-04-15T18:06:41Z"
 

--- a/other-cel/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
+++ b/other-cel/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
@@ -32,6 +32,6 @@ spec:
       validate:
         cel:
           expressions:
-            - expression: "!has(object.spec.rules) || !object.spec.rules.exists(rule, has(rule.host) && rule.host.contains('*'))"
+            - expression: "!object.spec.?rules.orValue([]).exists(rule, has(rule.host) && rule.host.contains('*'))"
               message: "Wildcards are not permitted as hosts."
 

--- a/other-cel/restrict-node-affinity/artifacthub-pkg.yml
+++ b/other-cel/restrict-node-affinity/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: a148811b16c64d0d77e4d14b4cc368acd90a186276801c2dc4cc7ce4f0fb9b98
+digest: 485e28fb5ff6628c443209cdd6425e70619a5a91c8334b13c8b83f6dd1a731d5
 createdAt: "2024-04-18T18:08:24Z"
 

--- a/other-cel/restrict-node-affinity/restrict-node-affinity.yaml
+++ b/other-cel/restrict-node-affinity/restrict-node-affinity.yaml
@@ -31,6 +31,6 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "!has(object.spec.affinity) || !has(object.spec.affinity.nodeAffinity)"
+          - expression: "!object.spec.?affinity.?nodeAffinity.hasValue()"
             message: "Node affinity cannot be used."
 

--- a/other-cel/restrict-node-label-creation/artifacthub-pkg.yml
+++ b/other-cel/restrict-node-label-creation/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Node, Label"
-digest: 688f42a4211a49dd6f743e2e302654447b9e27d8da63cb5547201be85cbb783b
+digest: f34cb899d81dd8927d55060f361d06d3b52d86b6bb319d9fb40a12fb7c6e46aa
 createdAt: "2024-05-20T03:52:11Z"

--- a/other-cel/restrict-node-label-creation/restrict-node-label-creation.yaml
+++ b/other-cel/restrict-node-label-creation/restrict-node-label-creation.yaml
@@ -31,7 +31,7 @@ spec:
       - name: "operation-should-be-update"
         expression: "request.operation == 'UPDATE'"
       - name: "has-foo-label"
-        expression: "has(object.metadata.labels) && 'foo' in object.metadata.labels"
+        expression: "object.metadata.?labels.?foo.hasValue()"
     validate:
       cel:
         expressions:

--- a/other-cel/restrict-sa-automount-sa-token/artifacthub-pkg.yml
+++ b/other-cel/restrict-sa-automount-sa-token/artifacthub-pkg.yml
@@ -27,6 +27,6 @@ annotations:
   kyverno/category: "Security in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "ServiceAccount"
-digest: 3401afb861d2b9ca9d53ab5667ac1da3a32ba4af4a421accf65ed8448a63a6f2
+digest: 5798ac8ef2989b7d9aa42c607f87b86c876bb7729afb5ba191b995f2ae3ffd99
 createdAt: "2024-04-18T18:11:04Z"
 

--- a/other-cel/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
+++ b/other-cel/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
@@ -31,6 +31,6 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "has(object.automountServiceAccountToken) && object.automountServiceAccountToken == false"
+          - expression: "object.?automountServiceAccountToken.orValue(true) == false"
             message: "ServiceAccounts must set automountServiceAccountToken to false."
 

--- a/other-cel/restrict-secrets-by-name/artifacthub-pkg.yml
+++ b/other-cel/restrict-secrets-by-name/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod, Secret"
-digest: 9a77d417ab9d59569a5e202ab0cdd73fc95d387b485be0003691b851e0065c50
+digest: 2095949d1b1569b58d0848ee30f97f6b82b283d12c7e8558f1a2fd891a114f80
 createdAt: "2024-04-20T16:40:34Z"
 

--- a/other-cel/restrict-secrets-by-name/restrict-secrets-by-name.yaml
+++ b/other-cel/restrict-secrets-by-name/restrict-secrets-by-name.yaml
@@ -33,12 +33,12 @@ spec:
       cel:
         variables:
           - name: allContainers
-            expression: "(object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : []))"
+            expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
         expressions: 
           - expression: >-
               variables.allContainers.all(container, 
-              !has(container.env) || container.env.all(env,
-              !has(env.valueFrom) || !has(env.valueFrom.secretKeyRef) || env.valueFrom.secretKeyRef.name.startsWith("safe-")))
+              container.?env.orValue([]).all(env,
+              env.?valueFrom.?secretKeyRef.?name.orValue('safe-').startsWith("safe-")))
             message: "Only Secrets beginning with `safe-` may be consumed in env statements."
   - name: safe-secrets-from-envfrom
     match:
@@ -53,12 +53,12 @@ spec:
       cel:
         variables:
           - name: allContainers
-            expression: "(object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : []))"
+            expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
         expressions: 
           - expression: >-
               variables.allContainers.all(container, 
-              !has(container.envFrom) || container.envFrom.all(env,
-              !has(env.secretRef) || env.secretRef.name.startsWith("safe-")))
+              container.?envFrom.orValue([]).all(env,
+              env.?secretRef.?name.orValue('safe-').startsWith("safe-")))
             message: "Only Secrets beginning with `safe-` may be consumed in envFrom statements."
   - name: safe-secrets-from-volumes
     match:
@@ -73,7 +73,7 @@ spec:
       cel:
         expressions:
           - expression: >-
-              !has(object.spec.volumes) || object.spec.volumes.all(volume,
-              !has(volume.secret) || volume.secret.secretName.startsWith("safe-"))
+              object.spec.?volumes.orValue([]).all(volume,
+              volume.?secret.?secretName.orValue('safe-').startsWith("safe-"))
             message: "Only Secrets beginning with `safe-` may be consumed in volumes."
 

--- a/other-cel/restrict-usergroup-fsgroup-id/artifacthub-pkg.yml
+++ b/other-cel/restrict-usergroup-fsgroup-id/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: b709760f5d54a7e1720885c487c7f6ba5db404e0aed99dfabdc093206b42092c
+digest: 65d0858b1b9196a038391e89afc535bf696c5a31514e6a830e0eeeb7626a1116
 createdAt: "2024-04-20T16:57:00Z"
 

--- a/other-cel/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml
+++ b/other-cel/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml
@@ -31,10 +31,10 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "has(object.spec.securityContext.runAsUser) && object.spec.securityContext.runAsUser == 1000"
+          - expression: "object.spec.?securityContext.?runAsUser.orValue(1) == 1000"
             message: "User ID should be 1000."
-          - expression: "has(object.spec.securityContext.runAsGroup) && object.spec.securityContext.runAsGroup == 3000"
+          - expression: "object.spec.?securityContext.?runAsGroup.orValue(1) == 3000"
             message: "Group ID should be 3000."
-          - expression: "has(object.spec.securityContext.fsGroup) && object.spec.securityContext.fsGroup == 2000"
+          - expression: "object.spec.?securityContext.?fsGroup.orValue(1) == 2000"
             message: "fs Group should be 2000."
 

--- a/other-cel/topologyspreadconstraints-policy/artifacthub-pkg.yml
+++ b/other-cel/topologyspreadconstraints-policy/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Deployment, StatefulSet"
-digest: bd9dae9c99706fe3d16d26f59bd1bb8ecdaf09ffb038d79e8906fb8c72ec3b0f
+digest: cf0723d2305d06f553934a723122bd60444b1dcff192dc9f81177c1e05951a7e
 createdAt: "2024-04-29T15:49:11Z"
 

--- a/other-cel/topologyspreadconstraints-policy/topologyspreadconstraints-policy.yaml
+++ b/other-cel/topologyspreadconstraints-policy/topologyspreadconstraints-policy.yaml
@@ -38,7 +38,6 @@ spec:
         cel:
           expressions:
             - expression: >-
-                has(object.spec.template.spec.topologySpreadConstraints) && 
-                size(object.spec.template.spec.topologySpreadConstraints.filter(t, t.topologyKey == 'kubernetes.io/hostname' || t.topologyKey == 'topology.kubernetes.io/zone')) == 2
+                size(object.spec.template.spec.?topologySpreadConstraints.orValue([]).filter(t, t.topologyKey == 'kubernetes.io/hostname' || t.topologyKey == 'topology.kubernetes.io/zone')) == 2
               message: "topologySpreadConstraint for kubernetes.io/hostname & topology.kubernetes.io/zone are required"
 

--- a/psa-cel/add-psa-namespace-reporting/add-psa-namespace-reporting.yaml
+++ b/psa-cel/add-psa-namespace-reporting/add-psa-namespace-reporting.yaml
@@ -37,6 +37,6 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "has(object.metadata.labels) && object.metadata.labels.exists(label, label.startsWith('pod-security.kubernetes.io/') && object.metadata.labels[label] != '')"
+          - expression: "object.metadata.?labels.orValue([]).exists(label, label.startsWith('pod-security.kubernetes.io/') && object.metadata.labels[label] != '')"
             message: This Namespace is missing a PSA label.
 

--- a/psa-cel/add-psa-namespace-reporting/artifacthub-pkg.yml
+++ b/psa-cel/add-psa-namespace-reporting/artifacthub-pkg.yml
@@ -20,5 +20,5 @@ annotations:
   kyverno/category: "Pod Security Admission, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Namespace"
-digest: d624eddc7d55bcdb3129ccb57f6e7d840b6eda6cf57134ce7385b89a92ea8686
+digest: f2682d998f335ebf99b534234213b491bfcb760ba7438b3d198efc2f14e86cdc
 createdAt: "2024-05-22T08:30:28Z"

--- a/psp-migration-cel/check-supplemental-groups/artifacthub-pkg.yml
+++ b/psp-migration-cel/check-supplemental-groups/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "PSP Migration in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 05135ed92926031b15d782552af3f8dbf8776014401328e186987344079fcc66
+digest: 8cd53a2a3b47f9847eb4acd6902c92a704e5f0d257354ee722f4d4d3808359ea
 createdAt: "2024-05-23T13:57:56Z"

--- a/psp-migration-cel/check-supplemental-groups/check-supplemental-groups.yaml
+++ b/psp-migration-cel/check-supplemental-groups/check-supplemental-groups.yaml
@@ -32,8 +32,6 @@ spec:
       cel:
         expressions:
           - expression: >-
-              !has(object.spec.securityContext) ||
-              !has(object.spec.securityContext.supplementalGroups) ||
-              object.spec.securityContext.supplementalGroups.all(supplementalGroup, (supplementalGroup >= 100 && supplementalGroup <= 200) || (supplementalGroup >= 500 && supplementalGroup <= 600))
+              object.spec.?securityContext.?supplementalGroups.orValue([]).all(supplementalGroup, (supplementalGroup >= 100 && supplementalGroup <= 200) || (supplementalGroup >= 500 && supplementalGroup <= 600))
             message: Any supplementalGroup ID must be within the range 100-200 or 500-600.
 

--- a/psp-migration-cel/restrict-adding-capabilities/artifacthub-pkg.yml
+++ b/psp-migration-cel/restrict-adding-capabilities/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "PSP Migration in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: a577515c97fa6c2990de6bc88df222e1555bf11bfacdf00e31b26c5c5fb086ac
+digest: ff4483e54ede27fe5d6ef217725ee7d2b40bc0fe7fb16398919783f6bdce6a3e
 createdAt: "2024-05-23T14:18:49Z"

--- a/psp-migration-cel/restrict-adding-capabilities/restrict-adding-capabilities.yaml
+++ b/psp-migration-cel/restrict-adding-capabilities/restrict-adding-capabilities.yaml
@@ -34,16 +34,13 @@ spec:
         cel:
           variables:
           - name: allContainers
-            expression: "(object.spec.containers + (has(object.spec.initContainers) ? object.spec.initContainers : []) + (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : []))"
+            expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
           - name: allowedCapabilities
             expression: "['NET_BIND_SERVICE', 'CAP_CHOWN']"
           expressions:
             - expression: >-
                 variables.allContainers.all(container, 
-                !has(container.securityContext) ||
-                !has(container.securityContext.capabilities) ||
-                !has(container.securityContext.capabilities.add) ||
-                container.securityContext.capabilities.add.all(capability, capability in variables.allowedCapabilities))
+                container.?securityContext.?capabilities.?add.orValue([]).all(capability, capability in variables.allowedCapabilities))
               message: >-
                 Any capabilities added other than NET_BIND_SERVICE or CAP_CHOWN are disallowed.
 

--- a/tekton-cel/require-tekton-bundle/artifacthub-pkg.yml
+++ b/tekton-cel/require-tekton-bundle/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Tekton in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "TaskRun, PipelineRun"
-digest: 396315ccb0132309267847614372230dbab14ab9935a1aac800d96981da37d10
+digest: d1031e87d2d3e9496022593cac502bd8382863247803e4bd06a1badbe782ae48
 createdAt: "2024-05-24T04:26:34Z"

--- a/tekton-cel/require-tekton-bundle/require-tekton-bundle.yaml
+++ b/tekton-cel/require-tekton-bundle/require-tekton-bundle.yaml
@@ -28,7 +28,7 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "has(object.spec.pipelineRef) && has(object.spec.pipelineRef.bundle) && object.spec.pipelineRef.bundle != ''"
+          - expression: "object.spec.?pipelineRef.?bundle.orValue('') != ''"
             message: "A bundle is required."
   - name: check-bundle-taskrun
     match:
@@ -39,6 +39,6 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "has(object.spec.taskRef) && has(object.spec.taskRef.bundle) && object.spec.taskRef.bundle != ''"
+          - expression: "object.spec.?taskRef.?bundle.orValue('') != ''"
             message: "A bundle is required."
 


### PR DESCRIPTION
## Related Issue(s)
Partially fixes: #1058
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
This PR makes use of optionals to make CEL expressions less redundant. Optionals are used wherever appropriate. No policies from `pod-security-cel` folder was updated in this PR.
<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
