### PR TITLE
fix: restrict-node-label-changes chainsaw test

### DIFF
--- a/other/restrict-node-label-changes/artifacthub-pkg.yml
+++ b/other/restrict-node-label-changes/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Node, Label"
-digest: 5f85ca279377a987568daa4353191e8e843ed6e708ffc9a4163e0fd95ec27894
+digest: 38106c8df0ccdaf9ae63887c117672b7eda38149160fa30d112dff26fa76fcc9

--- a/other/restrict-node-label-changes/restrict-node-label-changes.yaml
+++ b/other/restrict-node-label-changes/restrict-node-label-changes.yaml
@@ -25,6 +25,8 @@ spec:
       - resources:
           kinds:
           - Node
+          operations:
+          - UPDATE
     validate:
       message: "Modifying the `foo` label on a Node is not allowed."
       deny:
@@ -42,11 +44,10 @@ spec:
       - resources:
           kinds:
           - Node
+          operations:
+          - UPDATE
     preconditions:
       all:
-      - key: "{{ request.operation || 'BACKGROUND' }}"
-        operator: Equals
-        value: UPDATE
       - key: "{{ request.oldObject.metadata.labels.foo || '' }}"
         operator: Equals
         value: "?*"

--- a/other/restrict-node-label-changes/restrict-node-label-changes.yaml
+++ b/other/restrict-node-label-changes/restrict-node-label-changes.yaml
@@ -25,9 +25,8 @@ spec:
       - resources:
           kinds:
           - Node
-          operations:
-          - UPDATE
     validate:
+      allowExistingViolations: false
       message: "Modifying the `foo` label on a Node is not allowed."
       deny:
         conditions:
@@ -44,14 +43,16 @@ spec:
       - resources:
           kinds:
           - Node
-          operations:
-          - UPDATE
     preconditions:
       all:
+      - key: "{{ request.operation || 'BACKGROUND' }}"
+        operator: Equals
+        value: UPDATE
       - key: "{{ request.oldObject.metadata.labels.foo || '' }}"
         operator: Equals
         value: "?*"
     validate:
+      allowExistingViolations: false
       message: "Removing the `foo` label on a Node is not allowed."
       pattern:
         metadata:


### PR DESCRIPTION
## Related Issue(s)

Chainsaw test `other/restrict-node-label-changes/restrict-node-label-changes.yaml` broke after PR https://github.com/kyverno/kyverno/pull/10033#issuecomment-2047899999. This PR fixes the test
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
