### PR TITLE
Fix/restrict clusterrole nodesproxy

### DIFF
--- a/other-cel/restrict-clusterrole-nodesproxy/.kyverno-test/resource.yaml
+++ b/other-cel/restrict-clusterrole-nodesproxy/.kyverno-test/resource.yaml
@@ -48,3 +48,11 @@ metadata:
   name: default-rules
 rules: null
 ---
+# Ensure rules without 'resources' keyword are handled properly
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: no-resources
+rules:
+- nonResourceURLs: ["/test"]
+  verbs: ["get"]

--- a/other-cel/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other-cel/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -35,7 +35,8 @@ spec:
           expressions:
             - expression: >-
                 object.rules == null || 
-                !object.rules.exists(rule, 
+                !object.rules.exists(rule,
+                has(rule.resources) &&
                 rule.resources.exists(resource, resource == 'nodes/proxy') && 
                 rule.apiGroups.exists(apiGroup, apiGroup == ''))
               message: "A ClusterRole containing the nodes/proxy resource is not allowed."


### PR DESCRIPTION
## Related Issue(s)

didn't create one
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

<!--
What does this PR do?
-->

Allow `restrict-clusterrole-nodesproxy` policy to be used with rules that do not contains the `resources` keyword

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [ ] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
