### PR TITLE
Introducing JFrog policy allowing JFrog customers to check verified e…

### DIFF
--- a/jfrog/jfrog-evidence-check/artifacthub-pkg.yml
+++ b/jfrog/jfrog-evidence-check/artifacthub-pkg.yml
@@ -1,0 +1,33 @@
+---
+name: jfrog-evidence-check
+version: 1.0.0
+displayName: Require JFrog Evidence on Image
+createdAt: "2026-01-19T00:00:00.000Z" 
+description: >-
+# This policy checks for verified evidence on the JFrog platform for the pod images allowing for automation of complaince controls checks (i.e. SOC2, ISO 27001, etc.).
+      The policy uses Kyverno's apiCall feature to search for evidence in the JFrog GraphQL API.
+      When specific Verified Evidence Types are found on JFrog platform linked to the pod images the verification passes. 
+      this example checks specifically for SonarQube evidence
+      Prerequisite: Kubernetes docker-registry secret called `jfrog-secret` with a JFrog token added to the kyverno deployment:
+      --set "admissionController.container.extraArgs={--imagePullSecrets=jfrog-secret,--webhookTimeout=<seconds>}"
+install: |- 
+    ```shell
+    kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/jfrog/jfrog-evidence-check/jfrog-evidence-check.yaml
+    ```   
+keywords: 
+  - jfrog
+  - kyverno
+readme: | 
+  This policy checks for verified evidence on the JFrog platform for the pod images allowing for automation of complaince controls checks (i.e. SOC2, ISO 27001, etc.).
+      The policy uses Kyverno's apiCall feature to search for evidence in the JFrog GraphQL API.
+      When specific Verified Evidence Types are found on JFrog platform linked to the pod images the verification passes. 
+      this example checks specifically for SonarQube evidence
+      Prerequisite: Kubernetes docker-registry secret called `jfrog-secret` with a JFrog token added to the kyverno deployment:
+      --set "admissionController.container.extraArgs={--imagePullSecrets=jfrog-secret,--webhookTimeout=<seconds>}"
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations: # See the annotations guide on Artifact Hub here: https://artifacthub.io/docs/topics/annotations/kyverno/
+  kyverno/category: "JFrog"
+  kyverno/kubernetesVersion: "1.33"
+  kyverno/subject: "Pod"
+digest: 5f9d09e110d851c5151deaeaabb3b2dc17fca4f7f3b0da1a8c35e48644bddcf4  

--- a/jfrog/jfrog-evidence-check/jfrog-evidence-check.yaml
+++ b/jfrog/jfrog-evidence-check/jfrog-evidence-check.yaml
@@ -1,0 +1,93 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: jfrog-evidence-check
+  annotations:
+    policies.kyverno.io/title: Require JFrog Evidence on Image
+    policies.kyverno.io/category: JFrog
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.8.0
+    kyverno.io/kubernetes-version: ">=1.33"
+    policies.kyverno.io/description: >-
+      This policy checks for verified evidence on the JFrog platform for the pod images allowing for automation of complaince controls checks (i.e. SOC2, ISO 27001, etc.).
+      The policy uses Kyverno's apiCall feature to search for evidence in the JFrog GraphQL API.
+      When specific Verified Evidence Types are found on JFrog platform linked to the pod images the verification passes. this example checks specifically for Sonar evidence
+      Prerequisite: Kubernetes docker-registry secret called `jfrog-secret` with a JFrog token added to the kyverno deployment, --set "admissionController.container.extraArgs={--imagePullSecrets=jfrog-secret,--webhookTimeout=<seconds>}"
+spec:
+  background: true
+  admission: true
+  applyRules: All
+  webhookConfiguration:
+      timeoutSeconds: 20
+  rules:
+  - name: evidence-must-exist-on-image
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          operations:
+          - CREATE
+          - UPDATE
+          namespaces:
+          - "*"
+    validate:
+      allowExistingViolations: false
+      failureAction: Audit   
+      message: "Pod {{request.object.metadata.name}}: Missing verified sonar evidence for one or more container images."
+      foreach:
+        - list: request.object.spec.containers[]
+          context:
+            - name: imageData
+              imageRegistry: 
+                reference: "{{element.image}}"
+            - name: registryHost
+              variable:
+                jmesPath: "imageData.registry"
+            - name: repositoryKey
+              variable:
+                jmesPath: "imageData.repository | split(@, '/') | [0]"
+            - name: image_Path
+              variable:
+                jmesPath: "imageData.repository | split(@, '/') | [1:] | join('/', @)"
+            - name: imageTag
+              variable:
+                jmesPath: "imageData.identifier"
+            - name: imageDigest
+              variable:
+                jmesPath: "imageData.resolvedImage  | split(@, '@') | [1] | split(@, ':') | [1]"
+            - name: jfrogSecret
+              apiCall:
+                jmesPath: "data.\".dockerconfigjson\"|base64_decode(@)| parse_json(@).auths.\"{{registryHost}}\".password"
+                urlPath: "/api/v1/namespaces/kyverno/secrets/jfrog-secret"                    
+            - name: sonarEvidence
+              apiCall:
+                method: POST
+                jmesPath: "data.evidence.searchEvidence.edges[?node.predicateType == 'https://sonar.com/evidence/sonarqube/v1']"
+                service:
+                  url: "https://{{registryHost}}/onemodel/api/v1/graphql"          
+                  headers:
+                    - key: "Content-Type"
+                      value: "application/json"
+                    - key: "Accept"
+                      value: "application/json"
+                    - key: "Authorization"
+                      value: "Bearer {{jfrogSecret}}"
+                data:
+                  - key: query
+                    value: "{ evidence { searchEvidence(where: { hasSubjectWith: { repositoryKey: \"{{repositoryKey}}\", path: \"{{image_Path}}/{{imageTag}}\", sha256: \"{{imageDigest}}\" } }) { edges { node { downloadPath path name sha256 subject { repositoryKey path name } predicateType predicate createdBy createdAt verified } } } }}"             
+          deny:
+            conditions:
+              any:
+              - key: "{{sonarEvidence}}"
+                operator: AnyNotIn
+                value: ["*"]
+                message: "Pod {{request.object.metadata.name}}: Missing verified sonar evidence for container '{{element.name}}' with image '{{element.image}}'."
+              - key: "{{sonarEvidence | length(@)}}"
+                operator: Equals
+                value: 0
+              - key: "{{sonarEvidence[0].node.verified}}"
+                operator: NotEquals
+                value: true
+          


### PR DESCRIPTION
…vidence from specific predicate types are attached to their images

## Related Issue(s)
NA, this is a proactive enhancement for a new validating admission policy, not related to an existing issue 

## Description
This PR adds an example for Kyverno-JFrog customers of how to check that specific evidence types exist for pod's images. Evidence are checked for type and signing against the image JFrog platform. 

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.

Test manifests were not added because testing this policy requires a JFrog platform with an image with/out evidence. 