### PR TITLE
Exclude kube-system and istio-system from ambient mode policy

### DIFF
--- a/istio/add-ambient-mode-namespace/add-ambient-mode-namespace.yaml
+++ b/istio/add-ambient-mode-namespace/add-ambient-mode-namespace.yaml
@@ -23,6 +23,12 @@ spec:
       - resources:
           kinds:
           - Namespace
+    exclude:
+      any:
+      - resources:
+          names:
+            - kube-system
+            - istio-system      
     mutate:
       patchStrategicMerge:
         metadata:

--- a/istio/add-ambient-mode-namespace/artifacthub-pkg.yml
+++ b/istio/add-ambient-mode-namespace/artifacthub-pkg.yml
@@ -1,7 +1,7 @@
 name: add-ambient-mode-namespace
 version: 1.0.0
 displayName: Add Istio Ambient Mode
-createdAt: "2024-07-25T20:07:52.000Z"
+createdAt: "2025-05-28T20:07:52.000Z"
 description: >-
   In order for Istio to include namespaces in ambient mode, the label `istio.io/dataplane-mode` must be set to `ambient`. As an alternative to rejecting Namespace definitions which don't already contain this label, it can be added automatically. This policy adds the label `istio.io/dataplane-mode` set to `ambient` for all new Namespaces.
 install: |-
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Istio"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Namespace"
-digest: f81b9ba15c410e62589f0bf79b22a694b41a2294557c91d3c87683772922a8c0
+digest: f4b71db78ff5830b7bf2c4c94af0cd1d5b2495040738a465120f6f96a91affcc


### PR DESCRIPTION
## Related Issue(s)
This pr fixes #1280 

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
This pr updates the Istio ambient mode policy to exclude the `kube-system` and `istio-system` namespaces.

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
