### PR TITLE
fix: use generateExisting instead of generateExistingOnPolicyUpdate

### DIFF
--- a/argo/argo-cluster-generation-from-rancher-capi/argo-cluster-generation-from-rancher-capi.yaml
+++ b/argo/argo-cluster-generation-from-rancher-capi/argo-cluster-generation-from-rancher-capi.yaml
@@ -19,7 +19,7 @@ metadata:
       "Cluster-API cluster auto-registration" and Rancher issue https://github.com/rancher/rancher/issues/38053
       "Fix type and labels Rancher v2 provisioner specifies when creating CAPI Cluster Secret".
 spec:
-  generateExistingOnPolicyUpdate: true
+  generateExisting: true
   rules:
   - name: source-rancher-non-local-cluster-and-capi-secret
     match:

--- a/argo/argo-cluster-generation-from-rancher-capi/artifacthub-pkg.yml
+++ b/argo/argo-cluster-generation-from-rancher-capi/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Argo"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Secret"
-digest: ddc3b0655fa1302142238ec869466e5f2ce2547f2f683effc7e5b0a813803b54
+digest: 955247857bea3c8e70733e8dc214406319f08ded53700ba42a8bc59dfcf94aa5

--- a/kubeops/config-syncer-secret-generation-from-rancher-capi/artifacthub-pkg.yml
+++ b/kubeops/config-syncer-secret-generation-from-rancher-capi/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Kubeops"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Secret"
-digest: f45a05bf32cc4f14e962c58b62fbb69144d04a04a97abb08fe69e6c5843eb8e5
+digest: 9ce7e5f048b29eeef789ebf868ed508a593a43a49b3ae76a8e031160779d77bf

--- a/kubeops/config-syncer-secret-generation-from-rancher-capi/config-syncer-secret-generation-from-rancher-capi.yaml
+++ b/kubeops/config-syncer-secret-generation-from-rancher-capi/config-syncer-secret-generation-from-rancher-capi.yaml
@@ -16,7 +16,7 @@ metadata:
       required by the Kubeops Config Syncer for it to sync ConfigMaps/Secrets from
       the Rancher management cluster to downstream clusters.
 spec:
-  generateExistingOnPolicyUpdate: true
+  generateExisting: true
   rules:
   - name: source-rancher-non-local-cluster-and-capi-secret
     match:

--- a/other/generate-networkpolicy-existing/artifacthub-pkg.yml
+++ b/other/generate-networkpolicy-existing/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Namespace, NetworkPolicy"
-digest: 4cf8c5f46d007fdeb4f4da902003f65cbf9c783458ec752c342e5521eccf8c38
+digest: 4b22640f313949b16d47e144996489a7070e952b06e68f3ad1dc9ee5e013d976

--- a/other/generate-networkpolicy-existing/generate-networkpolicy-existing.yaml
+++ b/other/generate-networkpolicy-existing/generate-networkpolicy-existing.yaml
@@ -17,7 +17,7 @@ metadata:
       is additional overhead. This policy creates a new NetworkPolicy for existing
       Namespaces which results in a default deny behavior and labels it with created-by=kyverno.
 spec:
-  generateExistingOnPolicyUpdate: true
+  generateExisting: true
   rules:
   - name: generate-existing-networkpolicy
     match:


### PR DESCRIPTION
## Related Issue(s)
https://github.com/kyverno/kyverno/pull/10807
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
This PR modifies generate policies to make use of `spec.generateExisting` instead of `spec.generateExistingOnPolicyUpdate` as this field is deprecated in 1.10 and will no longer be used.
<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
