### PR TITLE
add policy opentelemetry/inject-otel-environment-variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -749,6 +749,24 @@ jobs:
       with:
         path: openshift-cel
 
+  opentelemetry:
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Setup Environment
+      uses: ./.github/actions/setup-env
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+    - name: Run Tests
+      uses: ./.github/actions/run-tests
+      with:
+        path: opentelemetry
+
   other:
     strategy:
       fail-fast: false
@@ -1225,6 +1243,7 @@ jobs:
     - nginx-ingress-cel
     - openshift
     - openshift-cel
+    - opentelemetry
     - other
     - other-vpol
     - other-mpol
@@ -1294,6 +1313,7 @@ jobs:
     - nginx-ingress-cel
     - openshift
     - openshift-cel
+    - opentelemetry
     - other
     - other-vpol
     - other-mpol

--- a/opentelemetry/inject-otel-environment-variable/.chainsaw-test/chainsaw-test.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: inject-otel-environment-variable
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../inject-otel-environment-variable.yaml
+    - apply:
+        file: ns.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: pod-resources.yaml
+    - assert:
+        file: pod-patched.yaml
+    - error:
+        file: pod-not-patched.yaml

--- a/opentelemetry/inject-otel-environment-variable/.chainsaw-test/ns.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.chainsaw-test/ns.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-inject-default
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-inject-disabled
+  annotations:
+    otel.corp.org/inject-env-var: "false"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otel-custom-endpoint
+  annotations:
+    otel.corp.org/otlp-endpoint: http://http-collector:4318

--- a/opentelemetry/inject-otel-environment-variable/.chainsaw-test/pod-not-patched.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.chainsaw-test/pod-not-patched.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-pod-optout
+  namespace: otel-inject-default
+spec:
+  containers:
+  - name: busybox
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-ns-optout
+  namespace: otel-inject-disabled
+spec:
+  containers:
+  - name: busybox
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/opentelemetry/inject-otel-environment-variable/.chainsaw-test/pod-patched.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.chainsaw-test/pod-patched.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-default
+  namespace: otel-inject-default
+spec:
+  containers:
+  - name: busybox
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://opentelemetry-collector.opentelemetry-collector:4317
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-ns-endpoint
+  namespace: otel-custom-endpoint
+spec:
+  containers:
+  - name: busybox
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://http-collector:4318
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-pod-endpoint
+  namespace: otel-inject-default
+spec:
+  containers:
+  - name: busybox
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://http-collector:4318
+---
+# The injected entry must come first, so a pre-existing declaration keeps precedence at runtime.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-init-and-preexisting-env
+  namespace: otel-inject-default
+spec:
+  initContainers:
+  - name: init
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://opentelemetry-collector.opentelemetry-collector:4317
+  containers:
+  - name: busybox
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://opentelemetry-collector.opentelemetry-collector:4317
+    - name: TEST_ENV
+      value: test

--- a/opentelemetry/inject-otel-environment-variable/.chainsaw-test/pod-resources.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.chainsaw-test/pod-resources.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-default
+  namespace: otel-inject-default
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-pod-optout
+  namespace: otel-inject-default
+  annotations:
+    otel.corp.org/inject-env-var: "false"
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-ns-optout
+  namespace: otel-inject-disabled
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-ns-endpoint
+  namespace: otel-custom-endpoint
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-pod-endpoint
+  namespace: otel-inject-default
+  annotations:
+    otel.corp.org/otlp-endpoint: http://http-collector:4318
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-init-and-preexisting-env
+  namespace: otel-inject-default
+spec:
+  initContainers:
+  - name: init
+    image: ghcr.io/kyverno/test-busybox:1.35
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    env:
+    - name: TEST_ENV
+      value: test

--- a/opentelemetry/inject-otel-environment-variable/.chainsaw-test/policy-ready.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,16 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: inject-otel-environment-variable
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready
+---
+# Namespace annotations are read through this entry: drop it and every namespace-level
+# assertion below silently flips to the injected default.
+apiVersion: kyverno.io/v2alpha1
+kind: GlobalContextEntry
+metadata:
+  name: namespaces

--- a/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-before-preexisting-env.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-before-preexisting-env.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-before-preexisting-env
+  namespace: default
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://opentelemetry-collector.opentelemetry-collector:4317
+    - name: TEST_ENV
+      value: test

--- a/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-custom-endpoint-ns.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-custom-endpoint-ns.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-custom-endpoint-ns
+  namespace: ns-w-custom-endpoint
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://http-collector:4318

--- a/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-custom-endpoint-pod.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-custom-endpoint-pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    otel.corp.org/otlp-endpoint: http://http-collector:4318
+  name: inject-custom-endpoint-pod
+  namespace: default
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://http-collector:4318

--- a/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-custom-endpoint.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-custom-endpoint.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+  name: inject-custom-endpoint
+  annotations:
+    otel.corp.org/otlp-endpoint: http://custom-endpoint:4318
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://custom-endpoint:4318

--- a/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-default.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-default.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-default
+  namespace: ns-wo-annotations
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://opentelemetry-collector.opentelemetry-collector:4317

--- a/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-ns.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-ns.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-ns
+  namespace: ns-w-inject-true
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://opentelemetry-collector.opentelemetry-collector:4317

--- a/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-pod.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.kyverno-test/expected/inject-pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    otel.corp.org/inject-env-var: "true"
+  name: inject-pod
+  namespace: ns-wo-annotations
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+    env:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://opentelemetry-collector.opentelemetry-collector:4317

--- a/opentelemetry/inject-otel-environment-variable/.kyverno-test/kyverno-test.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,79 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: inject-otel-environment-variable
+policies:
+  - ../inject-otel-environment-variable.yaml
+resources:
+  - resource.yaml
+variables: values.yaml
+results:
+  - policy: inject-otel-environment-variable
+    rule: inject-otel-environment-variable
+    resources:
+    - no-inject-pod
+    kind: Pod
+    result: skip
+
+  - policy: inject-otel-environment-variable
+    rule: inject-otel-environment-variable
+    resources:
+    - no-inject-ns
+    kind: Pod
+    result: skip
+
+  - policy: inject-otel-environment-variable
+    rule: inject-otel-environment-variable
+    resources:
+    - inject-ns
+    patchedResources: expected/inject-ns.yaml
+    kind: Pod
+    result: pass
+
+  - policy: inject-otel-environment-variable
+    rule: inject-otel-environment-variable
+    resources:
+    - inject-pod
+    patchedResources: expected/inject-pod.yaml
+    kind: Pod
+    result: pass
+
+  - policy: inject-otel-environment-variable
+    rule: inject-otel-environment-variable
+    resources:
+    - inject-default
+    patchedResources: expected/inject-default.yaml
+    kind: Pod
+    result: pass
+
+  - policy: inject-otel-environment-variable
+    rule: inject-otel-environment-variable
+    resources:
+    - inject-before-preexisting-env
+    patchedResources: expected/inject-before-preexisting-env.yaml
+    kind: Pod
+    result: pass
+
+  - policy: inject-otel-environment-variable
+    rule: inject-otel-environment-variable
+    resources:
+    - inject-custom-endpoint-pod
+    patchedResources: expected/inject-custom-endpoint-pod.yaml
+    kind: Pod
+    result: pass
+
+  - policy: inject-otel-environment-variable
+    rule: inject-otel-environment-variable
+    resources:
+    - inject-custom-endpoint-ns
+    patchedResources: expected/inject-custom-endpoint-ns.yaml
+    kind: Pod
+    result: pass
+
+  ## Enable for ConfigMap namespace filtering (see rule comments ConfigMap-NS-Filtering for detail)
+  # - policy: inject-otel-environment-variable
+  #   rule: inject-otel-environment-variable
+  #   resources:
+  #   - no-inject-ns-excluded-by-configmap
+  #   kind: Pod
+  #   result: skip

--- a/opentelemetry/inject-otel-environment-variable/.kyverno-test/resource.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.kyverno-test/resource.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: no-inject-pod
+  namespace: ns-wo-annotations
+  annotations:
+    otel.corp.org/inject-env-var: "false"
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: no-inject-ns
+  namespace: ns-w-inject-false
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-ns
+  namespace: ns-w-inject-true
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-pod
+  namespace: ns-wo-annotations
+  annotations:
+    otel.corp.org/inject-env-var: "true"
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-default
+  namespace: ns-wo-annotations
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-before-preexisting-env
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+    env:
+    - name: TEST_ENV
+      value: test
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-custom-endpoint-pod
+  annotations:
+    otel.corp.org/otlp-endpoint: http://http-collector:4318
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: inject-custom-endpoint-ns
+  namespace: ns-w-custom-endpoint
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: no-inject-ns-excluded-by-configmap
+  namespace: ns-excluded-by-configmap
+spec:
+  containers:
+  - name: debdiag
+    image: ghcr.io/babs/debdiag:0

--- a/opentelemetry/inject-otel-environment-variable/.kyverno-test/values.yaml
+++ b/opentelemetry/inject-otel-environment-variable/.kyverno-test/values.yaml
@@ -1,0 +1,24 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Values
+policies:
+- name: inject-otel-environment-variable
+  rules:
+  - name: inject-otel-environment-variable
+    values:
+      namespacefilters.data.exclude: '["ns-excluded-by-configmap"]'
+      # Global Reference simulation
+      namespaces:
+      - metadata:
+          name: ns-wo-annotations
+      - metadata:
+          name: ns-w-inject-true
+          annotations:
+            otel.corp.org/inject-env-var: "true"
+      - metadata:
+          name: ns-w-inject-false
+          annotations:
+            otel.corp.org/inject-env-var: "false"
+      - metadata:
+          name: ns-w-custom-endpoint
+          annotations:
+            otel.corp.org/otlp-endpoint: "http://http-collector:4318"

--- a/opentelemetry/inject-otel-environment-variable/artifacthub-pkg.yml
+++ b/opentelemetry/inject-otel-environment-variable/artifacthub-pkg.yml
@@ -1,0 +1,34 @@
+name: inject-otel-environment-variable
+version: 1.0.0
+displayName: Inject OpenTelemetry environment variable
+createdAt: "2024-12-27T00:00:00.000Z"
+description: >-
+  Injects OpenTelemetry `OTEL_EXPORTER_OTLP_ENDPOINT` env var in `containers` and `initContainers`.
+  Injection can be controlled by `otel.corp.org/inject-env-var: "false"` annotation on the Pod or at the Namespace level.
+  Value of the injected env var can also be overridden per Pod or Namespace via `otel.corp.org/otlp-endpoint: "http://xxxx:4317"` annotation.
+  The env var will be injected first, meaning that if one is already declared, the later will takes precedence over the injected one.
+  To avoid stress on the control plane API, a GlobalContextEntry containing Namespaces has to be declared (group: '', version: v1, resource: namespaces)
+  and `cache.kyverno.io/enabled: "true"` should be set on the `namespacefilters` ConfigMap (see rule comments ConfigMap-NS-Filtering).
+install: |-
+  ```shell
+  kubectl apply \
+    -f https://raw.githubusercontent.com/kyverno/policies/main/opentelemetry/inject-otel-environment-variable/globalcontext.yaml
+    -f https://raw.githubusercontent.com/kyverno/policies/main/opentelemetry/inject-otel-environment-variable/inject-otel-environment-variable.yaml
+  ```
+keywords:
+  - kyverno
+  - OpenTelemetry
+readme: |
+  Injects OpenTelemetry `OTEL_EXPORTER_OTLP_ENDPOINT` env var in `containers` and `initContainers`.
+  Injection can be controlled by `otel.corp.org/inject-env-var: "false"` annotation on the Pod or at the Namespace level.
+  Value of the injected env var can also be overridden per Pod or Namespace via `otel.corp.org/otlp-endpoint: "http://xxxx:4317"` annotation.
+  The env var will be injected first, meaning that if one is already declared, the later will takes precedence over the injected one.
+  To avoid stress on the control plane API, a GlobalContextEntry containing Namespaces has to be declared (group: '', version: v1, resource: namespaces)
+  and `cache.kyverno.io/enabled: "true"` should be set on the `namespacefilters` ConfigMap (see rule comments ConfigMap-NS-Filtering).
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/version: "1.13.0"
+  kyverno/category: "OpenTelemetry"
+  kyverno/subject: "Pod"
+digest: ffa101097cabaa69e4c3ddfa07d7d4526c5e9a4e32005d794ab37f6c118d6df9

--- a/opentelemetry/inject-otel-environment-variable/artifacthub-pkg.yml
+++ b/opentelemetry/inject-otel-environment-variable/artifacthub-pkg.yml
@@ -7,13 +7,13 @@ description: >-
   Injection can be controlled by `otel.corp.org/inject-env-var: "false"` annotation on the Pod or at the Namespace level.
   Value of the injected env var can also be overridden per Pod or Namespace via `otel.corp.org/otlp-endpoint: "http://xxxx:4317"` annotation.
   The env var will be injected first, meaning that if one is already declared, the later will takes precedence over the injected one.
-  To avoid stress on the control plane API, a GlobalContextEntry containing Namespaces has to be declared (group: '', version: v1, resource: namespaces)
-  and `cache.kyverno.io/enabled: "true"` should be set on the `namespacefilters` ConfigMap (see rule comments ConfigMap-NS-Filtering).
+  Namespace lookups go through the GlobalContextEntry shipped as the first document of the policy manifest (group: '', version: v1, resource: namespaces),
+  to avoid stress on the control plane API. Without it the lookup fails open and every namespace-level annotation is ignored.
+  Excluding namespaces through a ConfigMap is optional and disabled by default: see the `ConfigMap-NS-Filtering` rule comments,
+  which also require `cache.kyverno.io/enabled: "true"` on the `namespacefilters` ConfigMap.
 install: |-
   ```shell
-  kubectl apply \
-    -f https://raw.githubusercontent.com/kyverno/policies/main/opentelemetry/inject-otel-environment-variable/globalcontext.yaml
-    -f https://raw.githubusercontent.com/kyverno/policies/main/opentelemetry/inject-otel-environment-variable/inject-otel-environment-variable.yaml
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/opentelemetry/inject-otel-environment-variable/inject-otel-environment-variable.yaml
   ```
 keywords:
   - kyverno
@@ -23,12 +23,14 @@ readme: |
   Injection can be controlled by `otel.corp.org/inject-env-var: "false"` annotation on the Pod or at the Namespace level.
   Value of the injected env var can also be overridden per Pod or Namespace via `otel.corp.org/otlp-endpoint: "http://xxxx:4317"` annotation.
   The env var will be injected first, meaning that if one is already declared, the later will takes precedence over the injected one.
-  To avoid stress on the control plane API, a GlobalContextEntry containing Namespaces has to be declared (group: '', version: v1, resource: namespaces)
-  and `cache.kyverno.io/enabled: "true"` should be set on the `namespacefilters` ConfigMap (see rule comments ConfigMap-NS-Filtering).
+  Namespace lookups go through the GlobalContextEntry shipped as the first document of the policy manifest (group: '', version: v1, resource: namespaces),
+  to avoid stress on the control plane API. Without it the lookup fails open and every namespace-level annotation is ignored.
+  Excluding namespaces through a ConfigMap is optional and disabled by default: see the `ConfigMap-NS-Filtering` rule comments,
+  which also require `cache.kyverno.io/enabled: "true"` on the `namespacefilters` ConfigMap.
 
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/version: "1.13.0"
   kyverno/category: "OpenTelemetry"
-  kyverno/subject: "Pod"
-digest: ffa101097cabaa69e4c3ddfa07d7d4526c5e9a4e32005d794ab37f6c118d6df9
+  kyverno/subject: "Namespace, Pod"
+digest: cf484b1762532bd86fa9c1ba1cad09bdeceb58eb60636bc0c7af726709b68d1d

--- a/opentelemetry/inject-otel-environment-variable/globalcontext.yaml
+++ b/opentelemetry/inject-otel-environment-variable/globalcontext.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v2alpha1
+kind: GlobalContextEntry
+metadata:
+  name: namespaces
+spec:
+  kubernetesResource:
+    group: ''
+    version: v1
+    resource: namespaces

--- a/opentelemetry/inject-otel-environment-variable/globalcontext.yaml
+++ b/opentelemetry/inject-otel-environment-variable/globalcontext.yaml
@@ -1,9 +1,0 @@
-apiVersion: kyverno.io/v2alpha1
-kind: GlobalContextEntry
-metadata:
-  name: namespaces
-spec:
-  kubernetesResource:
-    group: ''
-    version: v1
-    resource: namespaces

--- a/opentelemetry/inject-otel-environment-variable/inject-otel-environment-variable.yaml
+++ b/opentelemetry/inject-otel-environment-variable/inject-otel-environment-variable.yaml
@@ -17,6 +17,7 @@ metadata:
       and `cache.kyverno.io/enabled: "true"` should be set on the `namespacefilters` ConfigMap (see rule comments ConfigMap-NS-Filtering).
 
 spec:
+  background: false
   rules:
   - name: inject-otel-environment-variable
     context:

--- a/opentelemetry/inject-otel-environment-variable/inject-otel-environment-variable.yaml
+++ b/opentelemetry/inject-otel-environment-variable/inject-otel-environment-variable.yaml
@@ -1,0 +1,105 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: inject-otel-environment-variable
+  annotations:
+    policies.kyverno.io/title: Injects OpenTelemetry environment variable
+    policies.kyverno.io/minversion: 1.13.0
+    kyverno.io/kyverno-version: 1.13.0
+    policies.kyverno.io/subject: Namespace, Pod
+    policies.kyverno.io/category: OpenTelemetry
+    policies.kyverno.io/description: >-
+      Injects OpenTelemetry `OTEL_EXPORTER_OTLP_ENDPOINT` env var in `containers` and `initContainers`.
+      Injection can be controlled by `otel.corp.org/inject-env-var: "false"` annotation on the Pod or at the Namespace level.
+      Value of the injected env var can also be overridden per Pod or Namespace via `otel.corp.org/otlp-endpoint: "http://xxxx:4317"` annotation.
+      The env var will be injected first, meaning that if one is already declared, the later will takes precedence over the injected one.
+      To avoid stress on the control plane API, a GlobalContextEntry containing Namespaces has to be declared (group: '', version: v1, resource: namespaces)
+      and `cache.kyverno.io/enabled: "true"` should be set on the `namespacefilters` ConfigMap (see rule comments ConfigMap-NS-Filtering).
+
+spec:
+  rules:
+  - name: inject-otel-environment-variable
+    context:
+    - name: namespaces
+      globalReference:
+        # This is the name of the GlobalContextEntry
+        #
+        # apiVersion: kyverno.io/v2alpha1
+        # kind: GlobalContextEntry
+        # metadata:
+        #   name: namespaces
+        # spec:
+        #   kubernetesResource:
+        #     group: ''
+        #     version: v1
+        #     resource: namespaces
+        name: namespaces
+    - name: nsannontations
+      variable:
+        jmesPath: namespaces[?metadata.name == '{{ request.object.metadata.namespace }}'] | [0].metadata.annotations
+        default: {}
+    - name: otlp_endpoint
+      variable:
+        jmesPath: request.object.metadata.annotations."otel.corp.org/otlp-endpoint" || nsannontations."otel.corp.org/otlp-endpoint"
+        default: 'http://opentelemetry-collector.opentelemetry-collector:4317'
+
+      # ConfigMap-NS-Filtering
+      # See https://kyverno.io/docs/writing-policies/external-data-sources/#handling-configmap-array-values
+      # Don't forget to enable kyverno's cache on the ConfigMap to avoid stress on the control plane
+      # Enable only if the proper config map has been enabled
+      #
+      # apiVersion: v1
+      # kind: ConfigMap
+      # metadata:
+      #   namespace: opentelemetry-collector
+      #   name: namespacefilters
+      #   labels:
+      #     cache.kyverno.io/enabled: "true"
+      # data:
+      #   exclude: '["ns-excluded-by-configmap"]'
+
+    ## Uncomment the following for configmap namespace filtering, make sure the proper ConfigMap exists!
+    ## Also uncomment bellow in the preconditions section
+    # - name: namespacefilters
+    #   configMap:
+    #     name: namespacefilters
+    #     namespace: opentelemetry-collector
+
+    preconditions:
+      all:
+      # By default inject, expect if namespace or pod annotations says otherwise
+      - key: "{{ request.object.metadata.annotations.\"otel.corp.org/inject-env-var\" || nsannontations.\"otel.corp.org/inject-env-var\" || 'true' }}"
+        operator: NotEquals
+        value: 'false'
+
+      # ConfigMap-NS-Filtering
+      # Env variable injection can be disabled on per NS basis using ConfigMap (no per pod override possible)
+      ## Uncomment the following for ConfigMap-based namespace filtering
+      ## Ensure the corresponding context above is uncommented and the appropriate ConfigMap is configured.
+      # - key: "{{ request.object.metadata.namespace }}"
+      #   operator: AnyNotIn
+      #   value: "{{ namespacefilters.data.exclude || '[]' }}"
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          operations:
+          - CREATE
+          - UPDATE
+    mutate:
+      foreach:
+      - list: request.object.spec.containers[]
+        patchesJson6902: |-
+          - op: add
+            path: /spec/containers/{{elementIndex}}/env/0
+            value:
+              name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "{{ otlp_endpoint }}"
+      - list: request.object.spec.initContainers[]
+        patchesJson6902: |-
+          - op: add
+            path: /spec/initContainers/{{elementIndex}}/env/0
+            value:
+              name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "{{ otlp_endpoint }}"

--- a/opentelemetry/inject-otel-environment-variable/inject-otel-environment-variable.yaml
+++ b/opentelemetry/inject-otel-environment-variable/inject-otel-environment-variable.yaml
@@ -87,7 +87,6 @@ spec:
           - Pod
           operations:
           - CREATE
-          - UPDATE
     mutate:
       foreach:
       - list: request.object.spec.containers[]

--- a/opentelemetry/inject-otel-environment-variable/inject-otel-environment-variable.yaml
+++ b/opentelemetry/inject-otel-environment-variable/inject-otel-environment-variable.yaml
@@ -1,3 +1,13 @@
+apiVersion: kyverno.io/v2alpha1
+kind: GlobalContextEntry
+metadata:
+  name: namespaces
+spec:
+  kubernetesResource:
+    group: ''
+    version: v1
+    resource: namespaces
+---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -13,8 +23,10 @@ metadata:
       Injection can be controlled by `otel.corp.org/inject-env-var: "false"` annotation on the Pod or at the Namespace level.
       Value of the injected env var can also be overridden per Pod or Namespace via `otel.corp.org/otlp-endpoint: "http://xxxx:4317"` annotation.
       The env var will be injected first, meaning that if one is already declared, the later will takes precedence over the injected one.
-      To avoid stress on the control plane API, a GlobalContextEntry containing Namespaces has to be declared (group: '', version: v1, resource: namespaces)
-      and `cache.kyverno.io/enabled: "true"` should be set on the `namespacefilters` ConfigMap (see rule comments ConfigMap-NS-Filtering).
+      Namespace lookups go through the GlobalContextEntry shipped as the first document of this manifest (group: '', version: v1, resource: namespaces),
+      to avoid stress on the control plane API. Without it the lookup fails open and every namespace-level annotation is ignored.
+      Excluding namespaces through a ConfigMap is optional and disabled by default: see the `ConfigMap-NS-Filtering` rule comments,
+      which also require `cache.kyverno.io/enabled: "true"` on the `namespacefilters` ConfigMap.
 
 spec:
   background: false
@@ -23,17 +35,9 @@ spec:
     context:
     - name: namespaces
       globalReference:
-        # This is the name of the GlobalContextEntry
-        #
-        # apiVersion: kyverno.io/v2alpha1
-        # kind: GlobalContextEntry
-        # metadata:
-        #   name: namespaces
-        # spec:
-        #   kubernetesResource:
-        #     group: ''
-        #     version: v1
-        #     resource: namespaces
+        # Name of the GlobalContextEntry shipped as the first document of this file.
+        # Without it the lookup fails open: namespace annotations resolve to {} and every
+        # namespace-level opt-out is silently ignored.
         name: namespaces
     - name: nsannontations
       variable:


### PR DESCRIPTION
## Description

This PR allow injection of opentelemetry environment variables based on namespace and pod annotations.  

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
