### PR TITLE
Added a policy for deny-default-service-account-bindings

### DIFF
--- a/other/deny-default-service-account-bindings/.tests/chainsaw-test.yaml
+++ b/other/deny-default-service-account-bindings/.tests/chainsaw-test.yaml
@@ -1,0 +1,13 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: sample-test
+spec:
+  steps:
+  - name: step-01
+    try:
+    - script:
+        content: kyverno test .
+        check:  
+          ($error != null): false

--- a/other/deny-default-service-account-bindings/.tests/kyverno-test.yaml
+++ b/other/deny-default-service-account-bindings/.tests/kyverno-test.yaml
@@ -1,0 +1,23 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kyverno-test.yaml
+policies:
+- ../deny-default-service-account-bindings.yaml
+resources:
+- resources.yaml
+results:
+- kind: RoleBinding
+  policy: deny-default-service-account-bindings
+  resources:
+  - goodpod01
+  - goodpod02
+  result: pass
+  rule: deny-default-service-account-bindings
+- kind: RoleBinding
+  policy: deny-default-service-account-bindings
+  resources:
+  - badpod01
+  - badpod02
+  result: fail
+  rule: deny-default-service-account-bindings

--- a/other/deny-default-service-account-bindings/.tests/resources.yaml
+++ b/other/deny-default-service-account-bindings/.tests/resources.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: goodpod01
+subjects:
+- kind: ServiceAccount
+  name: custom-service-account01
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: goodpod02
+subjects:
+- kind: ServiceAccount
+  name: custom-service-account02
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: badpod01
+subjects:
+- kind: ServiceAccount
+  name: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: badpod02
+subjects:
+- kind: ServiceAccount
+  name: default

--- a/other/deny-default-service-account-bindings/artifacthub-pkg.yml
+++ b/other/deny-default-service-account-bindings/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: deny-force-delete
+version: 1.0.0
+displayName: Deny Force Deletion of Resources
+createdAt: "2024-08-05T10:30:02.000Z"
+description: >-
+  The default service account is automatically mounted into all pods in a namespace unless explicitly overridden. If this account is bound to a Role or ClusterRole that grants extensive permissions, every pod in the namespace using the default service account will inherit these permissions. This setup can lead to unnecessary security risks if a pod is compromised, as an attacker could potentially gain access to other resources within the cluster.For an enhnaced security, using the default service account in RoleBindings is not recommended.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/deny-default-service-account-bindings/deny-default-service-account-bindings.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+readme: |
+  Using the default service account in RoleBindings is not allowed.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.28"
+  kyverno/subject: "Pod"
+digest: ca4094718f70c2bfbfad6051ce357a34c5dbb65512dcc118e0897786626aff37

--- a/other/deny-default-service-account-bindings/deny-default-service-account-bindings.yaml
+++ b/other/deny-default-service-account-bindings/deny-default-service-account-bindings.yaml
@@ -1,0 +1,34 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-default-service-account-bindings
+  annotations:
+    policies.kyverno.io/title: Deny binding of default service accounts
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.11.0
+    policies.kyverno.io/minversion: 1.10.0
+    kyverno.io/kubernetes-version: "1.26"
+    policies.kyverno.io/description: >-
+      The default service account is automatically mounted into all pods in a namespace unless 
+      explicitly overridden. If this account is bound to a Role or ClusterRole that grants extensive 
+      permissions, every pod in the namespace using the default service account will inherit these 
+      permissions. This setup can lead to unnecessary security risks if a pod is compromised, as an 
+      attacker could potentially gain access to other resources within the cluster.For an enhnaced 
+      security, using the default service account in RoleBindings is not recommended.
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+    - name: deny-default-service-account-bindings
+      match:
+        resources:
+          kinds:
+            - RoleBinding
+            - ClusterRoleBinding
+      validate:
+        message: "Using the default service account in RoleBindings is not allowed."
+        pattern:
+          subjects:
+            - kind: "ServiceAccount"
+              name: "!default"


### PR DESCRIPTION
## Description

The default service account is automatically mounted into all pods in a namespace unless explicitly overridden. If this account is bound to a Role or ClusterRole that grants extensive permissions, every pod in the namespace using the default service account will inherit these permissions. This setup can lead to unnecessary security risks if a pod is compromised, as an attacker could potentially gain access to other resources within the cluster.For an enhnaced security, using the default service account in RoleBindings is not recommended.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
