### PR TITLE
Converting ClusterPolicy to MutatingPolicy [patch 2]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,24 @@ jobs:
         shard-index: ${{ matrix.shard-index }}
         shard-count: 2
 
+  best-practices-mpol:
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Setup Environment
+      uses: ./.github/actions/setup-env
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+    - name: Run Tests
+      uses: ./.github/actions/run-tests
+      with:
+        path: best-practices-mpol
+
   castai:
     strategy:
       fail-fast: false
@@ -147,6 +165,24 @@ jobs:
       uses: ./.github/actions/run-tests
       with:
         path: castai
+
+  castai-mpol:
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Setup Environment
+      uses: ./.github/actions/setup-env
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+    - name: Run Tests
+      uses: ./.github/actions/run-tests
+      with:
+        path: castai-mpol
 
   cert-manager:
     strategy:
@@ -310,6 +346,24 @@ jobs:
       with:
         path: istio-cel
 
+  istio-mpol:
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Setup Environment
+      uses: ./.github/actions/setup-env
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+    - name: Run Tests
+      uses: ./.github/actions/run-tests
+      with:
+        path: istio-mpol
+
   karpenter:
     strategy:
       fail-fast: false
@@ -400,6 +454,24 @@ jobs:
       with:
         path: kubecost-cel
 
+  kubecost-mpol:
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Setup Environment
+      uses: ./.github/actions/setup-env
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+    - name: Run Tests
+      uses: ./.github/actions/run-tests
+      with:
+        path: kubecost-mpol
+
   kubeops:
     strategy:
       fail-fast: false
@@ -471,6 +543,24 @@ jobs:
       uses: ./.github/actions/run-tests
       with:
         path: linkerd-cel
+
+  linkerd-mpol:
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Setup Environment
+      uses: ./.github/actions/setup-env
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+    - name: Run Tests
+      uses: ./.github/actions/run-tests
+      with:
+        path: linkerd-mpol
 
   nginx-ingress:
     strategy:
@@ -664,6 +754,24 @@ jobs:
       with:
         path: psa-cel
 
+  psa-mpol:
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Setup Environment
+      uses: ./.github/actions/setup-env
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+    - name: Run Tests
+      uses: ./.github/actions/run-tests
+      with:
+        path: psa-mpol
+
   psp-migration:
     strategy:
       fail-fast: false
@@ -699,6 +807,24 @@ jobs:
       uses: ./.github/actions/run-tests
       with:
         path: psp-migration-cel
+
+  psp-migration-mpol:
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Setup Environment
+      uses: ./.github/actions/setup-env
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+    - name: Run Tests
+      uses: ./.github/actions/run-tests
+      with:
+        path: psp-migration-mpol
 
   tekton:
     strategy:
@@ -835,7 +961,9 @@ jobs:
     - aws-cel
     - best-practices
     - best-practices-cel
+    - best-practices-mpol
     - castai
+    - castai-mpol
     - cert-manager
     - cleanup
     - consul
@@ -845,15 +973,18 @@ jobs:
     - flux-cel
     - istio
     - istio-cel
+    - istio-mpol
     - karpenter
     - kasten
     - kasten-cel
     - kubecost
     - kubecost-cel
+    - kubecost-mpol
     - kubeops
     - kubevirt
     - linkerd
     - linkerd-cel
+    - linkerd-mpol
     - nginx-ingress
     - nginx-ingress-cel
     - openshift
@@ -864,8 +995,10 @@ jobs:
     - pod-security-cel
     - psa
     - psa-cel
+    - psa-mpol
     - psp-migration
     - psp-migration-cel
+    - psp-migration-mpol
     - tekton
     - tekton-cel
     - traefik
@@ -887,7 +1020,9 @@ jobs:
     - aws-cel
     - best-practices
     - best-practices-cel
+    - best-practices-mpol
     - castai
+    - castai-mpol
     - cert-manager
     - cleanup
     - consul
@@ -897,15 +1032,18 @@ jobs:
     - flux-cel
     - istio
     - istio-cel
+    - istio-mpol
     - karpenter
     - kasten
     - kasten-cel
     - kubecost
     - kubecost-cel
+    - kubecost-mpol
     - kubeops
     - kubevirt
     - linkerd
     - linkerd-cel
+    - linkerd-mpol
     - nginx-ingress
     - nginx-ingress-cel
     - openshift
@@ -916,8 +1054,10 @@ jobs:
     - pod-security-cel
     - psa
     - psa-cel
+    - psa-mpol
     - psp-migration
     - psp-migration-cel
+    - psp-migration-mpol
     - tekton
     - tekton-cel
     - traefik

--- a/best-practices-mpol/add-safe-to-evict/.chainsaw-test/chainsaw-test.yaml
+++ b/best-practices-mpol/add-safe-to-evict/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-safe-to-evict
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../add-safe-to-evict.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: ../.kyverno-test/resource.yaml
+    - apply:
+        file: resource-others.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: patchedResources.yaml
+    - error:
+        file: notPatchedResources.yaml

--- a/best-practices-mpol/add-safe-to-evict/.chainsaw-test/notPatchedResources.yaml
+++ b/best-practices-mpol/add-safe-to-evict/.chainsaw-test/notPatchedResources.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod05
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod06
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod07
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/best-practices-mpol/add-safe-to-evict/.chainsaw-test/patchedResources.yaml
+++ b/best-practices-mpol/add-safe-to-evict/.chainsaw-test/patchedResources.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod04
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod03
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/best-practices-mpol/add-safe-to-evict/.chainsaw-test/policy-ready.yaml
+++ b/best-practices-mpol/add-safe-to-evict/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-safe-to-evict
+status:
+  conditionStatus:
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+      type: RBACPermissionsGranted
+    (length(conditions)): 2
+    ready: true

--- a/best-practices-mpol/add-safe-to-evict/.chainsaw-test/resource-others.yaml
+++ b/best-practices-mpol/add-safe-to-evict/.chainsaw-test/resource-others.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod05
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod06
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    volumeMounts:
+    - mountPath: /var/local/aaa
+      name: myfile
+  volumes:
+    - name: myfile
+      hostPath:
+        path: "*"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod07
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    volumeMounts:
+    - mountPath: /var/local/aaa
+      name: myfile
+  volumes:
+    - name: myfile
+      emptyDir: {}

--- a/best-practices-mpol/add-safe-to-evict/.kyverno-test/kyverno-test.yaml
+++ b/best-practices-mpol/add-safe-to-evict/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,35 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: add-safe-to-evict
+policies:
+- ../add-safe-to-evict.yaml
+resources:
+- resource.yaml
+results:
+- kind: Pod
+  patchedResources: myapp-pod03-patched.yaml
+  policy: add-safe-to-evict
+  resources:
+  - myapp-pod03
+  result: pass
+  isMUtatingPolicy: true
+- kind: Pod
+  policy: add-safe-to-evict
+  resources:
+  - myapp-pod01
+  result: skip
+  isMUtatingPolicy: true
+- kind: Pod
+  patchedResources: myapp-pod04-patched.yaml
+  policy: add-safe-to-evict
+  resources:
+  - myapp-pod04
+  result: pass
+  isMUtatingPolicy: true
+- kind: Pod
+  policy: add-safe-to-evict
+  resources:
+  - myapp-pod02
+  result: skip
+  isMUtatingPolicy: true

--- a/best-practices-mpol/add-safe-to-evict/.kyverno-test/myapp-pod03-patched.yaml
+++ b/best-practices-mpol/add-safe-to-evict/.kyverno-test/myapp-pod03-patched.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod03
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.1
+    volumeMounts:
+    - mountPath: /var/local/aaa
+      name: mydir
+  volumes:
+    - name: mydir
+      emptyDir: {}

--- a/best-practices-mpol/add-safe-to-evict/.kyverno-test/myapp-pod04-patched.yaml
+++ b/best-practices-mpol/add-safe-to-evict/.kyverno-test/myapp-pod04-patched.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod04
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.1
+    volumeMounts:
+    - mountPath: /var/local/aaa
+      name: myfile
+  volumes:
+    - name: myfile
+      hostPath:
+        path: "/foo"

--- a/best-practices-mpol/add-safe-to-evict/.kyverno-test/resource.yaml
+++ b/best-practices-mpol/add-safe-to-evict/.kyverno-test/resource.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod01
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.1
+    volumeMounts:
+    - mountPath: /var/local/aaa
+      name: mydir
+  volumes:
+    - name: mydir
+      emptyDir: {}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod02
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.1
+    volumeMounts:
+    - mountPath: /var/local/aaa
+      name: myfile
+  volumes:
+    - name: myfile
+      hostPath:
+        path: "*"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod03
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.1
+    volumeMounts:
+    - mountPath: /var/local/aaa
+      name: mydir
+  volumes:
+    - name: mydir
+      emptyDir: {}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod04
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.1
+    volumeMounts:
+    - mountPath: /var/local/aaa
+      name: myfile
+  volumes:
+    - name: myfile
+      hostPath:
+        path: "/foo"

--- a/best-practices-mpol/add-safe-to-evict/add-safe-to-evict.yaml
+++ b/best-practices-mpol/add-safe-to-evict/add-safe-to-evict.yaml
@@ -1,0 +1,40 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-safe-to-evict
+  annotations:
+    policies.kyverno.io/title: Add Safe To Evict
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/subject: Pod,Annotation
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      The Kubernetes cluster autoscaler does not evict pods that 
+      use hostPath or emptyDir volumes. To allow eviction of these pods, the annotation 
+      cluster-autoscaler.kubernetes.io/safe-to-evict=true must be added to the pods.
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+  matchConditions:
+    - name: has-emptydir-or-hostpath
+      expression: |
+        has(object.spec.volumes) && 
+        object.spec.volumes.exists(v, has(v.emptyDir) || has(v.hostPath))
+    - name: annotation-not-present
+      expression: |
+        !has(object.metadata.annotations) || 
+        !object.metadata.annotations.exists(k, k == 'cluster-autoscaler.kubernetes.io/safe-to-evict')
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            metadata: Object.metadata{
+              annotations: {
+                "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
+              }
+            }
+          }

--- a/best-practices-mpol/add-safe-to-evict/artifacthub-pkg.yml
+++ b/best-practices-mpol/add-safe-to-evict/artifacthub-pkg.yml
@@ -1,0 +1,21 @@
+name: add-safe-to-evict
+version: 1.0.0
+displayName: Add Safe To Evict
+createdAt: "2023-04-10T19:47:15.000Z"
+description: >-
+  The Kubernetes cluster autoscaler does not evict pods that  use hostPath or emptyDir volumes. To allow eviction of these pods, the annotation  cluster-autoscaler.kubernetes.io/safe-to-evict=true must be added to the pods. 
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/best-practices-mpol/add-safe-to-evict/add-safe-to-evict.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+readme: |
+  The Kubernetes cluster autoscaler does not evict pods that  use hostPath or emptyDir volumes. To allow eviction of these pods, the annotation  cluster-autoscaler.kubernetes.io/safe-to-evict=true must be added to the pods. 
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/subject: "Pod,Annotation"
+digest: 73ca07d90a4a25045d2a7e239ab01f37d4c19885eb78186ed899973523ddef81

--- a/castai-mpol/add-castai-removal-disabled/.chainsaw-test/chainsaw-test.yaml
+++ b/castai-mpol/add-castai-removal-disabled/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-castai-removal-disabled
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../add-castai-removal-disabled.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: ../.kyverno-test/resources.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: ../.kyverno-test/patched01.yaml
+    - assert:
+        file: ../.kyverno-test/patched02.yaml

--- a/castai-mpol/add-castai-removal-disabled/.chainsaw-test/policy-ready.yaml
+++ b/castai-mpol/add-castai-removal-disabled/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-castai-removal-disabled
+status:
+  conditionStatus:
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+      type: RBACPermissionsGranted
+    (length(conditions)): 2
+    ready: true

--- a/castai-mpol/add-castai-removal-disabled/.kyverno-test/kyverno-test.yaml
+++ b/castai-mpol/add-castai-removal-disabled/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,23 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: add-castai-removal-disabled
+policies:
+- ../add-castai-removal-disabled.yaml
+resources:
+- resources.yaml
+results:
+- kind: CronJob
+  patchedResources: patched02.yaml
+  policy: add-castai-removal-disabled
+  resources:
+  - addcronjob01
+  result: pass
+  isMutatingPolicy: true
+- kind: Job
+  patchedResources: patched01.yaml
+  policy: add-castai-removal-disabled
+  resources:
+  - addjob01
+  result: pass
+  isMutatingPolicy: true

--- a/castai-mpol/add-castai-removal-disabled/.kyverno-test/patched01.yaml
+++ b/castai-mpol/add-castai-removal-disabled/.kyverno-test/patched01.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: addjob01
+spec:
+  template:
+    metadata:
+      labels:
+        autoscaling.cast.ai/removal-disabled: "true"
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+  backoffLimit: 4

--- a/castai-mpol/add-castai-removal-disabled/.kyverno-test/patched02.yaml
+++ b/castai-mpol/add-castai-removal-disabled/.kyverno-test/patched02.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: addcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            autoscaling.cast.ai/removal-disabled: "true"
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure

--- a/castai-mpol/add-castai-removal-disabled/.kyverno-test/resources.yaml
+++ b/castai-mpol/add-castai-removal-disabled/.kyverno-test/resources.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: addjob01
+spec:
+  template:
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+  backoffLimit: 4
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: addcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure

--- a/castai-mpol/add-castai-removal-disabled/add-castai-removal-disabled.yaml
+++ b/castai-mpol/add-castai-removal-disabled/add-castai-removal-disabled.yaml
@@ -1,0 +1,58 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-castai-removal-disabled
+  annotations:
+    policies.kyverno.io/title: Add CAST AI Removal Disabled
+    policies.kyverno.io/category: CAST AI
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: "Job, CronJob"
+    kyverno.io/kyverno-version: "1.15.0"
+    kyverno.io/kubernetes-version: "1.25"
+    policies.kyverno.io/minversion: "1.15.0"
+    policies.kyverno.io/description: >- 
+      CAST AI will not downscale a node that includes a pod with the 
+      autoscaling.cast.ai/removal-disabled="true" label on it, this protects
+      sensitive workloads from being evicted and can be attributed to any pod to
+      protect against unwanted downscaling. This policy will mutate jobs and 
+      cronjobs to add the removal-disabled label to protect against eviction. 
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["batch"]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["jobs", "cronjobs"]
+  mutations:
+  - patchType: ApplyConfiguration
+    applyConfiguration:
+      expression: |
+        object.kind == "Job" ?
+        Object{
+          spec: Object.spec{
+            template: Object.spec.template{
+              metadata: Object.spec.template.metadata{
+                labels: {
+                  "autoscaling.cast.ai/removal-disabled": "true"
+                }
+              }
+            }
+          }
+        } :
+        object.kind == "CronJob" ?
+        Object{
+          spec: Object.spec{
+            jobTemplate: Object.spec.jobTemplate{
+              spec: Object.spec.jobTemplate.spec{
+                template: Object.spec.jobTemplate.spec.template{
+                  metadata: Object.spec.jobTemplate.spec.template.metadata{
+                    labels: {
+                      "autoscaling.cast.ai/removal-disabled": "true"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        } : Object{}
+  reinvocationPolicy: Never

--- a/castai-mpol/add-castai-removal-disabled/artifacthub-pkg.yml
+++ b/castai-mpol/add-castai-removal-disabled/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: add-castai-removal-disabled
+version: 1.0.0
+displayName: Add CAST AI removal disabled
+createdAt: "2023-06-28T14:08:14.000Z"
+description: >-
+  CAST AI will not downscale a node that includes a pod with the autoscaling.cast.ai/removal-disabled="true" label on it, this protects sensitive workloads from being evicted and can be attributed to any pod to protect against unwanted downscaling. This policy will mutate jobs and cronjobs to add the removal-disabled label to protect against eviction. 
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/castai-mpol/add-castai-removal-disabled/add-castai-removal-disabled.yaml
+  ```
+keywords:
+  - kyverno
+  - CAST AI
+readme: |
+  CAST AI will not downscale a node that includes a pod with the autoscaling.cast.ai/removal-disabled="true" label on it, this protects sensitive workloads from being evicted and can be attributed to any pod to protect against unwanted downscaling. This policy will mutate jobs and cronjobs to add the removal-disabled label to protect against eviction. 
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "CAST AI"
+  kyverno/kubernetesVersion: "1.25"
+  kyverno/subject: "Job, CronJob"
+digest: 833eed6664314850866dd1bd27127964abf44a27e29f14d1c893ec5b1e3318c3

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/chainsaw-step-02-apply-1.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/chainsaw-step-02-apply-1.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio.io/dataplane-mode: ambient
+  name: istio-test-en-ns

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/chainsaw-step-02-apply-2.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/chainsaw-step-02-apply-2.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio.io/dataplane-mode: other
+  name: istio-test-dis-ns

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/chainsaw-step-02-apply-3.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/chainsaw-step-02-apply-3.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-test-none-ns

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/chainsaw-step-02-apply-4.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/chainsaw-step-02-apply-4.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    foo: bar
+  name: istio-test-alt-ns

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-ambient-mode-namespace
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../add-ambient-mode-namespace.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: chainsaw-step-02-apply-1.yaml
+    - apply:
+        file: chainsaw-step-02-apply-2.yaml
+    - apply:
+        file: chainsaw-step-02-apply-3.yaml
+    - apply:
+        file: chainsaw-step-02-apply-4.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: patched-ns-alt.yaml
+    - assert:
+        file: patched-ns-disabled.yaml
+    - assert:
+        file: patched-ns-enabled.yaml
+    - assert:
+        file: patched-ns-none.yaml

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/patched-ns-alt.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/patched-ns-alt.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    foo: bar
+    istio.io/dataplane-mode: ambient
+  name: istio-test-alt-ns

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/patched-ns-disabled.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/patched-ns-disabled.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio.io/dataplane-mode: ambient
+  name: istio-test-dis-ns

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/patched-ns-enabled.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/patched-ns-enabled.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio.io/dataplane-mode: ambient
+  name: istio-test-en-ns

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/patched-ns-none.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/patched-ns-none.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio.io/dataplane-mode: ambient
+  name: istio-test-none-ns

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/policy-ready.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-ambient-mode-namespace
+status:
+  conditionStatus:
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+      type: RBACPermissionsGranted
+    (length(conditions)): 2
+    ready: true

--- a/istio-mpol/add-ambient-mode-namespace/.kyverno-test/kyverno-test.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,21 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: add-ambient-mode-namespace
+policies:
+- ../add-ambient-mode-namespace.yaml
+resources:
+- ../.chainsaw-test/patched-ns-disabled.yaml
+- ../.chainsaw-test/patched-ns-enabled.yaml
+- ../.chainsaw-test/patched-ns-alt.yaml
+- ../.chainsaw-test/patched-ns-none.yaml
+results:
+- policy: add-ambient-mode-namespace
+  isMutatingPolicy: true
+  kind: Namespace
+  resources:
+  - istio-test-none-ns
+  - istio-test-dis-ns
+  - istio-test-en-ns
+  - istio-test-alt-ns
+  result: pass

--- a/istio-mpol/add-ambient-mode-namespace/add-ambient-mode-namespace.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/add-ambient-mode-namespace.yaml
@@ -1,0 +1,35 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-ambient-mode-namespace
+  annotations:
+    policies.kyverno.io/title: Add Istio Ambient Mode
+    policies.kyverno.io/category: Istio
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.8.0
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: Namespace
+    policies.kyverno.io/description: >-
+      In order for Istio to include namespaces in ambient mode, the label `istio.io/dataplane-mode` 
+      must be set to `ambient`. As an alternative to rejecting Namespace definitions which don't already 
+      contain this label, it can be added automatically. This policy adds the label `istio.io/dataplane-mode`
+      set to `ambient` for all new Namespaces.
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["namespaces"]
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            metadata: Object.metadata{
+              labels: {
+                "istio.io/dataplane-mode": "ambient"
+              }
+            }
+          }

--- a/istio-mpol/add-ambient-mode-namespace/artifacthub-pkg.yml
+++ b/istio-mpol/add-ambient-mode-namespace/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: add-ambient-mode-namespace
+version: 1.0.0
+displayName: Add Istio Ambient Mode
+createdAt: "2024-07-25T20:07:52.000Z"
+description: >-
+  In order for Istio to include namespaces in ambient mode, the label `istio.io/dataplane-mode` must be set to `ambient`. As an alternative to rejecting Namespace definitions which don't already contain this label, it can be added automatically. This policy adds the label `istio.io/dataplane-mode` set to `ambient` for all new Namespaces.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/istio-mpol/add-ambient-mode-namespace/add-ambient-mode-namespace.yaml
+  ```
+keywords:
+  - kyverno
+  - Istio
+readme: |
+  In order for Istio to include namespaces in ambient mode, the label `istio.io/dataplane-mode` must be set to `ambient`. As an alternative to rejecting Namespace definitions which don't already contain this label, it can be added automatically. This policy adds the label `istio.io/dataplane-mode` set to `ambient` for all new Namespaces.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Istio"
+  kyverno/kubernetesVersion: "1.24"
+  kyverno/subject: "Namespace"
+digest: b80af3050cf024227d75a554d51c62922f7afe3ce54a0c8c0e6207f1945a4059

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/chainsaw-step-02-apply-1.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/chainsaw-step-02-apply-1.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio-injection: enabled
+  name: istio-test-en-ns

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/chainsaw-step-02-apply-2.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/chainsaw-step-02-apply-2.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio-injection: disabled
+  name: istio-test-dis-ns

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/chainsaw-step-02-apply-3.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/chainsaw-step-02-apply-3.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-test-none-ns

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/chainsaw-step-02-apply-4.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/chainsaw-step-02-apply-4.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    foo: bar
+  name: istio-test-alt-ns

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-sidecar-injection-namespace
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../add-sidecar-injection-namespace.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: chainsaw-step-02-apply-1.yaml
+    - apply:
+        file: chainsaw-step-02-apply-2.yaml
+    - apply:
+        file: chainsaw-step-02-apply-3.yaml
+    - apply:
+        file: chainsaw-step-02-apply-4.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: patched-ns-alt.yaml
+    - assert:
+        file: patched-ns-disabled.yaml
+    - assert:
+        file: patched-ns-enabled.yaml
+    - assert:
+        file: patched-ns-none.yaml

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/patched-ns-alt.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/patched-ns-alt.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    foo: bar
+    istio-injection: enabled
+  name: istio-test-alt-ns

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/patched-ns-disabled.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/patched-ns-disabled.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio-injection: enabled
+  name: istio-test-dis-ns

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/patched-ns-enabled.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/patched-ns-enabled.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio-injection: enabled
+  name: istio-test-en-ns

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/patched-ns-none.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/patched-ns-none.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio-injection: enabled
+  name: istio-test-none-ns

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/policy-ready.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-sidecar-injection-namespace
+status:
+  conditionStatus:
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+      type: RBACPermissionsGranted
+    (length(conditions)): 2
+    ready: true

--- a/istio-mpol/add-sidecar-injection-namespace/add-sidecar-injection-namespace.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/add-sidecar-injection-namespace.yaml
@@ -1,0 +1,35 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-sidecar-injection-namespace
+  annotations:
+    policies.kyverno.io/title: Add Istio Sidecar Injection
+    policies.kyverno.io/category: Istio
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.8.0
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: Namespace
+    policies.kyverno.io/description: >-
+      In order for Istio to inject sidecars to workloads deployed into Namespaces, the label
+      `istio-injection` must be set to `enabled`. As an alternative to rejecting Namespace definitions
+      which don't already contain this label, it can be added automatically. This policy adds the label
+      `istio-injection` set to `enabled` for all new Namespaces.
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["namespaces"]
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            metadata: Object.metadata{
+              labels: {
+                "istio-injection": "enabled"
+              }
+            }
+          }

--- a/istio-mpol/add-sidecar-injection-namespace/artifacthub-pkg.yml
+++ b/istio-mpol/add-sidecar-injection-namespace/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: add-sidecar-injection-namespace
+version: 1.0.0
+displayName: Add Istio Sidecar Injection
+createdAt: "2023-04-10T20:07:52.000Z"
+description: >-
+  In order for Istio to inject sidecars to workloads deployed into Namespaces, the label `istio-injection` must be set to `enabled`. As an alternative to rejecting Namespace definitions which don't already contain this label, it can be added automatically. This policy adds the label `istio-inject` set to `enabled` for all new Namespaces.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/istio-mpol/add-sidecar-injection-namespace/add-sidecar-injection-namespace.yaml
+  ```
+keywords:
+  - kyverno
+  - Istio
+readme: |
+  In order for Istio to inject sidecars to workloads deployed into Namespaces, the label `istio-injection` must be set to `enabled`. As an alternative to rejecting Namespace definitions which don't already contain this label, it can be added automatically. This policy adds the label `istio-inject` set to `enabled` for all new Namespaces.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Istio"
+  kyverno/kubernetesVersion: "1.24"
+  kyverno/subject: "Namespace"
+digest: a7bbd0db4a12cd5b39126dd95d8a5cd055e5e5b43fe71be9ee4285fdc1660634

--- a/kasten/kasten-minimum-retention/artifacthub-pkg.yml
+++ b/kasten/kasten-minimum-retention/artifacthub-pkg.yml
@@ -17,4 +17,4 @@ annotations:
   kyverno/category: "Veeam Kasten"
   kyverno/kubernetesVersion: "1.24-1.30"
   kyverno/subject: "Policy"
-digest: e394e005816521b6157a1ef4a0c9757bca956dd706f6a82746fe661c7938d61f
+digest: 760285fac0a6f109e282d1b1a0ca87c32c2289efea3f8a520d17d2bcf997635d

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/.chainsaw-test/chainsaw-test.yaml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: enable-kubecost-continuous-rightsizing
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../enable-kubecost-continuous-rightsizing.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: ../.kyverno-test/resource.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: ../.kyverno-test/patchedResource1.yaml
+    - error:
+        file: not-patched-deploy.yaml

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/.chainsaw-test/not-patched-deploy.yaml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/.chainsaw-test/not-patched-deploy.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy01
+  labels:
+    app: busybox
+    env: test
+  annotations:
+    request.autoscaling.kubecost.com/enabled: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: ghcr.io/kyverno/test-busybox:1.35
+        name: busybox
+        command: ["sleep", "9999"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+          limits:
+            cpu: 100m
+            memory: 10Mi

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/.chainsaw-test/policy-ready.yaml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: enable-kubecost-continuous-rightsizing
+status:
+  conditionStatus:
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+      type: RBACPermissionsGranted
+    (length(conditions)): 2
+    ready: true

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/.kyverno-test/kyverno-test.yaml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: enable-kubecost-continuous-rightsizing
+policies:
+- ../enable-kubecost-continuous-rightsizing.yaml
+resources:
+- resource.yaml
+results:
+- kind: Deployment
+  patchedResources: patchedResource1.yaml
+  policy: enable-kubecost-continuous-rightsizing
+  resources:
+  - deploy02
+  result: pass
+  isMutatingPolicy: true
+- kind: Deployment
+  policy: enable-kubecost-continuous-rightsizing
+  resources:
+  - deploy01
+  result: skip
+  isMutatingPolicy: true

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/.kyverno-test/patchedResource1.yaml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/.kyverno-test/patchedResource1.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy02
+  labels:
+    app: busybox
+    env: test
+  annotations:
+    request.autoscaling.kubecost.com/enabled: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox:1.35
+        name: busybox
+        command: ["sleep", "9999"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+          limits:
+            cpu: 100m
+            memory: 10Mi

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/.kyverno-test/resource.yaml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/.kyverno-test/resource.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy01
+  labels:
+    app: busybox
+    env: test
+  annotations:
+    request.autoscaling.kubecost.com/enabled: "false"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox:1.35
+        name: busybox
+        command: ["sleep", "9999"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+          limits:
+            cpu: 100m
+            memory: 10Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy02
+  labels:
+    app: busybox
+    env: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox:1.35
+        name: busybox
+        command: ["sleep", "9999"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+          limits:
+            cpu: 100m
+            memory: 10Mi

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/artifacthub-pkg.yml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/artifacthub-pkg.yml
@@ -1,0 +1,21 @@
+name: enable-kubecost-continuous-rightsizing
+version: 1.0.0
+displayName: Enable Kubecost Continuous Rightsizing
+createdAt: "2023-05-07T00:00:00.000Z"
+description: >-
+  Kubecost is able to modify container resource requests and limits dynamically based upon observed utilization patterns and recommendations. This provides an easy way to automatically improve allocation of cluster resources by increasing efficiency. This policy will annotate all Deployments which have the label `env=test` with `request.autoscaling.kubecost.com/enabled="true"` if the annotation is not already present. Other annotations may be added according to need and users should see the documentation for a complete list.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/kubecost-mpol/enable-kubecost-continuous-rightsizing/enable-kubecost-continuous-rightsizing.yaml
+  ```
+keywords:
+  - kyverno
+  - Kubecost
+readme: |
+  Kubecost is able to modify container resource requests and limits dynamically based upon observed utilization patterns and recommendations. This provides an easy way to automatically improve allocation of cluster resources by increasing efficiency. This policy will annotate all Deployments which have the label `env=test` with `request.autoscaling.kubecost.com/enabled="true"` if the annotation is not already present. Other annotations may be added according to need and users should see the documentation for a complete list.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Kubecost"
+  kyverno/subject: "Deployment,Annotation"
+digest: 56f74fa0dd6e6973b2582f3f4347f47d13ce575389206a859070bb8396d06265

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/enable-kubecost-continuous-rightsizing.yaml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/enable-kubecost-continuous-rightsizing.yaml
@@ -1,0 +1,42 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: enable-kubecost-continuous-rightsizing
+  annotations:
+    policies.kyverno.io/title: Enable Kubecost Continuous Rightsizing
+    policies.kyverno.io/category: Kubecost
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Deployment, Annotation
+    kyverno.io/kyverno-version: 1.10.0
+    kyverno.io/kubernetes-version: "1.25"
+    policies.kyverno.io/description: >-
+      Kubecost is able to modify container resource requests and limits dynamically
+      based upon observed utilization patterns and recommendations. This provides an
+      easy way to automatically improve allocation of cluster resources by increasing
+      efficiency. This policy will annotate all Deployments which have the label
+      `env=test` with `request.autoscaling.kubecost.com/enabled="true"` if the annotation
+      is not already present. Other annotations may be added according to need and users
+      should see the documentation for a complete list.
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["apps"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["deployments"]
+  matchConditions:
+    - name: check-env-label
+      expression: "has(object.metadata.labels) && has(object.metadata.labels.env) && object.metadata.labels.env == 'test'"
+    - name: check-annotation-not-exists
+      expression: "!has(object.metadata.annotations) || !object.metadata.annotations.exists(k, k == 'request.autoscaling.kubecost.com/enabled')"
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            metadata: Object.metadata{
+              annotations: {
+                "request.autoscaling.kubecost.com/enabled": "true"
+              }
+            }
+          }

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-apply-1.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-apply-1.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    foo: bar
+  name: lmi-ns01

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-apply-2.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-apply-2.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    config.linkerd.io/proxy-await: enabled
+    linkerd.io/inject: enabled
+  name: lmi-ns02

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-apply-3.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-apply-3.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    config.linkerd.io/proxy-await: disabled
+    linkerd.io/inject: disabled
+  name: lmi-ns03

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-apply-4.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-apply-4.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    config.linkerd.io/proxy-await: disabled
+  name: lmi-ns04

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-apply-5.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-apply-5.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    linkerd.io/inject: disabled
+  name: lmi-ns05

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-assert-1.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-assert-1.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    config.linkerd.io/proxy-await: enabled
+    foo: bar
+    linkerd.io/inject: enabled
+  name: lmi-ns01

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-assert-2.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-assert-2.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    config.linkerd.io/proxy-await: enabled
+    linkerd.io/inject: enabled
+  name: lmi-ns02

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-assert-3.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-assert-3.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    config.linkerd.io/proxy-await: disabled
+    linkerd.io/inject: disabled
+  name: lmi-ns03

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-assert-4.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-assert-4.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    config.linkerd.io/proxy-await: disabled
+    linkerd.io/inject: enabled
+  name: lmi-ns04

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-assert-5.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-step-02-assert-5.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    config.linkerd.io/proxy-await: enabled
+    linkerd.io/inject: disabled
+  name: lmi-ns05

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-test.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-linkerd-mesh-injection
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../add-linkerd-mesh-injection.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: chainsaw-step-02-apply-1.yaml
+    - apply:
+        file: chainsaw-step-02-apply-2.yaml
+    - apply:
+        file: chainsaw-step-02-apply-3.yaml
+    - apply:
+        file: chainsaw-step-02-apply-4.yaml
+    - apply:
+        file: chainsaw-step-02-apply-5.yaml
+    - assert:
+        file: chainsaw-step-02-assert-1.yaml
+    - assert:
+        file: chainsaw-step-02-assert-2.yaml
+    - assert:
+        file: chainsaw-step-02-assert-3.yaml
+    - assert:
+        file: chainsaw-step-02-assert-4.yaml
+    - assert:
+        file: chainsaw-step-02-assert-5.yaml

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/policy-ready.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-linkerd-mesh-injection
+status:
+  conditionStatus:
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+      type: RBACPermissionsGranted
+    (length(conditions)): 2
+    ready: true

--- a/linkerd-mpol/add-linkerd-mesh-injection/add-linkerd-mesh-injection.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/add-linkerd-mesh-injection.yaml
@@ -1,0 +1,66 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-linkerd-mesh-injection
+  annotations:
+    policies.kyverno.io/title: Add Linkerd Mesh Injection
+    policies.kyverno.io/category: Linkerd
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Namespace, Annotation
+    policies.kyverno.io/description: >-
+      Sidecar proxy injection in Linkerd may be handled at the Namespace level by
+      setting the annotation `linkerd.io/inject` to `enabled`. In addition, a second
+      annotation may be applied which controls the Pod startup behavior. This policy
+      sets the annotations, if not present, `linkerd.io/inject` and `config.linkerd.io/proxy-await`
+      to `enabled` on all new Namespaces.
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["namespaces"]
+  variables:
+    - name: hasInjectAnnotation
+      expression: |
+        has(object.metadata.annotations) && 
+        object.metadata.annotations.exists(k, k == 'linkerd.io/inject')
+    - name: hasProxyAwaitAnnotation
+      expression: |
+        has(object.metadata.annotations) && 
+        object.metadata.annotations.exists(k, k == 'config.linkerd.io/proxy-await')
+    - name: needsInject
+      expression: "!variables.hasInjectAnnotation"
+    - name: needsProxyAwait
+      expression: "!variables.hasProxyAwaitAnnotation"
+  matchConditions:
+    - name: needs-at-least-one-annotation
+      expression: "variables.needsInject || variables.needsProxyAwait"
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          variables.needsInject && variables.needsProxyAwait ?
+          Object{
+            metadata: Object.metadata{
+              annotations: {
+                "linkerd.io/inject": "enabled",
+                "config.linkerd.io/proxy-await": "enabled"
+              }
+            }
+          } :
+          variables.needsInject ?
+          Object{
+            metadata: Object.metadata{
+              annotations: {
+                "linkerd.io/inject": "enabled"
+              }
+            }
+          } :
+          Object{
+            metadata: Object.metadata{
+              annotations: {
+                "config.linkerd.io/proxy-await": "enabled"
+              }
+            }
+          }

--- a/linkerd-mpol/add-linkerd-mesh-injection/artifacthub-pkg.yml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/artifacthub-pkg.yml
@@ -1,0 +1,21 @@
+name: add-linkerd-mesh-injection
+version: 1.0.0
+displayName: Add Linkerd Mesh Injection
+createdAt: "2023-04-10T20:19:58.000Z"
+description: >-
+  Sidecar proxy injection in Linkerd may be handled at the Namespace level by setting the annotation `linkerd.io/inject` to `enabled`. In addition, a second annotation may be applied which controls the Pod startup behavior. This policy sets the annotations, if not present, `linkerd.io/inject` and `config.linkerd.io/proxy-await` to `enabled` on all new Namespaces.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/linkerd-mpol/add-linkerd-mesh-injection/add-linkerd-mesh-injection.yaml
+  ```
+keywords:
+  - kyverno
+  - Linkerd
+readme: |
+  Sidecar proxy injection in Linkerd may be handled at the Namespace level by setting the annotation `linkerd.io/inject` to `enabled`. In addition, a second annotation may be applied which controls the Pod startup behavior. This policy sets the annotations, if not present, `linkerd.io/inject` and `config.linkerd.io/proxy-await` to `enabled` on all new Namespaces.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Linkerd"
+  kyverno/subject: "Namespace, Annotation"
+digest: 5e18439276cc351a9ce37e69dfb184583bff718c95275733bd0a47c9608ec738

--- a/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/chainsaw-step-02-apply-1.yaml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/chainsaw-step-02-apply-1.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    foo: bar
+  name: lpa-ns01

--- a/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/chainsaw-step-02-apply-2.yaml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/chainsaw-step-02-apply-2.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    config.linkerd.io/default-inbound-policy: allow
+  name: lpa-ns02

--- a/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/chainsaw-step-02-assert-1.yaml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/chainsaw-step-02-assert-1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    config.linkerd.io/default-inbound-policy: deny
+    foo: bar
+  name: lpa-ns01

--- a/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/chainsaw-step-02-assert-2.yaml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/chainsaw-step-02-assert-2.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    config.linkerd.io/default-inbound-policy: allow
+  name: lpa-ns02

--- a/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/chainsaw-test.yaml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-linkerd-policy-annotation
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../add-linkerd-policy-annotation.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: chainsaw-step-02-apply-1.yaml
+    - apply:
+        file: chainsaw-step-02-apply-2.yaml
+    - assert:
+        file: chainsaw-step-02-assert-1.yaml
+    - assert:
+        file: chainsaw-step-02-assert-2.yaml

--- a/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/policy-ready.yaml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-linkerd-policy-annotation
+status:
+  conditionStatus:
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+      type: RBACPermissionsGranted
+    (length(conditions)): 2
+    ready: true

--- a/linkerd-mpol/add-linkerd-policy-annotation/add-linkerd-policy-annotation.yaml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/add-linkerd-policy-annotation.yaml
@@ -1,0 +1,39 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-linkerd-policy-annotation
+  annotations:
+    policies.kyverno.io/title: Add Linkerd Policy Annotation
+    policies.kyverno.io/category: Linkerd
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Namespace,Annotation
+    policies.kyverno.io/description: >-
+      Linkerd will, by default, allow all incoming traffic to Pods in the mesh
+      including that from outside the cluster network. In many cases, this default
+      needs to be changed to deny all traffic so it may be selectively
+      opened using Linkerd policy objects. This policy sets the annotation
+      `config.linkerd.io/default-inbound-policy` to `deny`, if not present, for new Namespaces.
+      It can be customized with exclusions to more tightly control its application.
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["namespaces"]
+  matchConditions:
+    - name: annotation-not-present
+      expression: |
+        !has(object.metadata.annotations) || 
+        !object.metadata.annotations.exists(k, k == 'config.linkerd.io/default-inbound-policy')
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            metadata: Object.metadata{
+              annotations: {
+                "config.linkerd.io/default-inbound-policy": "deny"
+              }
+            }
+          }

--- a/linkerd-mpol/add-linkerd-policy-annotation/artifacthub-pkg.yml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/artifacthub-pkg.yml
@@ -1,0 +1,21 @@
+name: add-linkerd-policy-annotation
+version: 1.0.0
+displayName: Add Linkerd Policy Annotation
+createdAt: "2023-04-10T20:19:58.000Z"
+description: >-
+  Linkerd will, by default, allow all incoming traffic to Pods in the mesh including that from outside the cluster network. In many cases, this default needs to be changed to deny all traffic so it may be selectively opened using Linkerd policy objects. This policy sets the annotation `config.linkerd.io/default-inbound-policy` to `deny`, if not present, for new Namespaces. It can be customized with exclusions to more tightly control its application.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/linkerd-mpol/add-linkerd-policy-annotation/add-linkerd-policy-annotation.yaml
+  ```
+keywords:
+  - kyverno
+  - Linkerd
+readme: |
+  Linkerd will, by default, allow all incoming traffic to Pods in the mesh including that from outside the cluster network. In many cases, this default needs to be changed to deny all traffic so it may be selectively opened using Linkerd policy objects. This policy sets the annotation `config.linkerd.io/default-inbound-policy` to `deny`, if not present, for new Namespaces. It can be customized with exclusions to more tightly control its application.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Linkerd"
+  kyverno/subject: "Namespace,Annotation"
+digest: 1c258570deeff0c7f8354d5d5973168651942b01dc37b7ee9a573ca83048e191

--- a/openshift/inject-infrastructurename/artifacthub-pkg.yml
+++ b/openshift/inject-infrastructurename/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "OpenShift"
   kyverno/kubernetesVersion: "1.26"
   kyverno/subject: "MachineSet"
-digest: 55f4f0f016cfed1e26b0a3621fa3ced8cd89134ade53976dec7cd6d7b2d9911a
+digest: 01664af0bf65020cb8a29330e10f9e9d5cabffc2829ebfae8fea861af655961a

--- a/pod-security-cel/restricted/disallow-capabilities-strict/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/disallow-capabilities-strict/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 45c37cb004764c8fa03d95a018511660b1a6dc5b57752bfa8400384bf5c5037e
+digest: 66dadc5afe015311374581d5aea5a9cd16c498fdc546a27caa4bc113ecb1c651
 createdAt: "2023-12-04T09:04:49Z"

--- a/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/chainsaw-step-00-apply-1.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/chainsaw-step-00-apply-1.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: background-controller
+    app.kubernetes.io/instance: kyverno
+    app.kubernetes.io/part-of: kyverno
+  name: kyverno:background-controller:add-privileged-existing-namespaces
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - update

--- a/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/chainsaw-step-01-apply-1.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/chainsaw-step-01-apply-1.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: add-privileged-existing-ns01

--- a/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/chainsaw-test.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-privileged-existing-namespaces
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: chainsaw-step-00-apply-1.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: chainsaw-step-01-apply-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: ../add-privileged-existing-namespaces.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: patched-ns01.yaml
+    - error:
+        file: not-patched-ns03.yaml
+  - name: step-04
+    try:
+    - sleep:
+        duration: 3s
+    - apply:
+        file: policy-update.yaml
+    - assert:
+        file: patched-again-ns01.yaml

--- a/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/not-patched-ns03.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/not-patched-ns03.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  name: kube-system

--- a/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/patched-again-ns01.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/patched-again-ns01.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+  name: add-privileged-existing-ns01

--- a/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/patched-ns01.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/patched-ns01.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  name: add-privileged-existing-ns01

--- a/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/policy-ready.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-privileged-existing-namespaces
+status:
+  conditionStatus:
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+      type: RBACPermissionsGranted
+    (length(conditions)): 2
+    ready: true

--- a/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/policy-update.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/policy-update.yaml
@@ -1,0 +1,22 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-privileged-existing-namespaces
+spec:
+  mutateExistingOnPolicyUpdate: true
+  rules:
+  - name: label-privileged-namespaces
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+    mutate:
+      targets:
+        - apiVersion: v1
+          kind: Namespace
+      patchStrategicMerge:
+        metadata:
+          <(name): "!kube-system"
+          labels:
+            pod-security.kubernetes.io/enforce: baseline

--- a/psa-mpol/add-privileged-existing-namespaces/add-privileged-existing-namespaces.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/add-privileged-existing-namespaces.yaml
@@ -1,0 +1,42 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-privileged-existing-namespaces
+  annotations:
+    policies.kyverno.io/title: Add Privileged Label to Existing Namespaces
+    policies.kyverno.io/category: Pod Security Admission
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Namespace
+    kyverno.io/kyverno-version: 1.8.0
+    policies.kyverno.io/minversion: 1.7.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/description: >-
+      When Pod Security Admission is configured with a cluster-wide AdmissionConfiguration file
+      which sets either baseline or restricted, for example in many PaaS CIS profiles, it may
+      be necessary to relax this to privileged on a per-Namespace basis so that more
+      granular control can be provided. This policy labels new and existing Namespaces, except
+      that of kube-system, with the `pod-security.kubernetes.io/enforce: privileged` label.
+spec:
+  evaluation:
+    mutateExisting:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["namespaces"]
+  matchConditions:
+    - name: exclude-kube-system
+      expression: 'object.metadata.name != "kube-system"'
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            metadata: Object.metadata{
+              labels: {
+                "pod-security.kubernetes.io/enforce": "privileged"
+              }
+            }
+          }

--- a/psa-mpol/add-privileged-existing-namespaces/artifacthub-pkg.yml
+++ b/psa-mpol/add-privileged-existing-namespaces/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: add-privileged-existing-namespaces
+version: 1.0.0
+displayName: Add Privileged Label to Existing Namespaces
+createdAt: "2023-04-10T23:21:22.000Z"
+description: >-
+  When Pod Security Admission is configured with a cluster-wide AdmissionConfiguration file which sets either baseline or restricted, for example in many PaaS CIS profiles, it may be necessary to relax this to privileged on a per-Namespace basis so that more granular control can be provided. This policy labels new and existing Namespaces, except that of kube-system, with the `pod-security.kubernetes.io/enforce: privileged` label.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/psa-mpol/add-privileged-existing-namespaces/add-privileged-existing-namespaces.yaml
+  ```
+keywords:
+  - kyverno
+  - Pod Security Admission
+readme: |
+  When Pod Security Admission is configured with a cluster-wide AdmissionConfiguration file which sets either baseline or restricted, for example in many PaaS CIS profiles, it may be necessary to relax this to privileged on a per-Namespace basis so that more granular control can be provided. This policy labels new and existing Namespaces, except that of kube-system, with the `pod-security.kubernetes.io/enforce: privileged` label.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Pod Security Admission"
+  kyverno/kubernetesVersion: "1.24"
+  kyverno/subject: "Namespace"
+digest: 4a2081bb331f0c01b55908f33055567d34a610bdaaf6caaf63a31bcabe923aed

--- a/psa-mpol/add-psa-labels/.chainsaw-test/chainsaw-test.yaml
+++ b/psa-mpol/add-psa-labels/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-psa-labels
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../add-psa-labels.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: ns.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: patched-ns01.yaml
+    - assert:
+        file: patched-ns02.yaml
+    - assert:
+        file: patched-ns03.yaml

--- a/psa-mpol/add-psa-labels/.chainsaw-test/ns.yaml
+++ b/psa-mpol/add-psa-labels/.chainsaw-test/ns.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: add-psa-labels-ns01
+  labels:
+    foo: bar
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: add-psa-labels-ns02
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: add-psa-labels-ns03
+  labels:
+    pod-security.kubernetes.io/warn: baseline
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: add-psa-labels-ns04
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted

--- a/psa-mpol/add-psa-labels/.chainsaw-test/patched-ns01.yaml
+++ b/psa-mpol/add-psa-labels/.chainsaw-test/patched-ns01.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    foo: bar
+  name: add-psa-labels-ns01

--- a/psa-mpol/add-psa-labels/.chainsaw-test/patched-ns02.yaml
+++ b/psa-mpol/add-psa-labels/.chainsaw-test/patched-ns02.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: restricted
+  name: add-psa-labels-ns02

--- a/psa-mpol/add-psa-labels/.chainsaw-test/patched-ns03.yaml
+++ b/psa-mpol/add-psa-labels/.chainsaw-test/patched-ns03.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: baseline
+  name: add-psa-labels-ns03

--- a/psa-mpol/add-psa-labels/.chainsaw-test/policy-ready.yaml
+++ b/psa-mpol/add-psa-labels/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-psa-labels
+status:
+  conditionStatus:
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+      type: RBACPermissionsGranted
+    (length(conditions)): 2
+    ready: true

--- a/psa-mpol/add-psa-labels/.kyverno-test/kyverno-test.yaml
+++ b/psa-mpol/add-psa-labels/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,24 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: add-psa-labels
+policies:
+- ../add-psa-labels.yaml
+resources:
+- resource.yaml
+- resourcefail.yaml
+results:
+- kind: Namespace
+  patchedResources: patchedResourcefail.yaml
+  policy: add-psa-labels
+  resources:
+  - test-fail
+  result: fail
+  isMutatingPolicy: true
+- kind: Namespace
+  patchedResources: patchedResource.yaml
+  policy: add-psa-labels
+  resources:
+  - test
+  result: pass
+  isMutatingPolicy: true

--- a/psa-mpol/add-psa-labels/.kyverno-test/patchedResource.yaml
+++ b/psa-mpol/add-psa-labels/.kyverno-test/patchedResource.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+  labels:
+      pod-security.kubernetes.io/enforce: baseline
+      pod-security.kubernetes.io/warn: restricted

--- a/psa-mpol/add-psa-labels/.kyverno-test/patchedResourcefail.yaml
+++ b/psa-mpol/add-psa-labels/.kyverno-test/patchedResourcefail.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+  labels:
+      pod-security.kubernetes.io/fail: baseline-fail

--- a/psa-mpol/add-psa-labels/.kyverno-test/resource.yaml
+++ b/psa-mpol/add-psa-labels/.kyverno-test/resource.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test

--- a/psa-mpol/add-psa-labels/.kyverno-test/resourcefail.yaml
+++ b/psa-mpol/add-psa-labels/.kyverno-test/resourcefail.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-fail

--- a/psa-mpol/add-psa-labels/add-psa-labels.yaml
+++ b/psa-mpol/add-psa-labels/add-psa-labels.yaml
@@ -1,0 +1,56 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-psa-labels
+  annotations:
+    policies.kyverno.io/title: Add PSA Labels
+    policies.kyverno.io/category: Pod Security Admission, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.7.1
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/subject: Namespace
+    policies.kyverno.io/description: >-
+      Pod Security Admission (PSA) can be controlled via the assignment of labels
+      at the Namespace level which define the Pod Security Standard (PSS) profile
+      in use and the action to take. If not using a cluster-wide configuration
+      via an AdmissionConfiguration file, Namespaces must be explicitly labeled.
+      This policy assigns the labels `pod-security.kubernetes.io/enforce=baseline`
+      and `pod-security.kubernetes.io/warn=restricted` to all new Namespaces if
+      those labels are not included.
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["namespaces"]
+  matchConditions:
+    - name: needs-psa-labels
+      expression: |
+        !has(object.metadata.labels) ||
+        !object.metadata.labels.exists(k, k == 'pod-security.kubernetes.io/enforce') ||
+        !object.metadata.labels.exists(k, k == 'pod-security.kubernetes.io/warn')
+  variables:
+    - name: enforceValue
+      expression: |
+        has(object.metadata.labels) && 
+        object.metadata.labels.exists(k, k == 'pod-security.kubernetes.io/enforce') ?
+        object.metadata.labels['pod-security.kubernetes.io/enforce'] : 'baseline'
+    - name: warnValue
+      expression: |
+        has(object.metadata.labels) && 
+        object.metadata.labels.exists(k, k == 'pod-security.kubernetes.io/warn') ?
+        object.metadata.labels['pod-security.kubernetes.io/warn'] : 'restricted'
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            metadata: Object.metadata{
+              labels: {
+                "pod-security.kubernetes.io/enforce": string(variables.enforceValue),
+                "pod-security.kubernetes.io/warn": string(variables.warnValue)
+              }
+            }
+          }

--- a/psa-mpol/add-psa-labels/artifacthub-pkg.yml
+++ b/psa-mpol/add-psa-labels/artifacthub-pkg.yml
@@ -1,0 +1,23 @@
+name: add-psa-labels
+version: 1.0.0
+displayName: Add PSA Labels
+createdAt: "2023-04-10T23:21:22.000Z"
+description: >-
+  Pod Security Admission (PSA) can be controlled via the assignment of labels at the Namespace level which define the Pod Security Standard (PSS) profile in use and the action to take. If not using a cluster-wide configuration via an AdmissionConfiguration file, Namespaces must be explicitly labeled. This policy assigns the labels `pod-security.kubernetes.io/enforce=baseline` and `pod-security.kubernetes.io/warn=restricted` to all new Namespaces if those labels are not included.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/psa-mpol/add-psa-labels/add-psa-labels.yaml
+  ```
+keywords:
+  - kyverno
+  - Pod Security Admission
+  - EKS Best Practices
+readme: |
+  Pod Security Admission (PSA) can be controlled via the assignment of labels at the Namespace level which define the Pod Security Standard (PSS) profile in use and the action to take. If not using a cluster-wide configuration via an AdmissionConfiguration file, Namespaces must be explicitly labeled. This policy assigns the labels `pod-security.kubernetes.io/enforce=baseline` and `pod-security.kubernetes.io/warn=restricted` to all new Namespaces if those labels are not included.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Pod Security Admission, EKS Best Practices"
+  kyverno/kubernetesVersion: "1.24"
+  kyverno/subject: "Namespace"
+digest: 2c901e8fd195193f336eb91fed91e34530ad416174274199328a7aff4017c72d

--- a/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/README.md
+++ b/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/README.md
@@ -1,0 +1,11 @@
+## Description
+
+This is a test of the policy in this folder.
+
+## Expected Behavior
+
+The resource is expected to be mutated so it resembles the specified asserted resources. If it does, the test passes. If it does not, it fails.
+
+## Reference Issue(s)
+
+N/A

--- a/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/chainsaw-step-02-apply-1.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/chainsaw-step-02-apply-1.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: add-runtimeclassname

--- a/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/chainsaw-step-02-apply-2.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/chainsaw-step-02-apply-2.yaml
@@ -1,0 +1,5 @@
+apiVersion: node.k8s.io/v1
+handler: prodconfig
+kind: RuntimeClass
+metadata:
+  name: prodclass

--- a/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/chainsaw-test.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-runtimeclassname
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../add-runtimeClassName.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: chainsaw-step-02-apply-1.yaml
+    - apply:
+        file: chainsaw-step-02-apply-2.yaml
+  - name: step-03
+    try:
+    - apply:
+        file: ../.kyverno-test/resource.yaml
+    - assert:
+        file: ../.kyverno-test/patchedResource1.yaml

--- a/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/policy-ready.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-runtimeclassname
+status:
+  conditionStatus:
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+      type: RBACPermissionsGranted
+    (length(conditions)): 2
+    ready: true

--- a/psp-migration-mpol/add-runtimeClassName/.kyverno-test/kyverno-test.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,16 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: add-runtimeClassName
+policies:
+- ../add-runtimeClassName.yaml
+resources:
+- resource.yaml
+results:
+- kind: Pod
+  patchedResources: patchedResource1.yaml
+  policy: add-runtimeclassname
+  resources:
+  - pod01
+  result: pass
+  isMutatingPolicy: true

--- a/psp-migration-mpol/add-runtimeClassName/.kyverno-test/patchedResource1.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/.kyverno-test/patchedResource1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: busybox
+  name: pod01
+  namespace: add-runtimeclassname
+spec:
+  automountServiceAccountToken: false
+  runtimeClassName: prodclass
+  containers:
+  - name: busybox
+    image: somedummybusyboximage:1.1.0
+  - name: nginx
+    image: somedummynginximage:1.1.0

--- a/psp-migration-mpol/add-runtimeClassName/.kyverno-test/resource.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/.kyverno-test/resource.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: busybox
+  name: pod01
+  namespace: add-runtimeclassname
+spec:
+  automountServiceAccountToken: false
+  containers:
+  - name: busybox
+    image: somedummybusyboximage:1.1.0
+  - name: nginx
+    image: somedummynginximage:1.1.0

--- a/psp-migration-mpol/add-runtimeClassName/add-runtimeClassName.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/add-runtimeClassName.yaml
@@ -1,0 +1,32 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: MutatingPolicy
+metadata:
+  name: add-runtimeclassname
+  annotations:
+    policies.kyverno.io/title: Add runtimeClassName
+    policies.kyverno.io/category: PSP Migration
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.10.0
+    kyverno.io/kubernetes-version: "1.24"
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/description: >-
+      In the earlier Pod Security Policy controller, it was possible to configure a policy to add
+      a Pod's runtimeClassName. This was beneficial in that various container runtimes could be
+      specified according to a policy. This Kyverno policy mutates Pods to add a runtimeClassName
+      of `prodclass`.
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            spec: Object.spec{
+              runtimeClassName: "prodclass"
+            }
+          }

--- a/psp-migration-mpol/add-runtimeClassName/artifacthub-pkg.yml
+++ b/psp-migration-mpol/add-runtimeClassName/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: add-runtimeclassname
+version: 1.0.0
+displayName: Add runtimeClassName
+createdAt: "2023-05-22T00:00:00.000Z"
+description: >-
+  In the earlier Pod Security Policy controller, it was possible to configure a policy to add a Pod's runtimeClassName. This was beneficial in that various container runtimes could be specified according to a policy. This Kyverno policies mutates Pods to add a runtimeClassName of `prodclass`.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/psp-migration-mpol/add-runtimeClassName/add-runtimeClassName.yaml
+  ```
+keywords:
+  - kyverno
+  - PSP Migration
+readme: |
+  In the earlier Pod Security Policy controller, it was possible to configure a policy to add a Pod's runtimeClassName. This was beneficial in that various container runtimes could be specified according to a policy. This Kyverno policies mutates Pods to add a runtimeClassName of `prodclass`.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "PSP Migration"
+  kyverno/kubernetesVersion: "1.24"
+  kyverno/subject: "Pod"
+digest: 043d33822a1e157affe8db07640e1a15d9295f4c878c34e1426ff71f4a8537c2


### PR DESCRIPTION
## Related Issue(s)

https://github.com/kyverno/kyverno/issues/13709

## Description

This PR is the third patch to convert the traditional `ClusterPolicy` to the new v1alpha1 `MutatingPolicy`.
This here is 10 policies, and later patches will be 10 policies per PR.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
