### PR TITLE
feat: add new vpols that match subresources

### DIFF
--- a/other-vpol/advanced-restrict-image-registries/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/advanced-restrict-image-registries/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,13 @@ metadata:
   name: advanced-restrict-image-registries
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
  

--- a/other-vpol/allowed-annotations/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/allowed-annotations/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,14 @@ metadata:
   name: allowed-annotations
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
  
 

--- a/other-vpol/allowed-pod-priorities/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/allowed-pod-priorities/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,14 @@ metadata:
   name: allowed-podpriorities
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
  
 

--- a/other-vpol/block-cluster-admin-from-ns/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-cluster-admin-from-ns/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,13 @@ metadata:
   name: block-cluster-admin-from-ns
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
  

--- a/other-vpol/block-ephemeral-containers/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-ephemeral-containers/.chainsaw-test/policy-ready.yaml
@@ -4,12 +4,12 @@ metadata:
   name: block-ephemeral-containers
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - reason: Failed
-              status: "False"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - reason: Failed
+      status: "False"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
  

--- a/other-vpol/block-images-with-volumes/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-images-with-volumes/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,13 @@ metadata:
   name: block-images-with-volumes
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
  

--- a/other-vpol/block-kubectl-cp/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/block-kubectl-cp/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: block-kubectl-cp-by-pod-label
+spec:
+  steps:
+    - name: step-01
+      try:
+        - apply:
+            file: ../block-kubectl-cp.yaml
+        - assert:
+            file: policy-ready.yaml
+    - name: step-02
+      try:
+        - apply:
+            file: ns.yaml
+        - apply:
+            file: pods.yaml
+    - name: step-03
+      try:
+        - script:
+            content: if kubectl cp -n bkc-podlabel-ns pod01:/test1.txt ./test1.txt; then exit 1;else
+              exit 0; fi
+    - name: step-04
+      try:
+        - script:
+            content: rm -rf ./test1.txt

--- a/other-vpol/block-kubectl-cp/.chainsaw-test/ns.yaml
+++ b/other-vpol/block-kubectl-cp/.chainsaw-test/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bkc-podlabel-ns

--- a/other-vpol/block-kubectl-cp/.chainsaw-test/pods.yaml
+++ b/other-vpol/block-kubectl-cp/.chainsaw-test/pods.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod01
+  namespace: bkc-podlabel-ns
+spec:
+  containers:
+    - name: busybox
+      image: busybox:1.35
+      command: [ "/bin/sh", "-c" ]
+      args:
+        - touch /test1.txt
+        - sleep 300

--- a/other-vpol/block-kubectl-cp/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-kubectl-cp/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,15 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: block-kubectl-cp
+status:
+  conditionStatus:
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - reason: Failed
+      status: "False"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+ 

--- a/other-vpol/block-kubectl-cp/artifacthub-pkg.yml
+++ b/other-vpol/block-kubectl-cp/artifacthub-pkg.yml
@@ -1,0 +1,24 @@
+name: block-kubectl-cp
+version: 1.0.0
+displayName: Block "kubectl cp" by Pod Label in ValidatingPolicy
+description: >-
+  The `kubectl cp` command allows copying files between a local machine and a Pod's container, which may introduce security risks. This policy blocks the use of the `kubectl cp` command for Pods with the label `block-kubectl-cp=true`, preventing unauthorized data transfers.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other-vpol/block-kubectl-cp/block-kubectl-cp.yaml
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other-vpol/block-kubectl-cp/block-kubectl-cp.yaml
+keywords:
+  - kyverno
+  - kubectl
+  - other
+  - ValidatingPolicy
+readme: |
+  The kubectl cp command allows copying files between a local machine and a Pod's container, but it can be misused for unauthorized data transfers. 
+  This policy blocks the kubectl cp command for Pods labeled with block-kubectl-cp=true.
+annotations:
+  kyverno/category: "Sample"
+  kyverno/kubernetesVersion: "1.30"
+  kyverno/subject: "Pod"
+digest: 01a721b4a1ef2584aef21bcfbafa392ec3b6181054b331f11e570b146a0a9c6d
+createdAt: "2025-12-02T13:59:47Z"

--- a/other-vpol/block-kubectl-cp/block-kubectl-cp.yaml
+++ b/other-vpol/block-kubectl-cp/block-kubectl-cp.yaml
@@ -1,0 +1,34 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: block-kubectl-cp
+  annotations:
+    policies.kyverno.io/title: Block kubectl cp command by Pod Label
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.15.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The kubectl cp command is used to copy files between a local machine and a Pod's container. 
+      While this functionality is useful for transferring data, it may introduce security risks, 
+      such as unauthorized data exfiltration or modification. This policy blocks the use of the 
+      kubectl cp command on all Pods with label `block-kubectl-cp=true`, ensuring that sensitive 
+      workloads are protected from unintended file transfers. Other kubectl operations are unaffected, 
+      allowing for normal Pod management while preventing potential misuse of file copy capabilities.
+spec:
+  evaluation:
+    background:
+      enabled: true
+  validationActions: ["Deny"]
+  matchConstraints:
+    resourceRules:
+      - resources: ["pods/exec"]
+        operations: ["CONNECT"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+  validations:
+    - message: >
+        Cannot use `kubectl cp` on pods
+      expression: >
+        object.command.size() >= 2
+        && object.command[0] != "tar"
+        && object.command[1] != "cf"

--- a/other-vpol/block-large-images/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-large-images/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,13 @@ metadata:
   name: block-large-images
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
  

--- a/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: block-pod-exec-by-namespace
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../block-pod-exec-by-namespace.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: ns.yaml
+    - apply:
+        file: pods.yaml
+    - apply:
+        file: podcontrollers.yaml
+  - name: step-03
+    try:
+    - sleep:
+        duration: 5s
+  - name: step-04
+    try:
+    - script:
+        content: if kubectl exec -n pci pod02 -- ls; then exit 1;else exit 0; fi
+    - script:
+        content: if kubectl exec -n pci deploy/deployment01 -- ls; then exit 1;else
+          exit 0; fi
+    - script:
+        content: kubectl exec -n block-pod-exec-ns pod01 -- ls
+    - script:
+        content: kubectl exec -n block-pod-exec-ns deploy/deployment02 -- ls
+  - name: step-99
+    try:
+    - script:
+        content: kubectl delete deployments --all --force --grace-period=0 -n pci
+    - script:
+        content: kubectl delete deployments --all --force --grace-period=0 -n block-pod-exec-ns
+    - script:
+        content: kubectl delete pods --all --force --grace-period=0 -n pci
+    - script:
+        content: kubectl delete pods --all --force --grace-period=0 -n block-pod-exec-ns

--- a/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/ns.yaml
+++ b/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/ns.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: block-pod-exec-ns
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pci

--- a/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/podcontrollers.yaml
+++ b/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/podcontrollers.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: deployment01
+  namespace: pci
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: bb
+        image: busybox:1.35
+        command: ["sleep", "300"]
+      - name: bb2
+        image: busybox:1.35
+        command: ["sleep", "300"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: deployment02
+  namespace: block-pod-exec-ns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: bb
+        image: busybox:1.35
+        command: ["sleep", "300"]
+      - name: bb2
+        image: busybox:1.35
+        command: ["sleep", "300"]

--- a/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/pods.yaml
+++ b/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/pods.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod01
+  namespace: block-pod-exec-ns
+spec:
+  containers:
+  - name: busybox
+    image: busybox:1.35
+    command: ["sleep", "300"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod02
+  namespace: pci
+spec:
+  containers:
+  - name: busybox
+    image: busybox:1.35
+    command: ["sleep", "300"]
+  - name: busybox02
+    image: busybox:1.35
+    command: ["sleep", "300"]

--- a/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,15 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: deny-exec-by-namespace-name
+status:
+  conditionStatus:
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - reason: Failed
+      status: "False"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+ 

--- a/other-vpol/block-pod-exec-by-namespace/artifacthub-pkg.yml
+++ b/other-vpol/block-pod-exec-by-namespace/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: block-pod-exec-by-namespace
+version: 1.0.0
+displayName: Block Pod Exec by Namespace Name in ValidatingPolicy
+description: >-
+  The `exec` command may be used to gain shell access, or run other commands, in a Pod's container. While this can be useful for troubleshooting purposes, it could represent an attack vector and is discouraged. This policy blocks Pod exec commands to Pods in a Namespace called `pci`.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other-vpol/block-pod-exec-by-namespace/block-pod-exec-by-namespace.yaml
+  ```
+keywords:
+  - kyverno
+  - Sample
+  - ValidatingPolicy
+readme: |
+  The `exec` command may be used to gain shell access, or run other commands, in a Pod's container. While this can be useful for troubleshooting purposes, it could represent an attack vector and is discouraged. This policy blocks Pod exec commands to Pods in a Namespace called `pci`.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Sample"
+  kyverno/subject: "Pod"
+digest: 87239d5197cdad615045ecaa971112fce7b26f386474a7b766c084386f861488
+createdAt: "2025-12-02T13:59:47Z"

--- a/other-vpol/block-pod-exec-by-namespace/block-pod-exec-by-namespace.yaml
+++ b/other-vpol/block-pod-exec-by-namespace/block-pod-exec-by-namespace.yaml
@@ -1,0 +1,29 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: deny-exec-by-namespace-name
+  annotations:
+    policies.kyverno.io/title: Block Pod Exec by Namespace Name
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.15.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The `exec` command may be used to gain shell access, or run other commands, in a Pod's container. While this can
+      be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
+      This policy blocks Pod exec commands to Pods in a Namespace called `pci`.
+spec:
+  evaluation:
+    background:
+      enabled: true
+  validationActions: ["Deny"]
+  matchConstraints:
+    resourceRules:
+      - resources: ["pods/exec"]
+        operations: ["CONNECT"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+  validations:
+    - message: >
+        Pods in this namespace may not be exec'd into.
+      expression: >
+        request.namespace != "pci"

--- a/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: block-pod-exec-by-pod-label
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../block-pod-exec-by-pod-label.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: ns.yaml
+    - apply:
+        file: pods.yaml
+  - name: step-03
+    try:
+    - sleep:
+        duration: 5s
+  - name: step-04
+    try:
+    - script:
+        content: if kubectl exec -n bpe-podlabel-ns pod03 -- ls; then exit 1;else
+          exit 0; fi
+    - script:
+        content: kubectl exec -n bpe-podlabel-ns pod01 -- ls
+    - script:
+        content: kubectl exec -n bpe-podlabel-ns pod02 -- ls
+    - script:
+        content: kubectl exec -n bpe-podlabel-ns pod04 -- ls
+  - name: step-99
+    try:
+    - script:
+        content: kubectl delete all --all --force --grace-period=0 -n bpe-podlabel-ns

--- a/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/ns.yaml
+++ b/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bpe-podlabel-ns

--- a/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/pods.yaml
+++ b/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/pods.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod01
+  namespace: bpe-podlabel-ns
+spec:
+  containers:
+  - name: busybox
+    image: busybox:1.35
+    command: ["sleep", "300"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    foo: bar
+  name: pod02
+  namespace: bpe-podlabel-ns
+spec:
+  containers:
+  - name: busybox
+    image: busybox:1.35
+    command: ["sleep", "300"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    foo: bar
+    exec: "false"
+  name: pod03
+  namespace: bpe-podlabel-ns
+spec:
+  containers:
+  - name: busybox
+    image: busybox:1.35
+    command: ["sleep", "300"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    exec: "true"
+    foo: bar
+  name: pod04
+  namespace: bpe-podlabel-ns
+spec:
+  containers:
+  - name: busybox
+    image: busybox:1.35
+    command: ["sleep", "300"]

--- a/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,14 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: deny-exec-by-pod-label
+status:
+  conditionStatus:
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - reason: Failed
+      status: "False"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/block-pod-exec-by-pod-label/artifacthub-pkg.yml
+++ b/other-vpol/block-pod-exec-by-pod-label/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: block-pod-exec-by-pod-label
+version: 1.0.0
+displayName: Block Pod Exec by Pod Label in ValidatingPolicy
+description: >-
+  The `exec` command may be used to gain shell access, or run other commands, in a Pod's container. While this can be useful for troubleshooting purposes, it could represent an attack vector and is discouraged. This policy blocks Pod exec commands to Pods having the label `exec=false`.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other-vpol/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.yaml
+  ```
+keywords:
+  - kyverno
+  - Sample
+  - ValidatingPolicy
+readme: |
+  The `exec` command may be used to gain shell access, or run other commands, in a Pod's container. While this can be useful for troubleshooting purposes, it could represent an attack vector and is discouraged. This policy blocks Pod exec commands to Pods having the label `exec=false`.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Sample"
+  kyverno/subject: "Pod"
+digest: 6a600b7b9ddb201b36a4911443642fa0c4158499678c17d08bf285695a3c42b7
+createdAt: "2025-12-02T13:59:46Z"

--- a/other-vpol/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.yaml
+++ b/other-vpol/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.yaml
@@ -1,0 +1,32 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: deny-exec-by-pod-label
+  annotations:
+    policies.kyverno.io/title: Block Pod Exec by Pod Label
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.15.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The `exec` command may be used to gain shell access, or run other commands, in a Pod's container. While this can
+      be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
+      This policy blocks Pod exec commands to Pods having the label `exec=false`.
+spec:
+  evaluation:
+    background:
+      enabled: true
+  validationActions: ["Deny"]
+  matchConstraints:
+    resourceRules:
+      - resources: ["pods/exec"]
+        operations: ["CONNECT"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+  variables:
+    - name: pod
+      expression: resource.Get("v1", "pods", request.namespace, request.name)
+  validations:
+    - message: >
+        Pods in this namespace may not be exec'd into.
+      expression: >
+        variables.pod.metadata.?labels[?'exec'].orValue('') != 'false'

--- a/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: block-pod-exec-by-pod-name
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../block-pod-exec-by-pod-name.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: namespace.yaml
+    - apply:
+        file: pod-1.yaml
+    - apply:
+        file: pod-2.yaml
+    - apply:
+        file: pod-3.yaml
+  - name: step-03
+    try:
+    - sleep:
+        duration: 5s
+  - name: step-04
+    try:
+    - script:
+        content: if kubectl exec -n bpe-podname-ns myapp-maintenance-01 -- ls; then
+          exit 1;else exit 0; fi
+    - script:
+        content: if kubectl exec -n bpe-podname-ns myapp-maintenance-02 -- ls; then
+          exit 1;else exit 0; fi
+    - script:
+        content: kubectl exec -n bpe-podname-ns not-myapp -- ls
+  - name: step-99
+    try:
+    - script:
+        content: kubectl delete all --all --force --grace-period=0 -n bpe-podname-ns

--- a/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/namespace.yaml
+++ b/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bpe-podname-ns

--- a/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/pod-1.yaml
+++ b/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/pod-1.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-maintenance-01
+  namespace: bpe-podname-ns
+spec:
+  containers:
+  - command:
+    - sleep
+    - "300"
+    image: busybox:1.35
+    name: busybox
+  - command:
+    - sleep
+    - "300"
+    image: busybox:1.35
+    name: busybox02

--- a/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/pod-2.yaml
+++ b/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/pod-2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-maintenance-02
+  namespace: bpe-podname-ns
+spec:
+  containers:
+  - command:
+    - sleep
+    - "300"
+    image: busybox:1.35
+    name: busybox

--- a/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/pod-3.yaml
+++ b/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/pod-3.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: not-myapp
+  namespace: bpe-podname-ns
+spec:
+  containers:
+  - command:
+    - sleep
+    - "300"
+    image: busybox:1.35
+    name: busybox
+  - command:
+    - sleep
+    - "300"
+    image: busybox:1.35
+    name: busybox02

--- a/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,15 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: deny-exec-by-pod-name
+status:
+  conditionStatus:
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - reason: Failed
+      status: "False"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
+ 

--- a/other-vpol/block-pod-exec-by-pod-name/artifacthub-pkg.yml
+++ b/other-vpol/block-pod-exec-by-pod-name/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: block-pod-exec-by-pod-name
+version: 1.0.0
+displayName: Block Pod Exec by Pod Name in ValidatingPolicy
+description: >-
+  The `exec` command may be used to gain shell access, or run other commands, in a Pod's container. While this can be useful for troubleshooting purposes, it could represent an attack vector and is discouraged. This policy blocks Pod exec commands to Pods beginning with the name `myapp-maintenance-`.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other-vpol/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.yaml
+  ```
+keywords:
+  - kyverno
+  - Sample
+  - ValidatingPolicy
+readme: |
+  The `exec` command may be used to gain shell access, or run other commands, in a Pod's container. While this can be useful for troubleshooting purposes, it could represent an attack vector and is discouraged. This policy blocks Pod exec commands to Pods beginning with the name `myapp-maintenance-`.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Sample"
+  kyverno/subject: "Pod"
+digest: e4648f22588be1ffb8b9c966956f4000ef39307a469ec65161a167c7afb6d463
+createdAt: "2025-12-02T13:59:47Z"

--- a/other-vpol/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.yaml
+++ b/other-vpol/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.yaml
@@ -1,0 +1,30 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: deny-exec-by-pod-name
+  annotations:
+    policies.kyverno.io/title: Block Pod Exec by Pod Name
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/minversion: 1.15.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      The `exec` command may be used to gain shell access, or run other commands, in a Pod's container. While this can
+      be useful for troubleshooting purposes, it could represent an attack vector and is discouraged.
+      This policy blocks Pod exec commands to Pods beginning with the name
+      `myapp-maintenance-`.
+spec:
+  evaluation:
+    background:
+      enabled: true
+  validationActions: ["Deny"]
+  matchConstraints:
+    resourceRules:
+      - resources: ["pods/exec"]
+        operations: ["CONNECT"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+  validations:
+    - message: >
+        Exec'ing into Pods called "myapp-maintenance" is not allowed.
+      expression: >
+        !request.name.startsWith("myapp-maintenance-")

--- a/other-vpol/check-env-vars/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-env-vars/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,14 @@ metadata:
   name: check-env-vars
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
  
 

--- a/other-vpol/check-serviceaccount-secrets/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-serviceaccount-secrets/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,14 @@ metadata:
   name: check-serviceaccount-secrets
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
  
 

--- a/other-vpol/deny-commands-in-exec-probe/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/deny-commands-in-exec-probe/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,13 @@ metadata:
   name: deny-commands-in-exec-probe
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
  

--- a/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/policy-ready.yaml
@@ -3,13 +3,13 @@ kind: ValidatingPolicy
 metadata:
   name: deny-secret-service-account-token-type
 status:
-    conditionStatus:
-      conditions:
-      - reason: Succeeded
-        status: "True"
-        type: WebhookConfigured
-      - reason: Failed
-        status: "False"
-        type: RBACPermissionsGranted
-      
+  conditionStatus:
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - reason: Failed
+      status: "False"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured   
     

--- a/other-vpol/disallow-all-secrets/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/disallow-all-secrets/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: no-secrets
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/disallow-localhost-services/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/disallow-localhost-services/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: no-localhost-service
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/disallow-secrets-from-env-vars/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/disallow-secrets-from-env-vars/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: secrets-not-from-env-vars
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/docker-socket-requires-label/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/docker-socket-requires-label/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: docker-socket-check
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/enforce-pod-duration/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/enforce-pod-duration/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: pod-lifetime
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/ensure-probes-different/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/ensure-probes-different/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: validate-probes
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/ensure-readonly-hostpath/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/ensure-readonly-hostpath/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: ensure-readonly-hostpath
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/exclude-namespaces-dynamically/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/exclude-namespaces-dynamically/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,12 @@ metadata:
   name: exclude-namespaces-example
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/forbid-cpu-limits/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/forbid-cpu-limits/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: forbid-cpu-limits
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/imagepullpolicy-always/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/imagepullpolicy-always/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: imagepullpolicy-always
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/ingress-host-match-tls/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/ingress-host-match-tls/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: ingress-host-match-tls
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/limit-containers-per-pod/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/limit-containers-per-pod/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: limit-containers-per-pod
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/limit-hostpath-type-pv/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/limit-hostpath-type-pv/.chainsaw-test/policy-ready.yaml
@@ -4,10 +4,11 @@ metadata:
   name: limit-hostpath-type-pv
 status:
   conditionStatus:
-    conditions:
-    - reason: Succeeded
-      type: WebhookConfigured
-      status: "True"
+    (conditions[?type == 'RBACPermissionsGranted']):
     - reason: Failed
       status: "False"
-      type: RBACPermissionsGranted
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/limit-hostpath-vols/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/limit-hostpath-vols/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,12 @@ metadata:
   name: limit-hostpath-vols
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/memory-requests-equal-limits/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/memory-requests-equal-limits/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: memory-requests-equal-limits
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/metadata-match-regex/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/metadata-match-regex/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: metadata-match-regex
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/pdb-maxunavailable/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/pdb-maxunavailable/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,13 @@ metadata:
   name: pdb-maxunavailable
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
 

--- a/other-vpol/prevent-bare-pods/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/prevent-bare-pods/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: prevent-bare-pods
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/prevent-cr8escape/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/prevent-cr8escape/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,12 @@ metadata:
   name: prevent-cr8escape
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/require-annotations/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-annotations/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: require-annotations
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/require-container-port-names/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-container-port-names/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,12 @@ metadata:
   name: require-container-port-names
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/require-deployments-have-multiple-replicas/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-deployments-have-multiple-replicas/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: deployment-has-multiple-replicas
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/require-emptydir-requests-limits/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-emptydir-requests-limits/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,12 @@ metadata:
   name: require-emptydir-requests-and-limits
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/require-image-checksum/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-image-checksum/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: require-image-checksum
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/require-ingress-https/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-ingress-https/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: require-ingress-https
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/require-non-root-groups/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-non-root-groups/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,12 @@ metadata:
   name: require-non-root-groups
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/require-pod-priorityclassname/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-pod-priorityclassname/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,12 @@ metadata:
   name: require-pod-priorityclassname
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/require-qos-burstable/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-qos-burstable/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: require-qos-burstable
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/require-qos-guaranteed/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-qos-guaranteed/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,12 @@ metadata:
   name: require-qos-guaranteed
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/require-storageclass/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-storageclass/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: require-storageclass
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-annotations/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-annotations/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: restrict-annotations
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-binding-clusteradmin/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-binding-clusteradmin/.chainsaw-test/policy-ready.yaml
@@ -4,10 +4,11 @@ metadata:
   name: restrict-binding-clusteradmin
 status:
   conditionStatus:
-    conditions:
-    - reason: Succeeded
-      type: WebhookConfigured
-      status: "True"
+    (conditions[?type == 'RBACPermissionsGranted']):
     - reason: Failed
       status: "False"
-      type: RBACPermissionsGranted
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-binding-system-groups/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-binding-system-groups/.chainsaw-test/policy-ready.yaml
@@ -4,10 +4,11 @@ metadata:
   name: restrict-binding-system-groups
 status:
   conditionStatus:
-    conditions:
-    - reason: Succeeded
-      type: WebhookConfigured
-      status: "True"
+    (conditions[?type == 'RBACPermissionsGranted']):
     - reason: Failed
       status: "False"
-      type: RBACPermissionsGranted
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/policy-ready.yaml
@@ -4,11 +4,11 @@ metadata:
   name: restrict-clusterrole-nodesproxy
 status:
   conditionStatus:
-    conditions:
-    - reason: Succeeded
-      type: WebhookConfigured
-      status: "True"
+    (conditions[?type == 'RBACPermissionsGranted']):
     - reason: Failed
       status: "False"
-      type: RBACPermissionsGranted
-
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-controlplane-scheduling/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-controlplane-scheduling/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: restrict-controlplane-scheduling
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-deprecated-registry/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-deprecated-registry/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: restrict-deprecated-registry
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-escalation-verbs-roles/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-escalation-verbs-roles/.chainsaw-test/policy-ready.yaml
@@ -4,11 +4,11 @@ metadata:
   name: restrict-escalation-verbs-roles
 status:
   conditionStatus:
-    conditions:
-    - reason: Succeeded
-      type: WebhookConfigured
-      status: "True"
+    (conditions[?type == 'RBACPermissionsGranted']):
     - reason: Failed
       status: "False"
-      type: RBACPermissionsGranted
-
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-ingress-classes/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-ingress-classes/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: restrict-ingress-classes
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-ingress-defaultbackend/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-ingress-defaultbackend/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: restrict-ingress-defaultbackend
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-ingress-wildcard/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-ingress-wildcard/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: restrict-ingress-wildcard
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-jobs/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-jobs/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,13 @@ metadata:
   name: restrict-jobs
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured
  

--- a/other-vpol/restrict-loadbalancer/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-loadbalancer/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: no-loadbalancer-service
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-networkpolicy-empty-podselector/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-networkpolicy-empty-podselector/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: restrict-networkpolicy-empty-podselector
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-node-affinity/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-node-affinity/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: restrict-node-affinity
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-node-label-creation/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-node-label-creation/.chainsaw-test/policy-ready.yaml
@@ -4,12 +4,11 @@ metadata:
   name: restrict-node-label-creation
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - reason: Failed
-              status: "False"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - reason: Failed
+      status: "False"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-pod-controller-serviceaccount-updates/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-pod-controller-serviceaccount-updates/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,12 @@ metadata:
   name: restrict-pod-controller-serviceaccount-updates
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-sa-automount-sa-token/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-sa-automount-sa-token/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: restrict-sa-automount-sa-token
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-secret-role-verbs/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-secret-role-verbs/.chainsaw-test/policy-ready.yaml
@@ -4,11 +4,11 @@ metadata:
   name: restrict-secret-role-verbs
 status:
   conditionStatus:
-    conditions:
-    - reason: Succeeded
-      type: WebhookConfigured
-      status: "True"
+    (conditions[?type == 'RBACPermissionsGranted']):
     - reason: Failed
       status: "False"
-      type: RBACPermissionsGranted
-
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-secrets-by-name/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-secrets-by-name/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: restrict-secrets-by-name
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-service-port-range/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-service-port-range/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: restrict-service-port-range
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-storageclass/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-storageclass/.chainsaw-test/policy-ready.yaml
@@ -4,10 +4,11 @@ metadata:
   name: restrict-storageclass
 status:
   conditionStatus:
-    conditions:
-    - reason: Succeeded
-      type: WebhookConfigured
-      status: "True"
+    (conditions[?type == 'RBACPermissionsGranted']):
     - reason: Failed
       status: "False"
-      type: RBACPermissionsGranted
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-usergroup-fsgroup-id/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-usergroup-fsgroup-id/.chainsaw-test/policy-ready.yaml
@@ -4,14 +4,12 @@ metadata:
   name: validate-userid-groupid-fsgroup
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
-
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-wildcard-resources/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-wildcard-resources/.chainsaw-test/policy-ready.yaml
@@ -4,11 +4,11 @@ metadata:
   name: restrict-wildcard-resources
 status:
   conditionStatus:
-    conditions:
-    - reason: Succeeded
-      type: WebhookConfigured
-      status: "True"
+    (conditions[?type == 'RBACPermissionsGranted']):
     - reason: Failed
       status: "False"
-      type: RBACPermissionsGranted
-
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/restrict-wildcard-verbs/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-wildcard-verbs/.chainsaw-test/policy-ready.yaml
@@ -3,13 +3,12 @@ kind: ValidatingPolicy
 metadata:
   name: restrict-wildcard-verbs
 status:
-    conditionStatus:
-      conditions:
-      - reason: Succeeded
-        status: "True"
-        type: WebhookConfigured
-      - reason: Failed
-        status: "False"
-        type: RBACPermissionsGranted
-      
-    
+  conditionStatus:
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - reason: Failed
+      status: "False"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/topologyspreadconstraints-policy/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/topologyspreadconstraints-policy/.chainsaw-test/policy-ready.yaml
@@ -4,13 +4,12 @@ metadata:
   name: topologyspreadconstraints-policy
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-vpol/unique-ingress-paths/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other-vpol/unique-ingress-paths/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -4,13 +4,12 @@ metadata:
   name:  unique-ingress-path
 status:
   conditionStatus:
-            (conditions[?type == 'RBACPermissionsGranted']):
-            - message: Policy is ready for reporting.
-              reason: Succeeded
-              status: "True"
-            (conditions[?type == 'WebhookConfigured']):
-            - message: Webhook configured.
-              reason: Succeeded
-              status: "True"
-              type: WebhookConfigured
- 
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured


### PR DESCRIPTION
## Related Issue(s)
N/A
<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description
This PR adds new ValidatingPolicies that match subresources. The following policies are added:
1. block-kubectl-cp
2. deny-exec-by-pod-label
3. deny-exec-by-pod-name
4. deny-exec-by-namespace-name

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
