### PR TITLE
feat(cel): add ValidatingPolicy for aws-node IRSA + tests

### DIFF
--- a/aws-cel/require-aws-node-irsa/policy.yaml
+++ b/aws-cel/require-aws-node-irsa/policy.yaml
@@ -1,0 +1,29 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: require-aws-node-irsa
+  annotations:
+    policies.kyverno.io/title: Require aws-node DaemonSet use IRSA
+    policies.kyverno.io/category: AWS, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: DaemonSet
+    policies.kyverno.io/description: >-
+      Ensure the aws-node DaemonSet in kube-system does not use the "aws-node"
+      ServiceAccount (migrate to an IRSA-specific SA instead).
+spec:
+  validationActions:
+    - Audit
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["apps"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE","UPDATE"]
+        resources:   ["daemonsets"]
+  matchConditions:
+    - name: in-kube-system
+      expression: object.metadata.namespace == "kube-system"
+    - name: is-aws-node
+      expression: object.metadata.name == "aws-node"
+  validations:
+    - message: Update the aws-node DaemonSet to use IRSA (do not use "aws-node" ServiceAccount).
+      expression: object.spec.template.spec.serviceAccountName != "aws-node"

--- a/aws-cel/require-aws-node-irsa/tests/fail/ds.yaml
+++ b/aws-cel/require-aws-node-irsa/tests/fail/ds.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aws-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: aws-node
+  template:
+    metadata:
+      labels:
+        app: aws-node
+    spec:
+      serviceAccountName: aws-node
+      containers:
+        - name: c
+          image: registry.k8s.io/pause

--- a/aws-cel/require-aws-node-irsa/tests/fail/kyverno-test.yaml
+++ b/aws-cel/require-aws-node-irsa/tests/fail/kyverno-test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: require-aws-node-irsa-fail
+policies:
+  - ../../policy.yaml
+resources:
+  - ds.yaml
+results:
+  - isValidatingPolicy: true
+    kind: DaemonSet
+    policy: require-aws-node-irsa
+    resources:
+      - aws-node
+    result: fail

--- a/aws-cel/require-aws-node-irsa/tests/pass/ds.yaml
+++ b/aws-cel/require-aws-node-irsa/tests/pass/ds.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: aws-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: aws-node
+  template:
+    metadata:
+      labels:
+        app: aws-node
+    spec:
+      serviceAccountName: aws-node-irsa
+      containers:
+        - name: c
+          image: registry.k8s.io/pause

--- a/aws-cel/require-aws-node-irsa/tests/pass/kyverno-test.yaml
+++ b/aws-cel/require-aws-node-irsa/tests/pass/kyverno-test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: require-aws-node-irsa-pass
+policies:
+  - ../../policy.yaml
+resources:
+  - ds.yaml
+results:
+  - isValidatingPolicy: true
+    kind: DaemonSet
+    policy: require-aws-node-irsa
+    resources:
+      - aws-node
+    result: pass


### PR DESCRIPTION
**Summary**
Convert legacy `aws/require-aws-node-irsa` to a CEL `ValidatingPolicy` under `aws-cel/require-aws-node-irsa`, with `kyverno test` fixtures.

**What changed**

* Added: `aws-cel/require-aws-node-irsa/policy.yaml` (CEL `ValidatingPolicy`)
* Added tests:

  * `aws-cel/require-aws-node-irsa/tests/pass` (uses non-`aws-node` SA → **pass**)
  * `aws-cel/require-aws-node-irsa/tests/fail` (uses `aws-node` SA → **fail**)
* No changes to the legacy sample.

**Why**
Part of the ongoing migration of sample policies to CEL-based types for better performance, native K8s alignment, and clearer testability.

**Behavior (parity with legacy)**

* Target: `DaemonSet` **kube-system/aws-node** only.
* Fails when `spec.template.spec.serviceAccountName == "aws-node"`.
* Mirrors legacy action: `validationActions: Audit` (equivalent to `validationFailureAction: Audit`).

**Spec details**

* `matchConstraints.resourceRules`: `apps/v1`, `daemonsets`, `CREATE|UPDATE`
* `matchConditions`: name/namespace pinning (`kube-system` + `aws-node`)
* `validations[0].expression`: `object.spec.template.spec.serviceAccountName != "aws-node"`

**How I tested**

```bash
# from repo root: sources/policies
kyverno test aws-cel/require-aws-node-irsa/tests/pass
kyverno test aws-cel/require-aws-node-irsa/tests/fail
# both suites: "1 tests passed and 0 tests failed"
```

**Notes**

* This keeps the same user-facing intent as the legacy policy (stop using the shared `aws-node` SA; use IRSA-specific SA).
* Happy to adjust if maintainers prefer to **require** an explicit non-`aws-node` SA (vs. simply “not equal to `aws-node`”).
