### PR TITLE
fix disallow-privilege-escalation policy

### DIFF
--- a/pod-security-cel/restricted/disallow-privilege-escalation/.chainsaw-test/podcontroller-bad.yaml
+++ b/pod-security-cel/restricted/disallow-privilege-escalation/.chainsaw-test/podcontroller-bad.yaml
@@ -15,9 +15,6 @@ spec:
       containers:
       - name: container01
         image: ghcr.io/kyverno/test-busybox:1.35
-        securityContext:
-          runAsNonRoot: true
-          allowPrivilegeEscalation: true
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -56,8 +53,6 @@ spec:
       containers:
       - name: container01
         image: ghcr.io/kyverno/test-busybox:1.35
-        securityContext:
-          allowPrivilegeEscalation: true
       - name: container02
         image: ghcr.io/kyverno/test-busybox:1.35
         securityContext:
@@ -151,9 +146,6 @@ spec:
           containers:
           - name: container01
             image: ghcr.io/kyverno/test-busybox:1.35
-            securityContext:
-              runAsNonRoot: true
-              allowPrivilegeEscalation: true
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/pod-security-cel/restricted/disallow-privilege-escalation/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/disallow-privilege-escalation/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 3d361694af595b4070d5ad6ef8e65f893069209a29b7b23d026ea685393e96b5
+digest: c9bd2d00d8238f4cb76a30bacb3daaf2e7adeeb2f8c5f0a31372e29fbae89a2c
 createdAt: "2024-08-30T09:04:49Z"

--- a/pod-security-cel/restricted/disallow-privilege-escalation/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/disallow-privilege-escalation/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: c9bd2d00d8238f4cb76a30bacb3daaf2e7adeeb2f8c5f0a31372e29fbae89a2c
+digest: 7dcc7fc94c8c26c855804a9872be536cf327a3d4f2305ecea176eb04d2964491
 createdAt: "2024-08-30T09:04:49Z"

--- a/pod-security-cel/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/pod-security-cel/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -37,7 +37,7 @@ spec:
           expressions:
             - expression: >- 
                 variables.allContainers.all(container, 
-                container.?securityContext.?allowPrivilegeEscalation.orValue(true) == false)
+                container.?securityContext.allowPrivilegeEscalation.orValue(true) == false)
               message: >-
                 Privilege escalation is disallowed. 
                 All containers must set the securityContext.allowPrivilegeEscalation field to `false`.

--- a/pod-security-cel/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/pod-security-cel/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -37,6 +37,8 @@ spec:
           expressions:
             - expression: >- 
                 variables.allContainers.all(container, 
+                has(container.securityContext) &&
+                has(container.securityContext.allowPrivilegeEscalation) &&
                 container.securityContext.allowPrivilegeEscalation == false)
               message: >-
                 Privilege escalation is disallowed. 

--- a/pod-security-cel/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/pod-security-cel/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -37,7 +37,7 @@ spec:
           expressions:
             - expression: >- 
                 variables.allContainers.all(container, 
-                container.?securityContext.?allowPrivilegeEscalation.orValue(false) == false)
+                container.securityContext.allowPrivilegeEscalation == false)
               message: >-
                 Privilege escalation is disallowed. 
                 All containers must set the securityContext.allowPrivilegeEscalation field to `false`.

--- a/pod-security-cel/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/pod-security-cel/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -37,9 +37,7 @@ spec:
           expressions:
             - expression: >- 
                 variables.allContainers.all(container, 
-                has(container.securityContext) &&
-                has(container.securityContext.allowPrivilegeEscalation) &&
-                container.securityContext.allowPrivilegeEscalation == false)
+                container.?securityContext.?allowPrivilegeEscalation.orValue(true) == false)
               message: >-
                 Privilege escalation is disallowed. 
                 All containers must set the securityContext.allowPrivilegeEscalation field to `false`.


### PR DESCRIPTION
## Related Issue(s)

n/a

## Description

The pod security standard restricted mode does not allow a `nil` value for `allowPrivilegeEscalation`. 

It must be set to `false`.

```
    securityContext:
      allowPrivilegeEscalation: false
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [ ] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [ ] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
