### PR TITLE
fix restrict node label test for validating policy

### DIFF
--- a/other-vpol/restrict-node-label-creation/artifacthub-pkg.yml
+++ b/other-vpol/restrict-node-label-creation/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Node, Label"
-digest: ffd972b2c46df31a9d600c82474576284ac991b409993600d8d2e1ea37be9f8a
+digest: 0e5ded13f1a7b95646ee51df4f38f7b6657dd315b9183ba87d3297ca890b2d5d
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-node-label-creation/restrict-node-label-creation.yaml
+++ b/other-vpol/restrict-node-label-creation/restrict-node-label-creation.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restrict-node-label-creation
   annotations:
     policies.kyverno.io/title: Restrict node label creation in ValidatingPolicy
-    policies.kyverno.io/category: Sample in Vpol 
+    policies.kyverno.io/category: Sample in Vpol
     policies.kyverno.io/subject: Node, Label
     kyverno.io/kyverno-version: 1.12.1
     kyverno.io/kubernetes-version: "1.30"
@@ -28,12 +28,11 @@ spec:
         apiVersions: ["v1"]
         operations:  ["CREATE", "UPDATE"]
         resources:   ["nodes"]
-  matchConditions: 
+  matchConditions:
     - name: "operation-should-be-update"
       expression: "request.operation == 'UPDATE'"
     - name: "has-foo-label"
-      expression: "object.metadata.?labels.?foo.hasValue()"
+      expression: "oldObject.metadata.?labels.?foo != object.metadata.?labels.?foo"
   validations:
     - expression: "false"
       message: "Setting the `foo` label on a Node is not allowed."
-


### PR DESCRIPTION
## Description

The restrict node label test will fail even if the node previously had the `foo` label even it wasn't added in the current admission request. A previous PR fixed this issue for the cluster policy test. This PR extends the fix for validating policy as well

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
