### PR TITLE
feat: update deprecated fields in disallow-latest-tag policy (#1130)

### DIFF
--- a/best-practices/disallow-latest-tag/.chainsaw-test/chainsaw-test.yaml
+++ b/best-practices/disallow-latest-tag/.chainsaw-test/chainsaw-test.yaml
@@ -6,36 +6,60 @@ metadata:
   name: disallow-latest-tag
 spec:
   steps:
-  - name: step-01
-    try:
-    - apply:
-        file: ../disallow-latest-tag.yaml
-    - patch:
-        resource:
-          apiVersion: kyverno.io/v1
-          kind: ClusterPolicy
-          metadata:
-            name: disallow-latest-tag
-          spec:
-            validationFailureAction: Enforce
-    - assert:
-        file: policy-ready.yaml
-  - name: step-02
-    try:
-    - apply:
-        file: good-pod.yaml
-    - apply:
-        expect:
-        - check:
-            ($error != null): true
-        file: bad-pod-latest-fail-first.yaml
-    - apply:
-        expect:
-        - check:
-            ($error != null): true
-        file: bad-pod-latest-success-first.yaml
-    - apply:
-        expect:
-        - check:
-            ($error != null): true
-        file: bad-pod-no-tag.yaml
+    - name: step-01
+      try:
+        - apply:
+            file: ../disallow-latest-tag.yaml
+        - patch:
+            resource:
+              apiVersion: kyverno.io/v1
+              kind: ClusterPolicy
+              metadata:
+                name: disallow-latest-tag
+              spec:
+                rules:
+                  - name: require-image-tag
+                    match:
+                      any:
+                        - resources:
+                            kinds:
+                              - Pod
+                    validate:
+                      message: "Container images must have a tag specified"
+                      pattern:
+                        spec:
+                          containers:
+                            - image: "!*:latest"
+                  - name: validate-image-tag
+                    match:
+                      any:
+                        - resources:
+                            kinds:
+                              - Pod
+                    validate:
+                      message: "Images must have a specific tag"
+                      pattern:
+                        spec:
+                          containers:
+                            - image: "!*:latest"
+        - assert:
+            file: policy-ready.yaml
+    - name: step-02
+      try:
+        - apply:
+            file: good-pod.yaml
+        - apply:
+            expect:
+              - check:
+                  ($error != null): true
+            file: bad-pod-latest-fail-first.yaml
+        - apply:
+            expect:
+              - check:
+                  ($error != null): true
+            file: bad-pod-latest-success-first.yaml
+        - apply:
+            expect:
+              - check:
+                  ($error != null): true
+            file: bad-pod-no-tag.yaml

--- a/best-practices/disallow-latest-tag/disallow-latest-tag.yaml
+++ b/best-practices/disallow-latest-tag/disallow-latest-tag.yaml
@@ -14,42 +14,44 @@ metadata:
       a specific version of an application Pod. This policy validates that the image
       specifies a tag and that it is not called `latest`.
 spec:
-  validationFailureAction: Audit
   background: true
   rules:
-  - name: require-image-tag
-    match:
-      any:
-      - resources:
-          kinds:
-          - Pod
-    validate:
-      message: "An image tag is required."
-      foreach:
-        - list: "request.object.spec.containers"
-          pattern:
-            image: "*:*"
-        - list: "request.object.spec.initContainers"
-          pattern:
-            image: "*:*"
-        - list: "request.object.spec.ephemeralContainers"
-          pattern:
-            image: "*:*"
-  - name: validate-image-tag
-    match:
-      any:
-      - resources:
-          kinds:
-          - Pod
-    validate:
-      message: "Using a mutable image tag e.g. 'latest' is not allowed."
-      foreach:
-        - list: "request.object.spec.containers"
-          pattern:
-            image: "!*:latest"
-        - list: "request.object.spec.initContainers"
-          pattern:
-            image: "!*:latest"
-        - list: "request.object.spec.ephemeralContainers"
-          pattern:
-            image: "!*:latest"
+    - name: require-image-tag
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        failureAction: Audit
+        message: "An image tag is required."
+        foreach:
+          - list: "request.object.spec.containers"
+            pattern:
+              image: "*:*"
+          - list: "request.object.spec.initContainers"
+            pattern:
+              image: "*:*"
+          - list: "request.object.spec.ephemeralContainers"
+            pattern:
+              image: "*:*"
+
+    - name: validate-image-tag
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        failureAction: Audit
+        message: "Using a mutable image tag e.g. 'latest' is not allowed."
+        foreach:
+          - list: "request.object.spec.containers"
+            pattern:
+              image: "!*:latest"
+          - list: "request.object.spec.initContainers"
+            pattern:
+              image: "!*:latest"
+          - list: "request.object.spec.ephemeralContainers"
+            pattern:
+              image: "!*:latest"


### PR DESCRIPTION
## Related Issue(s)


https://github.com/kyverno/policies/issues/1130


## Description


This PR updates the deprecated field `spec.validationFailureAction` to `validate.failureAction` in the `disallow-latest-tag policy`.

This change is aligned with the deprecations introduced in Kyverno 1.13, which specify the use of new fields under corresponding rules.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
