### PR TITLE
Update require-pod-requests-limits.yaml

### DIFF
--- a/best-practices/require-pod-requests-limits/require-pod-requests-limits.yaml
+++ b/best-practices/require-pod-requests-limits/require-pod-requests-limits.yaml
@@ -16,7 +16,7 @@ metadata:
       This policy validates that all containers have something specified for memory and CPU
       requests and memory limits.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-resources


### PR DESCRIPTION
fix: corrected case typo from 'Audit' to 'audit' in Kyverno policy
## Related Issue(s)
No specific issue opened for this typo. This is a direct fix for functionality inconsistency due to incorrect casing in the validationFailureAction field.

## Description
This PR corrects a case sensitivity issue where validationFailureAction was set to 'Audit' instead of the expected 'audit' in Kyverno policies. Kyverno is case-sensitive for this field, and using the wrong case can cause policies to silently fail or behave unexpectedly.

## Checklist

 I have read the policy contribution guidelines.

 I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.

 I have added the artifacthub-pkg.yml file and have verified it is complete and correct.