### PR TITLE
[Feature] Add Karpenter Do Not Disrupt policy for Karpenter 1.x migration

### DIFF
--- a/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/chainsaw-test.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,28 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: add-karpenter-donot-disrupt
+spec:
+  steps:
+    - name: step-01
+      try:
+        - apply:
+            file: ../add-karpenter-donot-disrupt.yaml
+        - assert:
+            file: policy-ready.yaml
+    - name: step-02
+      try:
+        - apply:
+            file: ../.kyverno-test/resource.yaml
+        - apply:
+            file: resource-others.yaml
+    - name: step-03
+      try:
+        - assert:
+            file: ../.kyverno-test/patched01.yaml
+        - assert:
+            file: ../.kyverno-test/patched02.yaml
+        - assert:
+            file: patched03.yaml
+        - assert:
+            file: patched04.yaml

--- a/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/patched03.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/patched03.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-1
+  labels:
+    karpenter.sh/do-not-evict: "true"
+    karpenter.sh/do-not-disrupt: "true"
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.14.2

--- a/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/patched04.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/patched04.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-2
+  labels:
+    karpenter.sh/do-not-evict: "false"
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.14.2

--- a/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/policy-ready.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-karpenter-donot-disrupt
+status:
+  conditions:
+    - reason: Succeeded
+      status: "True"
+      type: Ready

--- a/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/resource-others.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/resource-others.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-1
+  labels:
+    karpenter.sh/do-not-evict: "true"
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.14.2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-2
+  labels:
+    karpenter.sh/do-not-evict: "false"
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.14.2

--- a/karpenter/add-karpenter-donot-disrupt/.kyverno-test/kyverno-test.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,23 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: add-karpenter-donot-disrupt
+policies:
+  - ../add-karpenter-donot-disrupt.yaml
+resources:
+  - resource.yaml
+results:
+  - kind: Pod
+    patchedResource: patched01.yaml
+    policy: add-karpenter-donot-disrupt
+    resources:
+      - test-pod-with-evict
+    result: pass
+    rule: add-donot-disrupt-label
+  - kind: Pod
+    patchedResource: patched02.yaml
+    policy: add-karpenter-donot-disrupt
+    resources:
+      - test-pod-without-evict
+    result: skip
+    rule: add-donot-disrupt-label

--- a/karpenter/add-karpenter-donot-disrupt/.kyverno-test/patched01.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.kyverno-test/patched01.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-with-evict
+  labels:
+    karpenter.sh/do-not-evict: "true"
+    karpenter.sh/do-not-disrupt: "true"
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.14.2

--- a/karpenter/add-karpenter-donot-disrupt/.kyverno-test/patched02.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.kyverno-test/patched02.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-without-evict
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.14.2

--- a/karpenter/add-karpenter-donot-disrupt/.kyverno-test/resource.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.kyverno-test/resource.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-with-evict
+  labels:
+    karpenter.sh/do-not-evict: "true"
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.14.2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-without-evict
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.14.2

--- a/karpenter/add-karpenter-donot-disrupt/add-karpenter-donot-disrupt.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/add-karpenter-donot-disrupt.yaml
@@ -19,17 +19,16 @@ spec:
   rules:
     - name: add-donot-disrupt-label
       match:
-        any:
-          - resources:
-              kinds:
-                - Pod
+        resources:
+          kinds:
+            - Pod
       preconditions:
         all:
-          - key: '{{request.object.metadata.labels."karpenter.sh/do-not-evict"}}'
-            operator: Equals
-            value: "true"
+          - key: '{{ request.object.metadata.labels."karpenter.sh/do-not-evict" || '''' }}'
+            operator: NotEquals
+            value: ""
       mutate:
         patchStrategicMerge:
           metadata:
             labels:
-              "karpenter.sh/do-not-disrupt": "true"
+              karpenter.sh/do-not-disrupt: "true"

--- a/karpenter/add-karpenter-donot-disrupt/add-karpenter-donot-disrupt.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/add-karpenter-donot-disrupt.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-karpenter-donot-disrupt
+  annotations:
+    policies.kyverno.io/title: Add Karpenter Do Not Disrupt
+    policies.kyverno.io/category: Karpenter, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.7.1
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/description: >-
+      This policy assists in migrating from Karpenter 0.x to 1.x by adding the
+      karpenter.sh/do-not-disrupt label to pods that have the deprecated
+      karpenter.sh/do-not-evict label. This ensures smooth upgrades and
+      maintains the intended protection against pod disruption.
+spec:
+  rules:
+    - name: add-donot-disrupt-label
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      preconditions:
+        all:
+          - key: '{{request.object.metadata.labels."karpenter.sh/do-not-evict"}}'
+            operator: Equals
+            value: "true"
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              "karpenter.sh/do-not-disrupt": "true"

--- a/karpenter/add-karpenter-donot-disrupt/artifacthub-pkg.yml
+++ b/karpenter/add-karpenter-donot-disrupt/artifacthub-pkg.yml
@@ -1,0 +1,33 @@
+name: add-karpenter-donot-disrupt
+version: 1.0.0
+displayName: Add Karpenter Do Not Disrupt Label
+createdAt: "2024-12-17T00:00:00Z"
+description: |
+  This policy assists in migrating from Karpenter 0.x to 1.x by adding the
+  karpenter.sh/do-not-disrupt label to pods that have the deprecated
+  karpenter.sh/do-not-evict label. This ensures smooth upgrades and
+  maintains the intended protection against pod disruption during Karpenter
+  node termination.
+install: |
+  ```sh
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/karpenter/add-karpenter-donot-disrupt/add-karpenter-donot-disrupt.yaml
+  ```
+keywords:
+  - kyverno
+  - karpenter
+readme: |
+  # Add Karpenter Do Not Disrupt Label
+
+  This policy facilitates the migration from Karpenter 0.x to 1.x by automatically
+  adding the new karpenter.sh/do-not-disrupt label to pods that use the deprecated
+  karpenter.sh/do-not-evict label.
+
+  When a pod is created with the old karpenter.sh/do-not-evict label, this policy
+  automatically adds the new karpenter.sh/do-not-disrupt label to ensure the pod
+  remains protected during node termination operations in Karpenter 1.x.
+
+  Reference for this change: https://karpenter.sh/v1.0/upgrading/v1beta1-migration/
+annotations:
+  kyverno.io/category: Pod
+  kyverno.io/kubernetes-version: "1.23"
+  kyverno.io/subject: "Pod, Migration"


### PR DESCRIPTION
[Feature] Add Karpenter Do Not Disrupt policy for Karpenter 1.x migration

This policy adds the karpenter.sh/do-not-disrupt label to pods that have the deprecated karpenter.sh/do-not-evict label to ensure smooth upgrades from Karpenter 0.x to 1.x versions.

Fixes [#1191](https://github.com/kyverno/policies/issues/1191)

## Related Issue(s)
- Issue [#1191](https://github.com/kyverno/policies/issues/1191): To add Karpenter Do Not Disrupt policy for Karpenter 1.x version

## Description
This PR:
- Adds a new policy to facilitate migration from Karpenter 0.x to 1.x
- Automatically adds `karpenter.sh/do-not-disrupt` label to pods having the deprecated `karpenter.sh/do-not-evict` label


## Checklist
- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution)
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.