### PR TITLE
Added a new policy: deny-force-delete

### DIFF
--- a/other/deny-force-delete/.chainsaw-test/README.md
+++ b/other/deny-force-delete/.chainsaw-test/README.md
@@ -1,0 +1,21 @@
+# Chainsaw tests for deny-force-delete Policy
+
+This section details the Chainsaw tests for the validation policy that blocks deleting certain resources when `--grace-period=0` and `--force` is used by non cluster admins. 
+
+The test has following steps:
+
+### Step 1:
+
+Apply the `deny-force-delete.yaml` policy and ensure that it is in the `Enforce` mode.
+
+### Step 2:
+
+Check the `deny-force-delete.yaml` policy and confirm the status is set to `True` and is ready.
+
+### Step 3:
+
+Run the policy against a `goodpod.yaml` which has resources with `gracePeriodSeconds` greater than `0`. The policy should allow these resources to go through and they will be deployed on the cluster. 
+
+### Step 4:
+
+Run the policy against a `badpod.yaml` which has resources with `gracePeriodSeconds` less than `1`. The policy should block these resources and generate an error which is validated in the `chainsaw-test.yaml`.

--- a/other/deny-force-delete/.chainsaw-test/badpod.yaml
+++ b/other/deny-force-delete/.chainsaw-test/badpod.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: test1-bad
+  name: test1-bad
+spec:
+  containers:
+  - image: nginx
+    name: test1-bad
+options:
+  gracePeriodSeconds: 0
+---
+# apiVersion: v1
+# kind: Pod
+# metadata:
+#   labels:
+#     run: test2-bad
+#   name: test2-bad
+# spec:
+#   containers:
+#   - image: nginx
+#     name: test2-bad
+# options:
+#   gracePeriodSeconds: 1
+

--- a/other/deny-force-delete/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other/deny-force-delete/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-zero-grace-delete
+status:
+  ready: true

--- a/other/deny-force-delete/.chainsaw-test/chainsaw-test.yaml
+++ b/other/deny-force-delete/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-force-delete
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../deny-force-delete.yaml
+    - patch:
+        resource:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          metadata:
+            name: deny-zero-grace-delete
+          spec:
+            validationFailureAction: Enforce
+    - assert:
+        file: chainsaw-step-01-assert-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: goodpod.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: badpod.yaml

--- a/other/deny-force-delete/.chainsaw-test/goodpod.yaml
+++ b/other/deny-force-delete/.chainsaw-test/goodpod.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: test1-good
+  name: test1-good
+spec:
+  containers:
+  - image: nginx
+    name: test1-good
+options:
+  gracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: test2-good
+  name: test2-good
+spec:
+  containers:
+  - image: nginx
+    name: test2-good
+options:
+  gracePeriodSeconds: 60
+

--- a/other/deny-force-delete/.kyverno-test/README.md
+++ b/other/deny-force-delete/.kyverno-test/README.md
@@ -1,0 +1,47 @@
+# Kyverno CLI tests for deny-zero-grace-delete Policy
+
+This section details the Kyverno CLI tests for the validation policy which blocks certain resources when `--grace-period=0` and `--force` is used by non cluster-admins
+
+The test validates the `deny-force-delete.yaml` policy for both positive and negative test using the Kyverno CLI tests for the following resources:
+
+1. Deployments
+2. CronJobs
+3. Pods
+
+`values.yaml` has the `request.options.gracePeriodSeconds` information for each resource being tested along with policy/rule details. The bad and good resources are passed using the `resource.yaml` file. 
+
+`user_info.yaml` has information about the user as this policy should block deletions only for non cluster-admins when `--grace-period=0` is used. 
+
+`user_info_cluster-admin.yaml` is the file name to use in the `kyverno-test.yaml` when cli tests are run for `cluster-admin` user.
+
+After applying the policy, each resource is validated against the preconfigured result specified in the `kyverno-test.yaml` and if there are any discrepancies, the test is considered as `fail`. 
+
+Note, there is a bug where when a cluster-admin tries to delete the resources, the cli test shows `Pass (Excluded)` instead of `skip`. This is being [tracked](https://github.com/kyverno/kyverno/issues/10497) and will be fixed. We also recommend using the latest version Kyverno CLI when running the CLI tests. The CLI test for this policy was run using `v1.12.4` 
+
+Here is the execution output of cli test with the `cluster-admin` role
+
+```sh
+$ kyverno test .
+Loading test  ( kyverno-test.yaml ) ...
+  Loading values/variables ...
+  Loading user infos ...
+  Loading policies ...
+  Loading resources ...
+  Loading exceptions ...
+  Applying 1 policy to 6 resources ...
+  Checking results ...
+
+│────│────────────────────────│────────────────────────│─────────────────────────────│────────│──────────│
+│ ID │ POLICY                 │ RULE                   │ RESOURCE                    │ RESULT │ REASON   │
+│────│────────────────────────│────────────────────────│─────────────────────────────│────────│──────────│
+│ 1  │ deny-zero-grace-delete │ deny-zero-grace-delete │ Pod/badpod01                │ Pass   │ Excluded │
+│ 2  │ deny-zero-grace-delete │ deny-zero-grace-delete │ Deployment/baddeployment01  │ Pass   │ Excluded │
+│ 3  │ deny-zero-grace-delete │ deny-zero-grace-delete │ CronJob/badcronjob01        │ Pass   │ Excluded │
+│ 4  │ deny-zero-grace-delete │ deny-zero-grace-delete │ Pod/goodpod01               │ Pass   │ Excluded │
+│ 5  │ deny-zero-grace-delete │ deny-zero-grace-delete │ Deployment/gooddeployment01 │ Pass   │ Excluded │
+│ 6  │ deny-zero-grace-delete │ deny-zero-grace-delete │ CronJob/goodcronjob01       │ Pass   │ Excluded │
+│────│────────────────────────│────────────────────────│─────────────────────────────│────────│──────────│
+
+
+Test Summary: 6 tests passed and 0 tests failed
+```

--- a/other/deny-force-delete/.kyverno-test/kyverno-test.yaml
+++ b/other/deny-force-delete/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,48 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-zero-grace-delete
+policies:
+- ../deny-force-delete.yaml
+resources:
+- resource.yaml
+results:
+- kind: Pod
+  policy: deny-zero-grace-delete
+  resources:
+  - badpod01
+  result: fail
+  rule: deny-zero-grace-delete
+- kind: Deployment
+  policy: deny-zero-grace-delete
+  resources:
+  - baddeployment01
+  result: fail
+  rule: deny-zero-grace-delete
+- kind: CronJob
+  policy: deny-zero-grace-delete
+  resources:
+  - badcronjob01
+  result: fail
+  rule: deny-zero-grace-delete
+- kind: Pod
+  policy: deny-zero-grace-delete
+  resources:
+  - goodpod01
+  result: pass
+  rule: deny-zero-grace-delete
+- kind: Deployment
+  policy: deny-zero-grace-delete
+  resources:
+  - gooddeployment01
+  result: pass
+  rule: deny-zero-grace-delete
+- kind: CronJob
+  policy: deny-zero-grace-delete
+  resources:
+  - goodcronjob01
+  result: pass
+  rule: deny-zero-grace-delete
+variables: values.yaml
+#userinfo: user_info_cluster-admin.yaml
+userinfo: user_info.yaml

--- a/other/deny-force-delete/.kyverno-test/resource.yaml
+++ b/other/deny-force-delete/.kyverno-test/resource.yaml
@@ -1,0 +1,135 @@
+###### Pods - Bad
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod01
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename
+  - name: initcontainer02
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: true
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: false
+options:
+  gracePeriodSeconds: 0
+###### Pods - Good
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod01
+spec:
+  initContainers:
+  - name: initcontainer01
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: false
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      allowPrivilegeEscalation: false
+options:
+  gracePeriodSeconds: 30
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+    options:
+      gracePeriodSeconds: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      initContainers:
+      - name: initcontainer01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          allowPrivilegeEscalation: false
+    options:
+      gracePeriodSeconds: 30
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+        options:
+          gracePeriodSeconds: 0
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+          - name: initcontainer01
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: false
+          containers:
+          - name: container01
+            image: dummyimagename
+            securityContext:
+              allowPrivilegeEscalation: false
+        options:
+          gracePeriodSeconds: 30
+

--- a/other/deny-force-delete/.kyverno-test/user_info.yaml
+++ b/other/deny-force-delete/.kyverno-test/user_info.yaml
@@ -1,0 +1,8 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: UserInfo
+metadata:
+  name: user-info
+clusterRoles:
+- developer
+userInfo:
+  username: someone@somecorp.com

--- a/other/deny-force-delete/.kyverno-test/user_info_cluster-admin.yaml
+++ b/other/deny-force-delete/.kyverno-test/user_info_cluster-admin.yaml
@@ -1,0 +1,8 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: UserInfo
+metadata:
+  name: user-info
+clusterRoles:
+- cluster-admin 
+userInfo:
+  username: someone@somecorp.com

--- a/other/deny-force-delete/.kyverno-test/values.yaml
+++ b/other/deny-force-delete/.kyverno-test/values.yaml
@@ -1,0 +1,48 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Values
+globalValues:
+  request.operation: DELETE
+policies:
+- name: deny-zero-grace-delete
+  resources:
+  - name: badpod01
+    values:
+      request.options.gracePeriodSeconds: 0
+  rules:
+  - name: deny-zero-grace-delete
+- name: deny-zero-grace-delete
+  resources:
+  - name: baddeployment01
+    values:
+      request.options.gracePeriodSeconds: 0
+  rules:
+  - name: deny-zero-grace-delete
+- name: deny-zero-grace-delete
+  resources:
+  - name: badcronjob01
+    values:
+      request.options.gracePeriodSeconds: 0
+  rules:
+  - name: deny-zero-grace-delete
+- name: deny-zero-grace-delete
+  ## good resources  
+  resources:
+  - name: goodpod01
+    values:
+      request.options.gracePeriodSeconds: 30
+  rules:
+  - name: deny-zero-grace-delete
+- name: deny-zero-grace-delete
+  resources:
+  - name: gooddeployment01
+    values:
+      request.options.gracePeriodSeconds: 30
+  rules:
+  - name: deny-zero-grace-delete
+- name: deny-zero-grace-delete
+  resources:
+  - name: goodcronjob01
+    values:
+      request.options.gracePeriodSeconds: 30
+  rules:
+  - name: deny-zero-grace-delete

--- a/other/deny-force-delete/README.md
+++ b/other/deny-force-delete/README.md
@@ -1,0 +1,54 @@
+# Deny Force delete
+
+Deny deleting any resources for non-admins with "--grace-period=0 --force" option.
+
+## Install
+
+```sh
+kubectl apply -f policies/deny-force-delete/
+```
+
+## Test
+
+### Deploying a sample pod with nginx image
+
+#### Sample pod yaml
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sample-pod
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: sample-container
+    image: nginx:latest
+```
+Apply the above pod.yaml file to create a pod.
+
+### Delete with --grace-period=0 as a non-admin user
+
+```sh
+kubectl delete pod.yaml --grace-period=0 --force
+```
+The above command will fail with an error for any non-admin user
+
+### Delete with any other --grace-period duration as a non-admin user
+
+For non-admin users, the command "kubectl delete <resource> --grace-period=duration --force" works for any other value for duration other than 0. 
+
+Note, if the policy should block non-admin users from deleting resources when `--now` is used, the deny condition in the policy should be updated like below.
+
+```sh
+      deny:
+        conditions:
+          all:
+          - key: "{{ request.options.gracePeriodSeconds }}"
+            operator: LessThan
+            value: 2
+```
+
+### Delete with any other --grace-period duration as a admin user
+
+Admin users can delete any resource with --grace-period=0

--- a/other/deny-force-delete/artifacthub-pkg.yml
+++ b/other/deny-force-delete/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: deny-force-delete
+version: 1.0.0
+displayName: Deny Force Deletion of Resources
+createdAt: "2024-07-19T10:30:02.000Z"
+description: >-
+  When deleting any resources (Pods/ Deployments/ Services/ Cronjobs etc.), the default timer is 30 seconds which allows a graceful shutdown of the resource. The flag '--grace-period=0 --force' removes this timer and shutsdown the resource immediately. Using this flag may result in data loss as resources as the state may not be saved or lead to potential service disruption. This policy prevents any non-admins to forcefully delete any resources immediately.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/deny-force-delete/deny-force-delete.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+readme: |
+  Force deletion of resources with '--grace-period=0 --force' is not allowed for non-admin users.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.28"
+  kyverno/subject: "Pod"
+digest: a5bf40f1814b078b737d2ff69240b9f9540e1dec76b6866fbf0f06ce55828832

--- a/other/deny-force-delete/artifacthub-pkg.yml
+++ b/other/deny-force-delete/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.28"
   kyverno/subject: "Pod"
-digest: ecbb0fc15eef41b6630a4886b852af1ffe329ddf6fb6d571d557a44cd3b196f8
+digest: a5bf40f1814b078b737d2ff69240b9f9540e1dec76b6866fbf0f06ce55828832

--- a/other/deny-force-delete/artifacthub-pkg.yml
+++ b/other/deny-force-delete/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.28"
   kyverno/subject: "Pod"
-digest: a5bf40f1814b078b737d2ff69240b9f9540e1dec76b6866fbf0f06ce55828832
+digest: ecbb0fc15eef41b6630a4886b852af1ffe329ddf6fb6d571d557a44cd3b196f8

--- a/other/deny-force-delete/deny-force-delete.yaml
+++ b/other/deny-force-delete/deny-force-delete.yaml
@@ -6,18 +6,20 @@ metadata:
     policies.kyverno.io/title: Deny force deletion of resources with zero grace period
     policies.kyverno.io/category: Other
     policies.kyverno.io/subject: Pod
-    kyverno.io/kyverno-version: 1.1.0
-    policies.kyverno.io/minversion: 1.9.0
+    kyverno.io/kyverno-version: 1.12.5
+    policies.kyverno.io/minversion: 1.10.0
     kyverno.io/kubernetes-version: "1.26"
     policies.kyverno.io/description: >-
-      When deleting any resources (Pods/ Deployments/ Services/ Cronjobs etc.), the default
-      timer is 30 seconds which allows a graceful shutdown of the resource. The flag 
-      '--grace-period=0 --force' removes this timer and shutsdown the resource immediately.
-      Using this flag may result in data loss as resources as the state may not be saved or
-      lead to potential service disruption. This policy prevents any non-admins to forcefully
-      delete any resources immediately.  
+      When deleting any resources, the default timer is 30 seconds which allows a graceful 
+      shutdown of the resource. The flags '--grace-period=0 --force' removes this timer and 
+      deletes the resource immediately.
+      Force deleting Kubernetes pods can result in lingering processes which  can cause issues 
+      like data corruption if these processes access shared resources or external APIs using 
+      the pod’s identity. Use force deletion only when certain the pod is terminated or if the 
+      application tolerates duplicates. Force deletion may cause resource allocation conflicts, 
+      leading to newly assigned pods being immediately evicted.      
 spec:
-  validationFailureAction: enforce
+  validationFailureAction: Audit
   background: false
   rules:
   - name: deny-zero-grace-delete
@@ -26,10 +28,6 @@ spec:
       - resources:
           kinds:
           - Pod
-          - Deployment
-          - Service
-          - PersistentVolumeClaim
-          - CronJob
           operations:
           - DELETE
     exclude:
@@ -41,6 +39,6 @@ spec:
       deny:
         conditions:
           all:
-          - key: "{{ request.options.gracePeriodSeconds }}"
-            operator: LessThan
-            value: 1
+          - key: "{{ request.options.gracePeriodSeconds || `1` }}"
+            operator: Equals 
+            value: 0

--- a/other/deny-force-delete/deny-force-delete.yaml
+++ b/other/deny-force-delete/deny-force-delete.yaml
@@ -1,0 +1,46 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-zero-grace-delete
+  annotations:
+    policies.kyverno.io/title: Deny force deletion of resources with zero grace period
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.1.0
+    policies.kyverno.io/minversion: 1.9.0
+    kyverno.io/kubernetes-version: "1.26"
+    policies.kyverno.io/description: >-
+      When deleting any resources (Pods/ Deployments/ Services/ Cronjobs etc.), the default
+      timer is 30 seconds which allows a graceful shutdown of the resource. The flag 
+      '--grace-period=0 --force' removes this timer and shutsdown the resource immediately.
+      Using this flag may result in data loss as resources as the state may not be saved or
+      lead to potential service disruption. This policy prevents any non-admins to forcefully
+      delete any resources immediately.  
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: deny-zero-grace-delete
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          - Deployment
+          - Service
+          - PersistentVolumeClaim
+          - CronJob
+          operations:
+          - DELETE
+    exclude:
+      any:
+      - clusterRoles:
+        - cluster-admin
+    validate:
+      message: "Force deletion of resources with '--grace-period=0 --force' is not allowed for non-admin users."
+      deny:
+        conditions:
+          all:
+          - key: "{{ request.options.gracePeriodSeconds }}"
+            operator: LessThan
+            value: 1

--- a/other/deny-force-delete/deny-force-delete.yaml
+++ b/other/deny-force-delete/deny-force-delete.yaml
@@ -6,20 +6,18 @@ metadata:
     policies.kyverno.io/title: Deny force deletion of resources with zero grace period
     policies.kyverno.io/category: Other
     policies.kyverno.io/subject: Pod
-    kyverno.io/kyverno-version: 1.12.5
-    policies.kyverno.io/minversion: 1.10.0
+    kyverno.io/kyverno-version: 1.1.0
+    policies.kyverno.io/minversion: 1.9.0
     kyverno.io/kubernetes-version: "1.26"
     policies.kyverno.io/description: >-
-      When deleting any resources, the default timer is 30 seconds which allows a graceful 
-      shutdown of the resource. The flags '--grace-period=0 --force' removes this timer and 
-      deletes the resource immediately.
-      Force deleting Kubernetes pods can result in lingering processes which  can cause issues 
-      like data corruption if these processes access shared resources or external APIs using 
-      the pod’s identity. Use force deletion only when certain the pod is terminated or if the 
-      application tolerates duplicates. Force deletion may cause resource allocation conflicts, 
-      leading to newly assigned pods being immediately evicted.      
+      When deleting any resources (Pods/ Deployments/ Services/ Cronjobs etc.), the default
+      timer is 30 seconds which allows a graceful shutdown of the resource. The flag 
+      '--grace-period=0 --force' removes this timer and shutsdown the resource immediately.
+      Using this flag may result in data loss as resources as the state may not be saved or
+      lead to potential service disruption. This policy prevents any non-admins to forcefully
+      delete any resources immediately.  
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: enforce
   background: false
   rules:
   - name: deny-zero-grace-delete
@@ -28,6 +26,10 @@ spec:
       - resources:
           kinds:
           - Pod
+          - Deployment
+          - Service
+          - PersistentVolumeClaim
+          - CronJob
           operations:
           - DELETE
     exclude:
@@ -39,6 +41,6 @@ spec:
       deny:
         conditions:
           all:
-          - key: "{{ request.options.gracePeriodSeconds || `1` }}"
-            operator: Equals 
-            value: 0
+          - key: "{{ request.options.gracePeriodSeconds }}"
+            operator: LessThan
+            value: 1


### PR DESCRIPTION
## Description

When deleting any resources (Pods/ Deployments/ Services/ Cronjobs etc.), the default timer is 30 seconds which allows a graceful shutdown of the resource. The flag '--grace-period=0 --force' removes this timer and shutsdown the resource immediately. Using this flag may result in data loss as resources as the state may not be saved or lead to potential service disruption. This policy prevents any non-admins to forcefully delete any resources immediately.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
