### PR TITLE
Added policy: deny-default-service-accounts

### DIFF
--- a/other/deny-default-service-accounts/.chainsaw-test/badpod.yaml
+++ b/other/deny-default-service-accounts/.chainsaw-test/badpod.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod01
+spec:
+  serviceAccountName: default
+  containers:
+  - name: badpod01
+    image: dummyimagename
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod02
+spec:
+  serviceAccountName: default
+  containers:
+  - image: dummyimagename
+    name: badpod02
+

--- a/other/deny-default-service-accounts/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other/deny-default-service-accounts/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,0 +1,6 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-default-service-accounts
+status:
+  ready: true

--- a/other/deny-default-service-accounts/.chainsaw-test/chainsaw-test.yaml
+++ b/other/deny-default-service-accounts/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,36 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: deny-default-service-accounts
+spec:
+  steps:
+  - name: step-01
+    try:
+    - create:
+        resource:
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: custom-service-account 
+    - apply:
+        file: ../deny-default-service-accounts.yaml
+    - patch:
+        resource:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          metadata:
+            name: deny-default-service-accounts
+          spec:
+            validationFailureAction: Enforce
+    - assert:
+        file: chainsaw-step-01-assert-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: goodpod.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: badpod.yaml

--- a/other/deny-default-service-accounts/.chainsaw-test/goodpod.yaml
+++ b/other/deny-default-service-accounts/.chainsaw-test/goodpod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod01
+spec:
+  serviceAccountName: custom-service-account
+  containers:
+  - image: nginx
+    name: goodpod01
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod02
+spec:
+  serviceAccountName: custom-service-account
+  containers:
+  - image: nginx
+    name: goodpod02

--- a/other/deny-default-service-accounts/.chainsaw-test/testpod.yaml
+++ b/other/deny-default-service-accounts/.chainsaw-test/testpod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod01
+spec:
+  serviceAccountName: custom-service-account
+  containers:
+  - name: goodpod01
+    image: dummyimage

--- a/other/deny-default-service-accounts/.kyverno-test/kyverno-test.yaml
+++ b/other/deny-default-service-accounts/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,33 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kyverno-test.yaml
+policies:
+- ../deny-default-service-accounts.yaml
+resources:
+- resources.yaml
+results:
+- kind: Pod
+  policy: deny-default-service-accounts
+  resources:
+  - goodpod01
+  result: pass
+  rule: deny-default-service-accounts
+- kind: Pod
+  policy: deny-default-service-accounts
+  resources:
+  - goodpod02
+  result: pass
+  rule: deny-default-service-accounts
+- kind: Pod
+  policy: deny-default-service-accounts
+  resources:
+  - badpod01
+  result: fail
+  rule: deny-default-service-accounts
+- kind: Pod
+  policy: deny-default-service-accounts
+  resources:
+  - badpod02
+  result: fail
+  rule: deny-default-service-accounts

--- a/other/deny-default-service-accounts/.kyverno-test/policy.yaml
+++ b/other/deny-default-service-accounts/.kyverno-test/policy.yaml
@@ -1,0 +1,30 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-default-service-accounts
+  annotations:
+    policies.kyverno.io/title: Deny using default service accounts
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.11.0
+    policies.kyverno.io/minversion: 1.10.0
+    kyverno.io/kubernetes-version: "1.26"
+    policies.kyverno.io/description: >-
+      For an enhnaced security posture, it is recommended to use specific service accounts
+      and not the default service accounts. These service accounts provide an identity for
+      processes that run in individual Pods and map them to a ServiceAccount object. 
+      This policy flags the Pods that use any default service accounts.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+  - name: deny-default-service-accounts
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "Default service accounts are not allowed to be used."
+      pattern:
+        spec:
+          serviceAccountName: "!default"

--- a/other/deny-default-service-accounts/.kyverno-test/resources.yaml
+++ b/other/deny-default-service-accounts/.kyverno-test/resources.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod01
+spec:
+  serviceAccountName: custom-service-account01
+  containers:
+  - name: goodpod01
+    image: dummyimage
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod02
+spec:
+  serviceAccountName: custom-service-account02
+  containers:
+  - name: goodpod02
+    image: dummyimage
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod01
+spec:
+  serviceAccountName: default
+  containers:
+  - name: badpod01
+    image: dummyimage
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod02
+spec:
+  serviceAccountName: default
+  containers:
+  - name: badpod02
+    image: dummyimage

--- a/other/deny-default-service-accounts/artifacthub-pkg.yml
+++ b/other/deny-default-service-accounts/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: deny-force-delete
+version: 1.0.0
+displayName: Deny using Default Service Accounts
+createdAt: "2024-08-05T10:30:02.000Z"
+description: >-
+  It is recommended to use specific service accounts and not the default service accounts. These service accounts provide an identity for that run in individual Pods and map them to a ServiceAccount object. This policy flags the Pods that use any default service accounts.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/deny-default-service-accounts//deny-default-service-accounts.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+readme: |
+  Resources are not allowed to be deployed with default service accounts.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.28"
+  kyverno/subject: "Pod"
+digest: cdb972732797f3434f4c0fa03386167130e612a1f5fafceb6fc28e885df9dc62

--- a/other/deny-default-service-accounts/deny-default-service-accounts.yaml
+++ b/other/deny-default-service-accounts/deny-default-service-accounts.yaml
@@ -1,0 +1,30 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-default-service-accounts
+  annotations:
+    policies.kyverno.io/title: Deny using default service accounts
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.11.0
+    policies.kyverno.io/minversion: 1.10.0
+    kyverno.io/kubernetes-version: "1.26"
+    policies.kyverno.io/description: >-
+      For an enhnaced security posture, it is recommended to use specific service accounts
+      and not the default service accounts. These service accounts provide an identity for
+      processes that run in individual Pods and map them to a ServiceAccount object. 
+      This policy flags the Pods that use any default service accounts.
+spec:
+  validationFailureAction: audit
+  background: false
+  rules:
+  - name: deny-default-service-accounts
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "Default service accounts are not allowed to be used."
+      pattern:
+        spec:
+          serviceAccountName: "!default"


### PR DESCRIPTION
## Description

For an enhnaced security posture, it is recommended to use specific service accounts and not the default service accounts. These service accounts provide an identity for processes that run in individual Pods and map them to a ServiceAccount object. This policy flags the Pods that use any default service accounts.
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
