### PR TITLE
disallow-capabilities-strict : simplify CEL expressions

### DIFF
--- a/pod-security-cel/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
+++ b/pod-security-cel/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
@@ -29,27 +29,21 @@ spec:
       validate:
         message: >-
           Containers must drop `ALL` capabilities.
-        cel: 
+        cel:
+          variables:
+            - name: allContainers
+              expression: >-
+                (has(object.spec.containers) ? object.spec.containers : []) +
+                (has(object.spec.initContainers) ? object.spec.initContainers : []) +
+                (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
           expressions:
-            - expression: >- 
-                object.spec.containers.all(container, has(container.securityContext) &&
-                has(container.securityContext.capabilities) &&
-                has(container.securityContext.capabilities.drop) &&
-                container.securityContext.capabilities.drop.exists_one(capability, capability == 'ALL'))
-    
-            - expression: >- 
-                !has(object.spec.initContainers) ||
-                object.spec.initContainers.all(container, has(container.securityContext) &&
-                has(container.securityContext.capabilities) &&
-                has(container.securityContext.capabilities.drop) &&
-                container.securityContext.capabilities.drop.exists_one(capability, capability == 'ALL'))
-            
-            - expression: >- 
-                !has(object.spec.ephemeralContainers) ||
-                object.spec.ephemeralContainers.all(container, has(container.securityContext) &&
-                has(container.securityContext.capabilities) &&
-                has(container.securityContext.capabilities.drop) &&
-                container.securityContext.capabilities.drop.exists_one(capability, capability == 'ALL'))
+            - expression: >-
+                variables.allContainers.all(container,
+                  has(container.securityContext) &&
+                  has(container.securityContext.capabilities) &&
+                  has(container.securityContext.capabilities.drop) &&
+                  container.securityContext.capabilities.drop.exists_one(capability, capability == 'ALL')
+                )
     - name: adding-capabilities-strict
       match:
         any:
@@ -61,29 +55,22 @@ spec:
             - UPDATE
       validate:
         cel:
+          variables:
+            - name: allContainers
+              expression: >-
+                (has(object.spec.containers) ? object.spec.containers : []) +
+                (has(object.spec.initContainers) ? object.spec.initContainers : []) +
+                (has(object.spec.ephemeralContainers) ? object.spec.ephemeralContainers : [])
           expressions:
-          - expression: >- 
-              object.spec.containers.all(container, !has(container.securityContext) ||
-              !has(container.securityContext.capabilities) ||
-              !has(container.securityContext.capabilities.add) ||
-              ((size(container.securityContext.capabilities.add) == 1) && (container.securityContext.capabilities.add[0] == 'NET_BIND_SERVICE')))
-            message: >-
-              Any capabilities added other than NET_BIND_SERVICE are disallowed.
-    
-          - expression: >- 
-              !has(object.spec.initContainers) ||
-              object.spec.initContainers.all(container, !has(container.securityContext) ||
-              !has(container.securityContext.capabilities) ||
-              !has(container.securityContext.capabilities.add) ||
-              ((size(container.securityContext.capabilities.add) == 1) && (container.securityContext.capabilities.add[0] == 'NET_BIND_SERVICE')))
-            message: >-
-              Any capabilities added other than NET_BIND_SERVICE are disallowed.
-          
-          - expression: >- 
-              !has(object.spec.ephemeralContainers) ||
-              object.spec.ephemeralContainers.all(container, !has(container.securityContext) ||
-              !has(container.securityContext.capabilities) ||
-              !has(container.securityContext.capabilities.add) ||
-              ((size(container.securityContext.capabilities.add) == 1) && (container.securityContext.capabilities.add[0] == 'NET_BIND_SERVICE')))
-            message: >-
-              Any capabilities added other than NET_BIND_SERVICE are disallowed.
+            - expression: >-
+                variables.allContainers.all(container,
+                  !has(container.securityContext) ||
+                  !has(container.securityContext.capabilities) ||
+                  !has(container.securityContext.capabilities.add) ||
+                  (
+                    size(container.securityContext.capabilities.add) == 1 &&
+                    container.securityContext.capabilities.add[0] == 'NET_BIND_SERVICE'
+                  )
+                )
+              message: >-
+                Any capabilities added other than NET_BIND_SERVICE are disallowed.


### PR DESCRIPTION
## Related Issue(s)

Partially addresses #1324 #1058 

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

Refactored disallow-capabilities-strict policy to remove redundancy by introducing an `allContainers` CEL variable combining all container types. Updated capability validation to use this variable, ensuring each container drops `ALL` capabilities and only adds `NET_BIND_SERVICE` when specified.

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
