### PR TITLE
restrict-seccomp-strict : simplify CEL expressions

### DIFF
--- a/pod-security-cel/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
+++ b/pod-security-cel/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
@@ -23,19 +23,17 @@ spec:
     - name: check-seccomp-strict
       match:
         any:
-        - resources:
-            kinds:
-              - Pod
-            operations:
-            - CREATE
-            - UPDATE
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+                - UPDATE
       validate:
         cel:
           expressions:
             - expression: >- 
-                !has(object.spec.securityContext) ||
-                !has(object.spec.securityContext.seccompProfile) ||
-                !has(object.spec.securityContext.seccompProfile.type) ||
+                !object.spec.?securityContext.?seccompProfile.?type.hasValue() ||
                 object.spec.securityContext.seccompProfile.type == 'RuntimeDefault' ||
                 object.spec.securityContext.seccompProfile.type == 'Localhost'
               message: >-
@@ -43,33 +41,31 @@ spec:
                 spec.securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`.
       
             - expression: >- 
-                object.spec.containers.all(container, !has(container.securityContext) ||
-                !has(container.securityContext.seccompProfile) ||
-                !has(container.securityContext.seccompProfile.type) ||
-                container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
-                container.securityContext.seccompProfile.type == 'Localhost')
+                object.spec.containers.all(container,
+                  !container.?securityContext.?seccompProfile.?type.hasValue() ||
+                  container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
+                  container.securityContext.seccompProfile.type == 'Localhost'
+                )
               message: >-
                 Use of custom Seccomp profiles is disallowed. The field
                 spec.containers[*].securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`.
               
             - expression: >- 
-                !has(object.spec.initContainers) ||
-                object.spec.initContainers.all(container, !has(container.securityContext) ||
-                !has(container.securityContext.seccompProfile) ||
-                !has(container.securityContext.seccompProfile.type) ||
-                container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
-                container.securityContext.seccompProfile.type == 'Localhost')
+                object.spec.?initContainers.orValue([]).all(container,
+                  !container.?securityContext.?seccompProfile.?type.hasValue() ||
+                  container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
+                  container.securityContext.seccompProfile.type == 'Localhost'
+                )
               message: >-
                 Use of custom Seccomp profiles is disallowed. The field
                 spec.initContainers[*].securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`.
 
             - expression: >- 
-                !has(object.spec.ephemeralContainers) ||
-                object.spec.ephemeralContainers.all(container, !has(container.securityContext) ||
-                !has(container.securityContext.seccompProfile) ||
-                !has(container.securityContext.seccompProfile.type) ||
-                container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
-                container.securityContext.seccompProfile.type == 'Localhost')
+                object.spec.?ephemeralContainers.orValue([]).all(container,
+                  !container.?securityContext.?seccompProfile.?type.hasValue() ||
+                  container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
+                  container.securityContext.seccompProfile.type == 'Localhost'
+                )
               message: >-
                 Use of custom Seccomp profiles is disallowed. The field
                 spec.ephemeralContainers[*].securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`.


### PR DESCRIPTION
## Related Issue(s)

Partially addresses #1324 

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

Refactored restrict-seccomp-strict policy to remove redundancy by replacing `has(...)` checks with optional field access and `.orValue([])` for container lists, keeping container-type–specific validations intact.

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
