### PR TITLE
fix!: memory-backed emptyDirs skip storage reqs

### DIFF
--- a/other/require-emptydir-requests-limits/.chainsaw-test/bad-pod.yaml
+++ b/other/require-emptydir-requests-limits/.chainsaw-test/bad-pod.yaml
@@ -42,7 +42,7 @@ spec:
     emptyDir: {}
   - name: foo
     emptyDir:
-      sizeLimit: 200Mi
+      medium: Memory
   - name: foo-host
     hostPath:
       path: /var/foo

--- a/other/require-emptydir-requests-limits/.chainsaw-test/pod-bad.yaml
+++ b/other/require-emptydir-requests-limits/.chainsaw-test/pod-bad.yaml
@@ -54,7 +54,7 @@ spec:
   volumes:
     - name: vol
       emptyDir:
-        sizeLimit: 200Mi
+        medium: Memory
     - name: foo
       emptyDir: {}
 ---
@@ -100,7 +100,7 @@ spec:
       emptyDir: {}
     - name: foo
       emptyDir:
-        sizeLimit: 200Mi
+        medium: Memory
 ---
 apiVersion: v1
 kind: Pod

--- a/other/require-emptydir-requests-limits/.chainsaw-test/pod-good.yaml
+++ b/other/require-emptydir-requests-limits/.chainsaw-test/pod-good.yaml
@@ -41,7 +41,7 @@ spec:
   volumes:
     - name: vol
       emptyDir:
-        sizeLimit: 200Mi
+        medium: Memory
 ---
 apiVersion: v1
 kind: Pod
@@ -85,7 +85,7 @@ spec:
       emptyDir: {}
     - name: foo
       emptyDir:
-        sizeLimit: 200Mi
+        medium: Memory
 ---
 apiVersion: v1
 kind: Pod
@@ -113,7 +113,7 @@ spec:
       emptyDir: {}
     - name: foo
       emptyDir:
-        sizeLimit: 200Mi
+        medium: Memory
 ---
 apiVersion: v1
 kind: Pod

--- a/other/require-emptydir-requests-limits/.chainsaw-test/podcontroller-bad.yaml
+++ b/other/require-emptydir-requests-limits/.chainsaw-test/podcontroller-bad.yaml
@@ -47,7 +47,7 @@ spec:
         emptyDir: {}
       - name: foo
         emptyDir:
-          sizeLimit: 200Mi
+          medium: Memory
       - name: foo-host
         hostPath:
           path: /var/foo
@@ -97,7 +97,7 @@ spec:
             emptyDir: {}
           - name: foo
             emptyDir:
-              sizeLimit: 200Mi
+              medium: Memory
           - name: foo-host
             hostPath:
               path: /var/foo

--- a/other/require-emptydir-requests-limits/.chainsaw-test/podcontroller-good.yaml
+++ b/other/require-emptydir-requests-limits/.chainsaw-test/podcontroller-good.yaml
@@ -52,7 +52,7 @@ spec:
         emptyDir: {}
       - name: foo
         emptyDir:
-          sizeLimit: 200Mi
+          medium: Memory
       - name: foo-host
         hostPath:
           path: /var/foo
@@ -104,7 +104,7 @@ spec:
             emptyDir: {}
           - name: foo
             emptyDir:
-              sizeLimit: 200Mi
+              medium: Memory
           - name: foo-host
             hostPath:
               path: /var/foo

--- a/other/require-emptydir-requests-limits/.kyverno-test/resource-skip.yaml
+++ b/other/require-emptydir-requests-limits/.kyverno-test/resource-skip.yaml
@@ -14,4 +14,4 @@ spec:
   volumes:
     - name: vol
       emptyDir:
-        sizeLimit: 1Gi
+        medium: Memory

--- a/other/require-emptydir-requests-limits/artifacthub-pkg.yml
+++ b/other/require-emptydir-requests-limits/artifacthub-pkg.yml
@@ -1,9 +1,9 @@
 name: require-emptydir-requests-limits
-version: 1.0.0
+version: 2.0.0
 displayName: Require Requests and Limits for emptyDir
 createdAt: "2023-04-10T20:30:05.000Z"
 description: >-
-  Pods which mount emptyDir volumes may be allowed to potentially overrun the medium backing the emptyDir volume. This sample ensures that any initContainers or containers mounting an emptyDir volume have ephemeral-storage requests and limits set. Policy will be skipped if the volume has already a sizeLimit set.
+  Pods which mount emptyDir volumes may be allowed to potentially overrun the medium backing the emptyDir volume. This sample ensures that any initContainers or containers mounting an emptyDir volume have ephemeral-storage requests and limits set. Policy will be skipped if the volume is memory-backed.
 install: |-
   ```shell
   kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/require-emptydir-requests-limits/require-emptydir-requests-limits.yaml
@@ -12,11 +12,11 @@ keywords:
   - kyverno
   - Other
 readme: |
-  Pods which mount emptyDir volumes may be allowed to potentially overrun the medium backing the emptyDir volume. This sample ensures that any initContainers or containers mounting an emptyDir volume have ephemeral-storage requests and limits set. Policy will be skipped if the volume has already a sizeLimit set.
+  Pods which mount emptyDir volumes may be allowed to potentially overrun the medium backing the emptyDir volume. This sample ensures that any initContainers or containers mounting an emptyDir volume have ephemeral-storage requests and limits set. Policy will be skipped if the volume is memory-backed.
   
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.27"
   kyverno/subject: "Pod"
-digest: a8af8eb42f821df85d7f51626642056fc846281435926701184fe7d40f4fe497
+digest: 9794ed8e584a0b64b8db3fbf83f6f16bfc9235c367c08d69c6c33c12ab1fd3cb

--- a/other/require-emptydir-requests-limits/require-emptydir-requests-limits.yaml
+++ b/other/require-emptydir-requests-limits/require-emptydir-requests-limits.yaml
@@ -15,7 +15,7 @@ metadata:
       the medium backing the emptyDir volume. This sample ensures that any
       initContainers or containers mounting an emptyDir volume have
       ephemeral-storage requests and limits set. Policy will be skipped if
-      the volume has already a sizeLimit set.
+      the volume is memory-backed.
 spec:
   background: false
   validationFailureAction: Audit
@@ -29,7 +29,7 @@ spec:
       context:
       - name: emptydirnames
         variable:
-          jmesPath: request.object.spec.volumes[?contains(keys(@), 'emptyDir') && !contains(keys(emptyDir), 'sizeLimit')].name
+          jmesPath: request.object.spec.volumes[?contains(keys(@), 'emptyDir') && (emptyDir.medium == '' || emptyDir.medium == `null`)].name
       preconditions:
         all:
           - key: "{{ request.object.spec.volumes[?contains(keys(@), 'emptyDir')] || `[]` | length(@) }}"


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

Closes https://github.com/kyverno/policies/issues/1365.

## Description

<!--
What does this PR do?
-->

_Require Requests and Limits for emptyDir_ policy enforces ephemeral-storage requests and limits on emptyDir volumes even if they are memory-backed. This PR addresses this by making an exception for memory-backed volumes.

The previous exception for emptyDir volumes with `sizeLimit` set is removed, because `sizeLimit` does not replace the `limits` mechanics, only complements it.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
