### PR TITLE
fix: modify the ingress resource

### DIFF
--- a/other-cel/prevent-cr8escape/.chainsaw-test/pods-good.yaml
+++ b/other-cel/prevent-cr8escape/.chainsaw-test/pods-good.yaml
@@ -18,11 +18,11 @@ kind: Pod
 metadata:
   name: goodpod02
 spec:
-  securityContext:
-    allowPrivilegeEscalation: false
   containers:
   - name: busybox
     image: ghcr.io/kyverno/test-busybox:1.35
+    securityContext:
+      allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Pod
@@ -32,4 +32,3 @@ spec:
   containers:
   - name: busybox
     image: ghcr.io/kyverno/test-busybox:1.35
-

--- a/other-cel/require-ingress-https/.chainsaw-test/ingress-good.yaml
+++ b/other-cel/require-ingress-https/.chainsaw-test/ingress-good.yaml
@@ -9,7 +9,7 @@ spec:
   ingressClassName: someingress
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - backend:
           service:
@@ -33,7 +33,7 @@ spec:
   ingressClassName: nginx-int
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix
@@ -43,7 +43,7 @@ spec:
             port:
               number: 80
   - host: endpoint02
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix
@@ -56,4 +56,3 @@ spec:
   - hosts:
     - endpoint01
     - endpoint02
-

--- a/other-cel/require-ingress-https/.kyverno-test/resource.yaml
+++ b/other-cel/require-ingress-https/.kyverno-test/resource.yaml
@@ -32,7 +32,7 @@ spec:
   ingressClassName: nginx-int
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix
@@ -64,7 +64,7 @@ spec:
   ingressClassName: nginx-int
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix
@@ -99,7 +99,7 @@ spec:
   ingressClassName: nginx-int
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix
@@ -130,7 +130,7 @@ spec:
   ingressClassName: someingress
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - backend:
           service:
@@ -154,7 +154,7 @@ spec:
   ingressClassName: nginx-int
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix
@@ -164,7 +164,7 @@ spec:
             port:
               number: 80
   - host: endpoint02
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix

--- a/other-cel/restrict-ingress-classes/.chainsaw-test/ingress-bad.yaml
+++ b/other-cel/restrict-ingress-classes/.chainsaw-test/ingress-bad.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - backend:
           service:
@@ -27,7 +27,7 @@ metadata:
 spec:
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix

--- a/other-cel/restrict-ingress-classes/.chainsaw-test/ingress-good.yaml
+++ b/other-cel/restrict-ingress-classes/.chainsaw-test/ingress-good.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - backend:
           service:
@@ -28,7 +28,7 @@ metadata:
 spec:
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix

--- a/other-cel/restrict-ingress-defaultbackend/.chainsaw-test/ingress-good.yaml
+++ b/other-cel/restrict-ingress-defaultbackend/.chainsaw-test/ingress-good.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - backend:
           service:
@@ -22,7 +22,7 @@ metadata:
 spec:
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix

--- a/other-cel/restrict-ingress-wildcard/.chainsaw-test/ingress-bad.yaml
+++ b/other-cel/restrict-ingress-wildcard/.chainsaw-test/ingress-bad.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   rules:
   - host: "*.foo.bar"
-    https:
+    http:
       paths:
       - backend:
           service:
@@ -22,7 +22,7 @@ metadata:
 spec:
   rules:
   - host: foo-bar
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix
@@ -32,7 +32,7 @@ spec:
             port:
               number: 80
   - host: "*.example.com"
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix
@@ -49,7 +49,7 @@ metadata:
 spec:
   rules:
   - host: "*.bar"
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix
@@ -59,7 +59,7 @@ spec:
             port:
               number: 80
   - host: foo-bar
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix

--- a/other-cel/restrict-ingress-wildcard/.chainsaw-test/ingress-good.yaml
+++ b/other-cel/restrict-ingress-wildcard/.chainsaw-test/ingress-good.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   rules:
   - host: endpoint01
-    https:
+    http:
       paths:
       - backend:
           service:
@@ -22,7 +22,7 @@ metadata:
 spec:
   rules:
   - host: endpoint02
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix
@@ -32,7 +32,7 @@ spec:
             port:
               number: 80
   - host: endpoint01
-    https:
+    http:
       paths:
       - path: /testpath
         pathType: Prefix

--- a/other-cel/restrict-node-affinity/.chainsaw-test/pod-good.yaml
+++ b/other-cel/restrict-node-affinity/.chainsaw-test/pod-good.yaml
@@ -14,14 +14,16 @@ metadata:
 spec:
   affinity:
     podAffinity:
-      prefferedDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: bar
-            operator: In
-            values:
-            - bar
-        topologyKey: topology.kubernetes.io/zone
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: bar
+              operator: In
+              values:
+              - bar
+          topologyKey: topology.kubernetes.io/zone
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 100
@@ -36,4 +38,3 @@ spec:
   containers:
     - name: busybox
       image: ghcr.io/kyverno/test-busybox:1.35
-

--- a/other-cel/restrict-node-affinity/.chainsaw-test/podcontroller-bad.yaml
+++ b/other-cel/restrict-node-affinity/.chainsaw-test/podcontroller-bad.yaml
@@ -53,4 +53,3 @@ spec:
           - name: busybox
             image: ghcr.io/kyverno/test-busybox:1.35
           restartPolicy: OnFailure
-

--- a/other-cel/restrict-node-affinity/.chainsaw-test/podcontroller-good.yaml
+++ b/other-cel/restrict-node-affinity/.chainsaw-test/podcontroller-good.yaml
@@ -17,14 +17,16 @@ spec:
     spec:
       affinity:
         podAffinity:
-          prefferedDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: bar
-                operator: In
-                values:
-                - bar
-            topologyKey: topology.kubernetes.io/zone
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: bar
+                  operator: In
+                  values:
+                  - bar
+              topologyKey: topology.kubernetes.io/zone
       containers:
       - name: busybox
         image: ghcr.io/kyverno/test-busybox:1.35
@@ -43,4 +45,3 @@ spec:
           - name: busybox
             image: ghcr.io/kyverno/test-busybox:1.35
           restartPolicy: OnFailure
-

--- a/other-cel/restrict-node-affinity/.kyverno-test/resource.yaml
+++ b/other-cel/restrict-node-affinity/.kyverno-test/resource.yaml
@@ -89,4 +89,3 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "500m"
-

--- a/tekton-cel/require-tekton-bundle/artifacthub-pkg.yml
+++ b/tekton-cel/require-tekton-bundle/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Tekton in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "TaskRun, PipelineRun"
-digest: d1031e87d2d3e9496022593cac502bd8382863247803e4bd06a1badbe782ae48
+digest: 040ff6442dff95a14000ef7ac2a4f953659997d19654a8a959c0b59427ac4ee9
 createdAt: "2024-05-24T04:26:34Z"

--- a/tekton-cel/require-tekton-bundle/require-tekton-bundle.yaml
+++ b/tekton-cel/require-tekton-bundle/require-tekton-bundle.yaml
@@ -36,6 +36,9 @@ spec:
       - resources:
           kinds:
           - TaskRun
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       cel:
         expressions:


### PR DESCRIPTION
## Related Issue(s)
N/A
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
This PR fixes the test `other-cel/require-ingress-https` as it was failing because of the following error:
```
 l.go:52: | 11:40:28 | require-ingress-https | step-02   | CREATE    | WARN  | networking.k8s.io/v1/Ingress @ chainsaw-moral-parrot/goodingress01
        === ERROR
        Ingress in version "v1" cannot be handled as a Ingress: strict decoding error: unknown field "spec.rules[0].https"
```
<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
