### PR TITLE
Fix for issue: 1186 CEL expression is updated to support NET_RAW drop capability

### DIFF
--- a/best-practices-cel/require-drop-cap-net-raw/.chainsaw-test/good-pod.yaml
+++ b/best-practices-cel/require-drop-cap-net-raw/.chainsaw-test/good-pod.yaml
@@ -23,4 +23,19 @@ spec:
       capabilities:
         drop:
           - CAP_NET_RAW
-
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: drop-netraw-good
+spec:
+  containers:
+    - args:
+        - sleep
+        - infinity
+      image: ghcr.io/kyverno/test-busybox:1.35
+      name: busybox
+      securityContext:
+         capabilities:
+           drop:
+             - NET_RAW

--- a/best-practices-cel/require-drop-cap-net-raw/artifacthub-pkg.yml
+++ b/best-practices-cel/require-drop-cap-net-raw/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 28cac97e2c441528f12158cc0c6d3c8c07067537831a88d5445a2128b42746b4
-createdAt: "2024-03-15T03:05:47Z"
+digest: 594b30a84f36a2b46b723a4110d843f6099d7e7c17c82b70a91942c7081bb901
+createdAt: "2024-10-23T03:05:47Z"
 

--- a/best-practices-cel/require-drop-cap-net-raw/require-drop-cap-net-raw.yaml
+++ b/best-practices-cel/require-drop-cap-net-raw/require-drop-cap-net-raw.yaml
@@ -32,12 +32,13 @@ spec:
       validate:
         cel:
           variables:
+            - name: mustDropCapabilities
+              expression: "['CAP_NET_RAW','NET_RAW']"
             - name: allContainers
               expression: "object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([])"
           expressions:
             - expression: >-
                 variables.allContainers.all(container, 
-                container.?securityContext.?capabilities.?drop.orValue([]).exists(capability, capability.upperAscii() == 'CAP_NET_RAW'))
+                container.?securityContext.?capabilities.?drop.orValue([]).exists(capability, capability.upperAscii() in variables.mustDropCapabilities))
               message: >-
                 Containers must drop the `CAP_NET_RAW` capability.
-        


### PR DESCRIPTION
## Related Issue(s)

kyverno should allow the pod with NET_RAW drop capability. It is already fixed for non cel policy.
There is another policy version created with CEL expression which needs to be updated so that the policy is consistent between cel and non cel versions

## Description
pod with NET_RAW drop capability is allowed

Closes https://github.com/kyverno/policies/issues/1186

## Checklist

- [] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
