### PR TITLE
chore(kyverno): migrate policies from v1alpha1 to v1 across security rules

### DIFF
--- a/best-practices-gpol/add-network-policy/.chainsaw-test/policy-ready.yaml
+++ b/best-practices-gpol/add-network-policy/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-networkpolicy

--- a/best-practices-gpol/add-network-policy/add-network-policy.yaml
+++ b/best-practices-gpol/add-network-policy/add-network-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-networkpolicy

--- a/best-practices-gpol/add-ns-quota/.chainsaw-test/policy-ready.yaml
+++ b/best-practices-gpol/add-ns-quota/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-ns-quota

--- a/best-practices-gpol/add-ns-quota/add-ns-quota.yaml
+++ b/best-practices-gpol/add-ns-quota/add-ns-quota.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-ns-quota

--- a/best-practices-gpol/add-rolebinding/.chainsaw-test/policy-ready.yaml
+++ b/best-practices-gpol/add-rolebinding/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-rolebinding

--- a/best-practices-gpol/add-rolebinding/add-rolebinding.yaml
+++ b/best-practices-gpol/add-rolebinding/add-rolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-rolebinding

--- a/best-practices-mpol/add-safe-to-evict/.chainsaw-test/policy-ready.yaml
+++ b/best-practices-mpol/add-safe-to-evict/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-safe-to-evict

--- a/best-practices-mpol/add-safe-to-evict/add-safe-to-evict.yaml
+++ b/best-practices-mpol/add-safe-to-evict/add-safe-to-evict.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-safe-to-evict

--- a/castai-mpol/add-castai-removal-disabled/.chainsaw-test/policy-ready.yaml
+++ b/castai-mpol/add-castai-removal-disabled/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-castai-removal-disabled

--- a/castai-mpol/add-castai-removal-disabled/add-castai-removal-disabled.yaml
+++ b/castai-mpol/add-castai-removal-disabled/add-castai-removal-disabled.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-castai-removal-disabled

--- a/cleanup-dpol/cleanup-bare-pods/.chainsaw-test/chainsaw-step-02-assert-1.yaml
+++ b/cleanup-dpol/cleanup-bare-pods/.chainsaw-test/chainsaw-step-02-assert-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: DeletingPolicy
 metadata:
   name: clean-bare-pods

--- a/cleanup-dpol/cleanup-bare-pods/.chainsaw-test/chainsaw-test.yaml
+++ b/cleanup-dpol/cleanup-bare-pods/.chainsaw-test/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
             file: ../cleanup-bare-pods.yaml
         - patch:
             resource:
-              apiVersion: policies.kyverno.io/v1alpha1
+              apiVersion: policies.kyverno.io/v1
               kind: DeletingPolicy
               metadata:
                 name: clean-bare-pods

--- a/cleanup-dpol/cleanup-bare-pods/cleanup-bare-pods.yaml
+++ b/cleanup-dpol/cleanup-bare-pods/cleanup-bare-pods.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: DeletingPolicy
 metadata:
   name: clean-bare-pods

--- a/cleanup-dpol/cleanup-empty-replicasets/cleanup-empty-replicasets.yaml
+++ b/cleanup-dpol/cleanup-empty-replicasets/cleanup-empty-replicasets.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: DeletingPolicy
 metadata:
   name: cleanup-empty-replicasets

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/policy-ready.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ambient-mode-namespace

--- a/istio-mpol/add-ambient-mode-namespace/add-ambient-mode-namespace.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/add-ambient-mode-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ambient-mode-namespace

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/policy-ready.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-sidecar-injection-namespace

--- a/istio-mpol/add-sidecar-injection-namespace/add-sidecar-injection-namespace.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/add-sidecar-injection-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-sidecar-injection-namespace

--- a/karpenter-mpol/add-karpenter-daemonset-priority-class/.chainsaw-test/policy-ready.yaml
+++ b/karpenter-mpol/add-karpenter-daemonset-priority-class/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-daemonset-priority-class

--- a/karpenter-mpol/add-karpenter-daemonset-priority-class/add-karpenter-daemonset-priority-class.yaml
+++ b/karpenter-mpol/add-karpenter-daemonset-priority-class/add-karpenter-daemonset-priority-class.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-daemonset-priority-class

--- a/karpenter-mpol/add-karpenter-donot-evict/.chainsaw-test/policy-ready.yaml
+++ b/karpenter-mpol/add-karpenter-donot-evict/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-donot-evict

--- a/karpenter-mpol/add-karpenter-donot-evict/add-karpenter-donot-evict.yaml
+++ b/karpenter-mpol/add-karpenter-donot-evict/add-karpenter-donot-evict.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-donot-evict

--- a/karpenter-mpol/add-karpenter-nodeselector/.chainsaw-test/policy-ready.yaml
+++ b/karpenter-mpol/add-karpenter-nodeselector/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-nodeselector

--- a/karpenter-mpol/add-karpenter-nodeselector/add-karpenter-nodeselector.yaml
+++ b/karpenter-mpol/add-karpenter-nodeselector/add-karpenter-nodeselector.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-nodeselector

--- a/karpenter-mpol/set-karpenter-non-cpu-limits/.chainsaw-test/policy-ready.yaml
+++ b/karpenter-mpol/set-karpenter-non-cpu-limits/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: set-karpenter-non-cpu-limits

--- a/karpenter-mpol/set-karpenter-non-cpu-limits/set-karpenter-non-cpu-limits.yaml
+++ b/karpenter-mpol/set-karpenter-non-cpu-limits/set-karpenter-non-cpu-limits.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: set-karpenter-non-cpu-limits

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/.chainsaw-test/policy-ready.yaml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: enable-kubecost-continuous-rightsizing

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/enable-kubecost-continuous-rightsizing.yaml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/enable-kubecost-continuous-rightsizing.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: enable-kubecost-continuous-rightsizing

--- a/kubevirt-gpol/add-services/.chainsaw-test/policy-ready.yaml
+++ b/kubevirt-gpol/add-services/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: k6t-add-services

--- a/kubevirt-gpol/add-services/add-services.yaml
+++ b/kubevirt-gpol/add-services/add-services.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: k6t-add-services

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/policy-ready.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-linkerd-mesh-injection

--- a/linkerd-mpol/add-linkerd-mesh-injection/add-linkerd-mesh-injection.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/add-linkerd-mesh-injection.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-linkerd-mesh-injection

--- a/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/policy-ready.yaml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-linkerd-policy-annotation

--- a/linkerd-mpol/add-linkerd-policy-annotation/add-linkerd-policy-annotation.yaml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/add-linkerd-policy-annotation.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-linkerd-policy-annotation

--- a/other-gpol/create-default-pdb/.chainsaw-test/policy-ready.yaml
+++ b/other-gpol/create-default-pdb/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: create-default-pdb

--- a/other-gpol/create-default-pdb/create-default-pdb.yaml
+++ b/other-gpol/create-default-pdb/create-default-pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: create-default-pdb

--- a/other-mpol/add-certificates-volume/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-certificates-volume/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-certificates-volume

--- a/other-mpol/add-certificates-volume/add-certificates-volume.yaml
+++ b/other-mpol/add-certificates-volume/add-certificates-volume.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-certificates-volume

--- a/other-mpol/add-default-resources/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-default-resources/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-default-resources

--- a/other-mpol/add-default-resources/add-default-resources.yaml
+++ b/other-mpol/add-default-resources/add-default-resources.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-default-resources

--- a/other-mpol/add-default-securitycontext/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-default-securitycontext/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-default-securitycontext

--- a/other-mpol/add-default-securitycontext/add-default-securitycontext.yaml
+++ b/other-mpol/add-default-securitycontext/add-default-securitycontext.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-default-securitycontext

--- a/other-mpol/add-emptydir-sizelimit/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-emptydir-sizelimit/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-emptydir-sizelimit

--- a/other-mpol/add-emptydir-sizelimit/add-emptydir-sizelimit.yaml
+++ b/other-mpol/add-emptydir-sizelimit/add-emptydir-sizelimit.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-emptydir-sizelimit

--- a/other-mpol/add-env-vars-from-cm/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-env-vars-from-cm/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-env-vars-from-cm

--- a/other-mpol/add-env-vars-from-cm/add-env-vars-from-cm.yaml
+++ b/other-mpol/add-env-vars-from-cm/add-env-vars-from-cm.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-env-vars-from-cm

--- a/other-mpol/add-image-as-env-var/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-image-as-env-var/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-image-as-env-var

--- a/other-mpol/add-image-as-env-var/add-image-as-env-var.yaml
+++ b/other-mpol/add-image-as-env-var/add-image-as-env-var.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-image-as-env-var

--- a/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-imagepullsecrets-for-containers-and-initcontainers

--- a/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/add-imagepullsecrets-for-containers-and-initcontainers.yaml
+++ b/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/add-imagepullsecrets-for-containers-and-initcontainers.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-imagepullsecrets-for-containers-and-initcontainers

--- a/other-mpol/add-imagepullsecrets/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-imagepullsecrets/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-imagepullsecrets

--- a/other-mpol/add-imagepullsecrets/add-imagepullsecrets.yaml
+++ b/other-mpol/add-imagepullsecrets/add-imagepullsecrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-imagepullsecrets

--- a/other-mpol/add-labels/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-labels/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-labels

--- a/other-mpol/add-labels/add-labels.yaml
+++ b/other-mpol/add-labels/add-labels.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-labels

--- a/other-mpol/add-ndots/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-ndots/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ndots

--- a/other-mpol/add-ndots/add-ndots.yaml
+++ b/other-mpol/add-ndots/add-ndots.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ndots

--- a/other-mpol/add-nodeSelector/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-nodeSelector/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-nodeselector

--- a/other-mpol/add-nodeSelector/add-nodeSelector.yaml
+++ b/other-mpol/add-nodeSelector/add-nodeSelector.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-nodeselector

--- a/other-mpol/add-pod-priorityclassname/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-pod-priorityclassname/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-pod-priorityclassname

--- a/other-mpol/add-pod-priorityclassname/add-pod-priorityclassname.yaml
+++ b/other-mpol/add-pod-priorityclassname/add-pod-priorityclassname.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-pod-priorityclassname

--- a/other-mpol/add-pod-proxies/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-pod-proxies/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-pod-proxies

--- a/other-mpol/add-pod-proxies/add-pod-proxies.yaml
+++ b/other-mpol/add-pod-proxies/add-pod-proxies.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-pod-proxies

--- a/other-mpol/add-tolerations/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-tolerations/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-tolerations

--- a/other-mpol/add-tolerations/add-tolerations.yaml
+++ b/other-mpol/add-tolerations/add-tolerations.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-tolerations

--- a/other-mpol/add-ttl-jobs/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-ttl-jobs/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ttl-jobs

--- a/other-mpol/add-ttl-jobs/add-ttl-jobs.yaml
+++ b/other-mpol/add-ttl-jobs/add-ttl-jobs.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ttl-jobs

--- a/other-mpol/add-volume-deployment/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-volume-deployment/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-volume

--- a/other-mpol/add-volume-deployment/add-volume-deployment.yaml
+++ b/other-mpol/add-volume-deployment/add-volume-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-volume

--- a/other-mpol/always-pull-images/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/always-pull-images/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: always-pull-images

--- a/other-mpol/always-pull-images/always-pull-images.yaml
+++ b/other-mpol/always-pull-images/always-pull-images.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: always-pull-images

--- a/other-mpol/annotate-base-images/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/annotate-base-images/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: annotate-base-images

--- a/other-mpol/annotate-base-images/annotate-base-images.yaml
+++ b/other-mpol/annotate-base-images/annotate-base-images.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: annotate-base-images

--- a/other-mpol/apply-pss-restricted-profile/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/apply-pss-restricted-profile/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: apply-pss-restricted-profile

--- a/other-mpol/apply-pss-restricted-profile/apply-pss-restricted-profile.yaml
+++ b/other-mpol/apply-pss-restricted-profile/apply-pss-restricted-profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: apply-pss-restricted-profile

--- a/other-mpol/disable-automountserviceaccounttoken/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/disable-automountserviceaccounttoken/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: disable-automountserviceaccounttoken

--- a/other-mpol/disable-automountserviceaccounttoken/disable-automountserviceaccounttoken.yaml
+++ b/other-mpol/disable-automountserviceaccounttoken/disable-automountserviceaccounttoken.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: disable-automountserviceaccounttoken

--- a/other-mpol/disable-service-discovery/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/disable-service-discovery/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: disable-service-discovery

--- a/other-mpol/disable-service-discovery/disable-service-discovery.yaml
+++ b/other-mpol/disable-service-discovery/disable-service-discovery.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: disable-service-discovery

--- a/other-mpol/inject-sidecar-deployment/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/inject-sidecar-deployment/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: inject-sidecar

--- a/other-mpol/inject-sidecar-deployment/inject-sidecar-deployment.yaml
+++ b/other-mpol/inject-sidecar-deployment/inject-sidecar-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: inject-sidecar

--- a/other-mpol/label-existing-namespaces/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/label-existing-namespaces/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: label-existing-namespaces

--- a/other-mpol/label-existing-namespaces/label-existing-namespaces.yaml
+++ b/other-mpol/label-existing-namespaces/label-existing-namespaces.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: label-existing-namespaces

--- a/other-mpol/label-nodes-cri/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/label-nodes-cri/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: label-nodes-cri

--- a/other-mpol/label-nodes-cri/label-nodes-cri.yaml
+++ b/other-mpol/label-nodes-cri/label-nodes-cri.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: label-nodes-cri

--- a/other-mpol/mitigate-log4shell/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/mitigate-log4shell/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: log4shell-mitigation

--- a/other-mpol/mitigate-log4shell/mitigate-log4shell.yaml
+++ b/other-mpol/mitigate-log4shell/mitigate-log4shell.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: log4shell-mitigation

--- a/other-mpol/mutate-large-termination-gps/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/mutate-large-termination-gps/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: mutate-termination-grace-period-seconds

--- a/other-mpol/mutate-large-termination-gps/mutate-large-termination-gps.yaml
+++ b/other-mpol/mutate-large-termination-gps/mutate-large-termination-gps.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: mutate-termination-grace-period-seconds

--- a/other-mpol/prepend-image-registry/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/prepend-image-registry/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: prepend-registry

--- a/other-mpol/prepend-image-registry/prepend-image-registry.yaml
+++ b/other-mpol/prepend-image-registry/prepend-image-registry.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: prepend-registry

--- a/other-mpol/remove-hostpath-volumes/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/remove-hostpath-volumes/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: remove-hostpath-volumes

--- a/other-mpol/remove-hostpath-volumes/remove-hostpath-volumes.yaml
+++ b/other-mpol/remove-hostpath-volumes/remove-hostpath-volumes.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: remove-hostpath-volumes

--- a/other-mpol/replace-image-registry/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/replace-image-registry/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: replace-image-registry

--- a/other-mpol/replace-image-registry/replace-image-registry.yaml
+++ b/other-mpol/replace-image-registry/replace-image-registry.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: replace-image-registry

--- a/other-mpol/replace-ingress-hosts/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/replace-ingress-hosts/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: replace-ingress-hosts

--- a/other-mpol/replace-ingress-hosts/replace-ingress-hosts.yaml
+++ b/other-mpol/replace-ingress-hosts/replace-ingress-hosts.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: replace-ingress-hosts

--- a/other-mpol/resolve-image-to-digest/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/resolve-image-to-digest/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: resolve-image-to-digest

--- a/other-mpol/resolve-image-to-digest/resolve-image-to-digest.yaml
+++ b/other-mpol/resolve-image-to-digest/resolve-image-to-digest.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: resolve-image-to-digest

--- a/other-mpol/spread-pods-across-topology/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/spread-pods-across-topology/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: spread-pods

--- a/other-mpol/spread-pods-across-topology/spread-pods-across-topology.yaml
+++ b/other-mpol/spread-pods-across-topology/spread-pods-across-topology.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: spread-pods

--- a/other-mpol/update-image-tag/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/update-image-tag/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: update-image-tag

--- a/other-mpol/update-image-tag/update-image-tag.yaml
+++ b/other-mpol/update-image-tag/update-image-tag.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: update-image-tag

--- a/other-vpol/advanced-restrict-image-registries/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/advanced-restrict-image-registries/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../advanced-restrict-image-registries.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: advanced-restrict-image-registries

--- a/other-vpol/advanced-restrict-image-registries/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/advanced-restrict-image-registries/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: advanced-restrict-image-registries

--- a/other-vpol/advanced-restrict-image-registries/advanced-restrict-image-registries.yaml
+++ b/other-vpol/advanced-restrict-image-registries/advanced-restrict-image-registries.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: advanced-restrict-image-registries

--- a/other-vpol/allowed-annotations/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/allowed-annotations/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../allowed-annotations.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: allowed-annotations

--- a/other-vpol/allowed-annotations/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/allowed-annotations/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-annotations

--- a/other-vpol/allowed-annotations/allowed-annotations.yaml
+++ b/other-vpol/allowed-annotations/allowed-annotations.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-annotations

--- a/other-vpol/allowed-base-images/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other-vpol/allowed-base-images/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-base-images

--- a/other-vpol/allowed-base-images/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/allowed-base-images/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../allowed-base-images.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: allowed-base-images

--- a/other-vpol/allowed-base-images/allowed-base-images.yaml
+++ b/other-vpol/allowed-base-images/allowed-base-images.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-base-images

--- a/other-vpol/allowed-image-repos/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other-vpol/allowed-image-repos/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-image-repos

--- a/other-vpol/allowed-image-repos/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/allowed-image-repos/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../allowed-image-repos.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: allowed-image-repos

--- a/other-vpol/allowed-image-repos/allowed-image-repos.yaml
+++ b/other-vpol/allowed-image-repos/allowed-image-repos.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-image-repos

--- a/other-vpol/allowed-pod-priorities/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/allowed-pod-priorities/.chainsaw-test/chainsaw-test.yaml
@@ -20,7 +20,7 @@ spec:
         file: ../allowed-pod-priorities.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: allowed-podpriorities

--- a/other-vpol/allowed-pod-priorities/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/allowed-pod-priorities/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-podpriorities

--- a/other-vpol/allowed-pod-priorities/allowed-pod-priorities.yaml
+++ b/other-vpol/allowed-pod-priorities/allowed-pod-priorities.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-podpriorities

--- a/other-vpol/block-cluster-admin-from-ns/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-cluster-admin-from-ns/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-cluster-admin-from-ns

--- a/other-vpol/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
+++ b/other-vpol/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-cluster-admin-from-ns

--- a/other-vpol/block-ephemeral-containers/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/block-ephemeral-containers/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../block-ephemeral-containers.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: block-ephemeral-containers

--- a/other-vpol/block-ephemeral-containers/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-ephemeral-containers/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-ephemeral-containers

--- a/other-vpol/block-ephemeral-containers/block-ephemeral-containers.yaml
+++ b/other-vpol/block-ephemeral-containers/block-ephemeral-containers.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-ephemeral-containers

--- a/other-vpol/block-images-with-volumes/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/block-images-with-volumes/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../block-images-with-volumes.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: block-images-with-volumes

--- a/other-vpol/block-images-with-volumes/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-images-with-volumes/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-images-with-volumes

--- a/other-vpol/block-images-with-volumes/block-images-with-volumes.yaml
+++ b/other-vpol/block-images-with-volumes/block-images-with-volumes.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-images-with-volumes

--- a/other-vpol/block-kubectl-cp/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-kubectl-cp/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-kubectl-cp

--- a/other-vpol/block-kubectl-cp/block-kubectl-cp.yaml
+++ b/other-vpol/block-kubectl-cp/block-kubectl-cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-kubectl-cp

--- a/other-vpol/block-large-images/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/block-large-images/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../block-large-images.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: block-large-images

--- a/other-vpol/block-large-images/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-large-images/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-large-images

--- a/other-vpol/block-large-images/block-large-images.yaml
+++ b/other-vpol/block-large-images/block-large-images.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-large-images

--- a/other-vpol/block-pod-exec-by-namespace-label/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-namespace-label/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-namespace-label

--- a/other-vpol/block-pod-exec-by-namespace-label/block-pod-exec-by-namespace-label.yaml
+++ b/other-vpol/block-pod-exec-by-namespace-label/block-pod-exec-by-namespace-label.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-namespace-label

--- a/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-namespace-name

--- a/other-vpol/block-pod-exec-by-namespace/block-pod-exec-by-namespace.yaml
+++ b/other-vpol/block-pod-exec-by-namespace/block-pod-exec-by-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-namespace-name

--- a/other-vpol/block-pod-exec-by-pod-and-container/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-pod-and-container/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-and-container

--- a/other-vpol/block-pod-exec-by-pod-and-container/block-pod-exec-by-pod-and-container.yaml
+++ b/other-vpol/block-pod-exec-by-pod-and-container/block-pod-exec-by-pod-and-container.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-and-container

--- a/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-label

--- a/other-vpol/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.yaml
+++ b/other-vpol/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-label

--- a/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-name

--- a/other-vpol/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.yaml
+++ b/other-vpol/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-name

--- a/other-vpol/block-updates-deletes/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-updates-deletes/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-updates-deletes

--- a/other-vpol/block-updates-deletes/block-updates-deletes.yaml
+++ b/other-vpol/block-updates-deletes/block-updates-deletes.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-updates-deletes

--- a/other-vpol/check-env-vars/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-env-vars/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../check-env-vars.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-env-vars

--- a/other-vpol/check-env-vars/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-env-vars/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-env-vars

--- a/other-vpol/check-env-vars/check-env-vars.yaml
+++ b/other-vpol/check-env-vars/check-env-vars.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-env-vars

--- a/other-vpol/check-hpa-exists/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-hpa-exists/.chainsaw-test/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
         file: ../check-hpa-exists.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-hpa-exists

--- a/other-vpol/check-hpa-exists/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-hpa-exists/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-hpa-exists

--- a/other-vpol/check-hpa-exists/check-hpa-exists.yaml
+++ b/other-vpol/check-hpa-exists/check-hpa-exists.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-hpa-exists

--- a/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/.chainsaw-test/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
     try:
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-ingress-nginx-controller-version-and-annotation-policy

--- a/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-ingress-nginx-controller-version-and-annotation-policy

--- a/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/check-ingress-nginx-controller-version-and-annotation-policy.yaml
+++ b/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/check-ingress-nginx-controller-version-and-annotation-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-ingress-nginx-controller-version-and-annotation-policy

--- a/other-vpol/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.yaml
+++ b/other-vpol/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-kernel

--- a/other-vpol/check-nvidia-gpu/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-nvidia-gpu/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../check-nvidia-gpu.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-nvidia-gpus

--- a/other-vpol/check-nvidia-gpu/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-nvidia-gpu/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-nvidia-gpus

--- a/other-vpol/check-nvidia-gpu/check-nvidia-gpu.yaml
+++ b/other-vpol/check-nvidia-gpu/check-nvidia-gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-nvidia-gpus

--- a/other-vpol/check-serviceaccount-secrets/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-serviceaccount-secrets/.chainsaw-test/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
         file :  ../check-serviceaccount-secrets.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-serviceaccount-secrets
@@ -37,7 +37,7 @@ spec:
     try:
     - delete:
         ref:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           name: check-serviceaccount-secrets
 

--- a/other-vpol/check-serviceaccount-secrets/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-serviceaccount-secrets/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-serviceaccount-secrets

--- a/other-vpol/check-serviceaccount-secrets/check-serviceaccount-secrets.yaml
+++ b/other-vpol/check-serviceaccount-secrets/check-serviceaccount-secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-serviceaccount-secrets

--- a/other-vpol/check-serviceaccount/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-serviceaccount/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../check-serviceaccount.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-sa

--- a/other-vpol/check-serviceaccount/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-serviceaccount/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-sa

--- a/other-vpol/check-serviceaccount/check-serviceaccount.yaml
+++ b/other-vpol/check-serviceaccount/check-serviceaccount.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-sa

--- a/other-vpol/check-subjectaccessreview/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-subjectaccessreview/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../check-subjectaccessreview.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-subjectaccessreview

--- a/other-vpol/check-subjectaccessreview/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-subjectaccessreview/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-subjectaccessreview

--- a/other-vpol/check-subjectaccessreview/check-subjectaccessreview.yaml
+++ b/other-vpol/check-subjectaccessreview/check-subjectaccessreview.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-subjectaccessreview

--- a/other-vpol/deny-commands-in-exec-probe/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/deny-commands-in-exec-probe/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../deny-commands-in-exec-probe.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: deny-commands-in-exec-probe

--- a/other-vpol/deny-commands-in-exec-probe/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/deny-commands-in-exec-probe/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-commands-in-exec-probe

--- a/other-vpol/deny-commands-in-exec-probe/deny-commands-in-exec-probe.yaml
+++ b/other-vpol/deny-commands-in-exec-probe/deny-commands-in-exec-probe.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-commands-in-exec-probe

--- a/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../deny-secret-service-account-token-type.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: deny-secret-service-account-token-type

--- a/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-secret-service-account-token-type

--- a/other-vpol/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-secret-service-account-token-type

--- a/other-vpol/disallow-all-secrets/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/disallow-all-secrets/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-all-secrets.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: no-secrets

--- a/other-vpol/disallow-all-secrets/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/disallow-all-secrets/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-secrets

--- a/other-vpol/disallow-all-secrets/disallow-all-secrets.yaml
+++ b/other-vpol/disallow-all-secrets/disallow-all-secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-secrets

--- a/other-vpol/disallow-localhost-services/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/disallow-localhost-services/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-localhost-services.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: no-localhost-service

--- a/other-vpol/disallow-localhost-services/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/disallow-localhost-services/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-localhost-service

--- a/other-vpol/disallow-localhost-services/disallow-localhost-services.yaml
+++ b/other-vpol/disallow-localhost-services/disallow-localhost-services.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-localhost-service

--- a/other-vpol/disallow-secrets-from-env-vars/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/disallow-secrets-from-env-vars/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-secrets-from-env-vars.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: secrets-not-from-env-vars

--- a/other-vpol/disallow-secrets-from-env-vars/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/disallow-secrets-from-env-vars/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: secrets-not-from-env-vars

--- a/other-vpol/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml
+++ b/other-vpol/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: secrets-not-from-env-vars

--- a/other-vpol/docker-socket-requires-label/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/docker-socket-requires-label/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../docker-socket-requires-label.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: docker-socket-check

--- a/other-vpol/docker-socket-requires-label/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/docker-socket-requires-label/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: docker-socket-check

--- a/other-vpol/docker-socket-requires-label/docker-socket-requires-label.yaml
+++ b/other-vpol/docker-socket-requires-label/docker-socket-requires-label.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: docker-socket-check

--- a/other-vpol/enforce-pod-duration/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/enforce-pod-duration/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../enforce-pod-duration.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: pod-lifetime

--- a/other-vpol/enforce-pod-duration/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/enforce-pod-duration/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: pod-lifetime

--- a/other-vpol/enforce-pod-duration/enforce-pod-duration.yaml
+++ b/other-vpol/enforce-pod-duration/enforce-pod-duration.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: pod-lifetime

--- a/other-vpol/enforce-readwriteonce-pod/enforce-readwriteonce-pod.yaml
+++ b/other-vpol/enforce-readwriteonce-pod/enforce-readwriteonce-pod.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: readwriteonce-pod

--- a/other-vpol/ensure-probes-different/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/ensure-probes-different/.chainsaw-test/chainsaw-test.yaml
@@ -16,7 +16,7 @@ spec:
         file: ../ensure-probes-different.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: validate-probes

--- a/other-vpol/ensure-probes-different/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/ensure-probes-different/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: validate-probes

--- a/other-vpol/ensure-probes-different/ensure-probes-different.yaml
+++ b/other-vpol/ensure-probes-different/ensure-probes-different.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: validate-probes

--- a/other-vpol/ensure-readonly-hostpath/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/ensure-readonly-hostpath/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../ensure-readonly-hostpath.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: ensure-readonly-hostpath

--- a/other-vpol/ensure-readonly-hostpath/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/ensure-readonly-hostpath/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: ensure-readonly-hostpath

--- a/other-vpol/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
+++ b/other-vpol/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: ensure-readonly-hostpath

--- a/other-vpol/exclude-namespaces-dynamically/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/exclude-namespaces-dynamically/.chainsaw-test/chainsaw-test.yaml
@@ -16,7 +16,7 @@ spec:
         file: ../exclude-namespaces-dynamically.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: exclude-namespaces-example

--- a/other-vpol/exclude-namespaces-dynamically/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/exclude-namespaces-dynamically/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: exclude-namespaces-example

--- a/other-vpol/exclude-namespaces-dynamically/exclude-namespaces-dynamically.yaml
+++ b/other-vpol/exclude-namespaces-dynamically/exclude-namespaces-dynamically.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: exclude-namespaces-example

--- a/other-vpol/forbid-cpu-limits/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/forbid-cpu-limits/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../forbid-cpu-limits.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: forbid-cpu-limits

--- a/other-vpol/forbid-cpu-limits/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/forbid-cpu-limits/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: forbid-cpu-limits

--- a/other-vpol/forbid-cpu-limits/forbid-cpu-limits.yaml
+++ b/other-vpol/forbid-cpu-limits/forbid-cpu-limits.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: forbid-cpu-limits

--- a/other-vpol/imagepullpolicy-always/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/imagepullpolicy-always/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../imagepullpolicy-always.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: imagepullpolicy-always

--- a/other-vpol/imagepullpolicy-always/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/imagepullpolicy-always/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: imagepullpolicy-always

--- a/other-vpol/imagepullpolicy-always/imagepullpolicy-always.yaml
+++ b/other-vpol/imagepullpolicy-always/imagepullpolicy-always.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: imagepullpolicy-always

--- a/other-vpol/ingress-host-match-tls/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/ingress-host-match-tls/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../ingress-host-match-tls.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: ingress-host-match-tls

--- a/other-vpol/ingress-host-match-tls/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/ingress-host-match-tls/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: ingress-host-match-tls

--- a/other-vpol/ingress-host-match-tls/ingress-host-match-tls.yaml
+++ b/other-vpol/ingress-host-match-tls/ingress-host-match-tls.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: ingress-host-match-tls

--- a/other-vpol/limit-containers-per-pod/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/limit-containers-per-pod/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../limit-containers-per-pod.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: limit-containers-per-pod

--- a/other-vpol/limit-containers-per-pod/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/limit-containers-per-pod/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-containers-per-pod

--- a/other-vpol/limit-containers-per-pod/limit-containers-per-pod.yaml
+++ b/other-vpol/limit-containers-per-pod/limit-containers-per-pod.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-containers-per-pod

--- a/other-vpol/limit-hostpath-type-pv/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/limit-hostpath-type-pv/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../limit-hostpath-type-pv.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: limit-hostpath-type-pv

--- a/other-vpol/limit-hostpath-type-pv/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/limit-hostpath-type-pv/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-hostpath-type-pv

--- a/other-vpol/limit-hostpath-type-pv/limit-hostpath-type-pv.yaml
+++ b/other-vpol/limit-hostpath-type-pv/limit-hostpath-type-pv.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-hostpath-type-pv

--- a/other-vpol/limit-hostpath-vols/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/limit-hostpath-vols/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../limit-hostpath-vols.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: limit-hostpath-vols

--- a/other-vpol/limit-hostpath-vols/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/limit-hostpath-vols/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-hostpath-vols

--- a/other-vpol/limit-hostpath-vols/limit-hostpath-vols.yaml
+++ b/other-vpol/limit-hostpath-vols/limit-hostpath-vols.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-hostpath-vols

--- a/other-vpol/memory-requests-equal-limits/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/memory-requests-equal-limits/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../memory-requests-equal-limits.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: memory-requests-equal-limits

--- a/other-vpol/memory-requests-equal-limits/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/memory-requests-equal-limits/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: memory-requests-equal-limits

--- a/other-vpol/memory-requests-equal-limits/memory-requests-equal-limits.yaml
+++ b/other-vpol/memory-requests-equal-limits/memory-requests-equal-limits.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: memory-requests-equal-limits

--- a/other-vpol/metadata-match-regex/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/metadata-match-regex/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../metadata-match-regex.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: metadata-match-regex

--- a/other-vpol/metadata-match-regex/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/metadata-match-regex/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: metadata-match-regex

--- a/other-vpol/metadata-match-regex/metadata-match-regex.yaml
+++ b/other-vpol/metadata-match-regex/metadata-match-regex.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: metadata-match-regex

--- a/other-vpol/pdb-maxunavailable/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/pdb-maxunavailable/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../pdb-maxunavailable.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: pdb-maxunavailable

--- a/other-vpol/pdb-maxunavailable/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/pdb-maxunavailable/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: pdb-maxunavailable

--- a/other-vpol/pdb-maxunavailable/pdb-maxunavailable.yaml
+++ b/other-vpol/pdb-maxunavailable/pdb-maxunavailable.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: pdb-maxunavailable

--- a/other-vpol/prevent-bare-pods/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/prevent-bare-pods/.chainsaw-test/chainsaw-test.yaml
@@ -16,7 +16,7 @@ spec:
         file: ../prevent-bare-pods.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: prevent-bare-pods

--- a/other-vpol/prevent-bare-pods/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/prevent-bare-pods/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: prevent-bare-pods

--- a/other-vpol/prevent-bare-pods/prevent-bare-pods.yaml
+++ b/other-vpol/prevent-bare-pods/prevent-bare-pods.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: prevent-bare-pods

--- a/other-vpol/prevent-cr8escape/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/prevent-cr8escape/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: prevent-cr8escape

--- a/other-vpol/prevent-cr8escape/prevent-cr8escape.yaml
+++ b/other-vpol/prevent-cr8escape/prevent-cr8escape.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: prevent-cr8escape

--- a/other-vpol/require-annotations/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-annotations/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-annotations.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-annotations

--- a/other-vpol/require-annotations/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-annotations/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-annotations

--- a/other-vpol/require-annotations/require-annotations.yaml
+++ b/other-vpol/require-annotations/require-annotations.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-annotations

--- a/other-vpol/require-container-port-names/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-container-port-names/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-container-port-names.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-container-port-names

--- a/other-vpol/require-container-port-names/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-container-port-names/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-container-port-names

--- a/other-vpol/require-container-port-names/require-container-port-names.yaml
+++ b/other-vpol/require-container-port-names/require-container-port-names.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-container-port-names

--- a/other-vpol/require-deployments-have-multiple-replicas/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-deployments-have-multiple-replicas/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-deployments-have-multiple-replicas.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: deployment-has-multiple-replicas

--- a/other-vpol/require-deployments-have-multiple-replicas/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-deployments-have-multiple-replicas/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deployment-has-multiple-replicas

--- a/other-vpol/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.yaml
+++ b/other-vpol/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deployment-has-multiple-replicas

--- a/other-vpol/require-emptydir-requests-limits/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-emptydir-requests-limits/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-emptydir-requests-limits.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-emptydir-requests-and-limits

--- a/other-vpol/require-emptydir-requests-limits/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-emptydir-requests-limits/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-emptydir-requests-and-limits

--- a/other-vpol/require-emptydir-requests-limits/require-emptydir-requests-limits.yaml
+++ b/other-vpol/require-emptydir-requests-limits/require-emptydir-requests-limits.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-emptydir-requests-and-limits

--- a/other-vpol/require-image-checksum/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-image-checksum/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-image-checksum.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-image-checksum

--- a/other-vpol/require-image-checksum/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-image-checksum/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-image-checksum

--- a/other-vpol/require-image-checksum/require-image-checksum.yaml
+++ b/other-vpol/require-image-checksum/require-image-checksum.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-image-checksum

--- a/other-vpol/require-ingress-https/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-ingress-https/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-ingress-https.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-ingress-https

--- a/other-vpol/require-ingress-https/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-ingress-https/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-ingress-https

--- a/other-vpol/require-ingress-https/require-ingress-https.yaml
+++ b/other-vpol/require-ingress-https/require-ingress-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-ingress-https

--- a/other-vpol/require-non-root-groups/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-non-root-groups/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../require-non-root-groups.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-non-root-groups

--- a/other-vpol/require-non-root-groups/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-non-root-groups/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-non-root-groups

--- a/other-vpol/require-non-root-groups/.kyverno-test/check-fsgroup.yaml
+++ b/other-vpol/require-non-root-groups/.kyverno-test/check-fsgroup.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-fsgroup

--- a/other-vpol/require-non-root-groups/.kyverno-test/check-supplementalgroups.yaml
+++ b/other-vpol/require-non-root-groups/.kyverno-test/check-supplementalgroups.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-supplementalgroups

--- a/other-vpol/require-non-root-groups/require-non-root-groups.yaml
+++ b/other-vpol/require-non-root-groups/require-non-root-groups.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-non-root-groups

--- a/other-vpol/require-pod-priorityclassname/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-pod-priorityclassname/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-pod-priorityclassname.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-pod-priorityclassname

--- a/other-vpol/require-pod-priorityclassname/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-pod-priorityclassname/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-pod-priorityclassname

--- a/other-vpol/require-pod-priorityclassname/require-pod-priorityclassname.yaml
+++ b/other-vpol/require-pod-priorityclassname/require-pod-priorityclassname.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-pod-priorityclassname

--- a/other-vpol/require-qos-burstable/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-qos-burstable/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-qos-burstable.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-qos-burstable

--- a/other-vpol/require-qos-burstable/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-qos-burstable/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-qos-burstable

--- a/other-vpol/require-qos-burstable/require-qos-burstable.yaml
+++ b/other-vpol/require-qos-burstable/require-qos-burstable.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-qos-burstable

--- a/other-vpol/require-qos-guaranteed/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-qos-guaranteed/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-qos-guaranteed.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-qos-guaranteed

--- a/other-vpol/require-qos-guaranteed/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-qos-guaranteed/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-qos-guaranteed

--- a/other-vpol/require-qos-guaranteed/require-qos-guaranteed.yaml
+++ b/other-vpol/require-qos-guaranteed/require-qos-guaranteed.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-qos-guaranteed

--- a/other-vpol/require-storageclass/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-storageclass/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-storageclass.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-storageclass

--- a/other-vpol/require-storageclass/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-storageclass/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-storageclass

--- a/other-vpol/require-storageclass/require-storageclass.yaml
+++ b/other-vpol/require-storageclass/require-storageclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-storageclass

--- a/other-vpol/restrict-annotations/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-annotations/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-annotations.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-annotations

--- a/other-vpol/restrict-annotations/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-annotations/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-annotations

--- a/other-vpol/restrict-annotations/restrict-annotations.yaml
+++ b/other-vpol/restrict-annotations/restrict-annotations.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-annotations

--- a/other-vpol/restrict-binding-clusteradmin/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-binding-clusteradmin/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-binding-clusteradmin.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-binding-clusteradmin

--- a/other-vpol/restrict-binding-clusteradmin/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-binding-clusteradmin/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-binding-clusteradmin

--- a/other-vpol/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml
+++ b/other-vpol/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-binding-clusteradmin

--- a/other-vpol/restrict-binding-system-groups/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-binding-system-groups/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-binding-system-groups.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-binding-system-groups

--- a/other-vpol/restrict-binding-system-groups/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-binding-system-groups/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-binding-system-groups

--- a/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.yaml
+++ b/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-binding-system-groups

--- a/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-clusterrole-nodesproxy.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-clusterrole-nodesproxy

--- a/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-clusterrole-nodesproxy

--- a/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-clusterrole-nodesproxy

--- a/other-vpol/restrict-controlplane-scheduling/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-controlplane-scheduling/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-controlplane-scheduling.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-controlplane-scheduling

--- a/other-vpol/restrict-controlplane-scheduling/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-controlplane-scheduling/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-controlplane-scheduling

--- a/other-vpol/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml
+++ b/other-vpol/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-controlplane-scheduling

--- a/other-vpol/restrict-deprecated-registry/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-deprecated-registry/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-deprecated-registry

--- a/other-vpol/restrict-deprecated-registry/restrict-deprecated-registry.yaml
+++ b/other-vpol/restrict-deprecated-registry/restrict-deprecated-registry.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-deprecated-registry

--- a/other-vpol/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml
+++ b/other-vpol/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-edit-for-endpoints

--- a/other-vpol/restrict-escalation-verbs-roles/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-escalation-verbs-roles/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-escalation-verbs-roles.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-escalation-verbs-roles

--- a/other-vpol/restrict-escalation-verbs-roles/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-escalation-verbs-roles/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-escalation-verbs-roles

--- a/other-vpol/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
+++ b/other-vpol/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-escalation-verbs-roles

--- a/other-vpol/restrict-ingress-classes/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-ingress-classes/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-ingress-classes.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-ingress-classes

--- a/other-vpol/restrict-ingress-classes/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-ingress-classes/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-classes

--- a/other-vpol/restrict-ingress-classes/restrict-ingress-classes.yaml
+++ b/other-vpol/restrict-ingress-classes/restrict-ingress-classes.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-classes

--- a/other-vpol/restrict-ingress-defaultbackend/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-ingress-defaultbackend/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-ingress-defaultbackend.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-ingress-defaultbackend

--- a/other-vpol/restrict-ingress-defaultbackend/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-ingress-defaultbackend/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-defaultbackend

--- a/other-vpol/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.yaml
+++ b/other-vpol/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-defaultbackend

--- a/other-vpol/restrict-ingress-wildcard/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-ingress-wildcard/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-ingress-wildcard.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-ingress-wildcard

--- a/other-vpol/restrict-ingress-wildcard/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-ingress-wildcard/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-wildcard

--- a/other-vpol/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
+++ b/other-vpol/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-wildcard

--- a/other-vpol/restrict-jobs/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-jobs/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-jobs

--- a/other-vpol/restrict-jobs/restrict-jobs.yaml
+++ b/other-vpol/restrict-jobs/restrict-jobs.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-jobs

--- a/other-vpol/restrict-loadbalancer/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-loadbalancer/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-loadbalancer.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: no-loadbalancer-service

--- a/other-vpol/restrict-loadbalancer/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-loadbalancer/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-loadbalancer-service

--- a/other-vpol/restrict-loadbalancer/restrict-loadbalancer.yaml
+++ b/other-vpol/restrict-loadbalancer/restrict-loadbalancer.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-loadbalancer-service

--- a/other-vpol/restrict-networkpolicy-empty-podselector/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-networkpolicy-empty-podselector/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-networkpolicy-empty-podselector.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-networkpolicy-empty-podselector

--- a/other-vpol/restrict-networkpolicy-empty-podselector/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-networkpolicy-empty-podselector/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-networkpolicy-empty-podselector

--- a/other-vpol/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.yaml
+++ b/other-vpol/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-networkpolicy-empty-podselector

--- a/other-vpol/restrict-node-affinity/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-node-affinity/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-node-affinity.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-node-affinity

--- a/other-vpol/restrict-node-affinity/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-node-affinity/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-node-affinity

--- a/other-vpol/restrict-node-affinity/restrict-node-affinity.yaml
+++ b/other-vpol/restrict-node-affinity/restrict-node-affinity.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-node-affinity

--- a/other-vpol/restrict-node-label-creation/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-node-label-creation/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-node-label-creation

--- a/other-vpol/restrict-node-label-creation/restrict-node-label-creation.yaml
+++ b/other-vpol/restrict-node-label-creation/restrict-node-label-creation.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-node-label-creation

--- a/other-vpol/restrict-pod-controller-serviceaccount-updates/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-pod-controller-serviceaccount-updates/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-pod-controller-serviceaccount-updates.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-pod-controller-serviceaccount-updates

--- a/other-vpol/restrict-pod-controller-serviceaccount-updates/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-pod-controller-serviceaccount-updates/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-pod-controller-serviceaccount-updates

--- a/other-vpol/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.yaml
+++ b/other-vpol/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-pod-controller-serviceaccount-updates

--- a/other-vpol/restrict-sa-automount-sa-token/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-sa-automount-sa-token/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-sa-automount-sa-token.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-sa-automount-sa-token

--- a/other-vpol/restrict-sa-automount-sa-token/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-sa-automount-sa-token/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-sa-automount-sa-token

--- a/other-vpol/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
+++ b/other-vpol/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-sa-automount-sa-token

--- a/other-vpol/restrict-secret-role-verbs/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-secret-role-verbs/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-secret-role-verbs.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-secret-role-verbs

--- a/other-vpol/restrict-secret-role-verbs/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-secret-role-verbs/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-secret-role-verbs

--- a/other-vpol/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
+++ b/other-vpol/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-secret-role-verbs

--- a/other-vpol/restrict-secrets-by-name/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-secrets-by-name/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../restrict-secrets-by-name.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-secrets-by-name

--- a/other-vpol/restrict-secrets-by-name/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-secrets-by-name/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-secrets-by-name

--- a/other-vpol/restrict-secrets-by-name/restrict-secrets-by-name.yaml
+++ b/other-vpol/restrict-secrets-by-name/restrict-secrets-by-name.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-secrets-by-name

--- a/other-vpol/restrict-service-port-range/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-service-port-range/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-service-port-range.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-service-port-range

--- a/other-vpol/restrict-service-port-range/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-service-port-range/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-service-port-range

--- a/other-vpol/restrict-service-port-range/restrict-service-port-range.yaml
+++ b/other-vpol/restrict-service-port-range/restrict-service-port-range.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-service-port-range

--- a/other-vpol/restrict-storageclass/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-storageclass/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-storageclass.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-storageclass

--- a/other-vpol/restrict-storageclass/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-storageclass/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-storageclass

--- a/other-vpol/restrict-storageclass/restrict-storageclass.yaml
+++ b/other-vpol/restrict-storageclass/restrict-storageclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-storageclass

--- a/other-vpol/restrict-usergroup-fsgroup-id/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-usergroup-fsgroup-id/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-usergroup-fsgroup-id.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: validate-userid-groupid-fsgroup

--- a/other-vpol/restrict-usergroup-fsgroup-id/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-usergroup-fsgroup-id/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: validate-userid-groupid-fsgroup

--- a/other-vpol/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml
+++ b/other-vpol/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: validate-userid-groupid-fsgroup

--- a/other-vpol/restrict-wildcard-resources/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-wildcard-resources/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-wildcard-resources.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-wildcard-resources

--- a/other-vpol/restrict-wildcard-resources/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-wildcard-resources/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-wildcard-resources

--- a/other-vpol/restrict-wildcard-resources/restrict-wildcard-resources.yaml
+++ b/other-vpol/restrict-wildcard-resources/restrict-wildcard-resources.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-wildcard-resources

--- a/other-vpol/restrict-wildcard-verbs/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-wildcard-verbs/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-wildcard-verbs.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-wildcard-verbs

--- a/other-vpol/restrict-wildcard-verbs/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-wildcard-verbs/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-wildcard-verbs

--- a/other-vpol/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
+++ b/other-vpol/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-wildcard-verbs

--- a/other-vpol/topologyspreadconstraints-policy/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/topologyspreadconstraints-policy/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../topologyspreadconstraints-policy.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: topologyspreadconstraints-policy

--- a/other-vpol/topologyspreadconstraints-policy/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/topologyspreadconstraints-policy/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: topologyspreadconstraints-policy

--- a/other-vpol/topologyspreadconstraints-policy/topologyspreadconstraints-policy.yaml
+++ b/other-vpol/topologyspreadconstraints-policy/topologyspreadconstraints-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: topologyspreadconstraints-policy

--- a/other-vpol/unique-ingress-paths/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other-vpol/unique-ingress-paths/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name:  unique-ingress-path

--- a/other-vpol/unique-ingress-paths/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/unique-ingress-paths/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../unique-ingress-paths.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: unique-ingress-path

--- a/other-vpol/unique-ingress-paths/unique-ingress-paths.yaml
+++ b/other-vpol/unique-ingress-paths/unique-ingress-paths.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: unique-ingress-path

--- a/other/verify-image-ivpol/.chainsaw-test/policy-ready.yaml
+++ b/other/verify-image-ivpol/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ImageValidatingPolicy
 metadata:
   name: verify-image-ivpol

--- a/other/verify-image-ivpol/verify-image-ivpol.yaml
+++ b/other/verify-image-ivpol/verify-image-ivpol.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ImageValidatingPolicy
 metadata:
   name: verify-image-ivpol

--- a/pod-security-vpol/baseline/disallow-capabilities/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-capabilities/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-capabilities.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-capabilities

--- a/pod-security-vpol/baseline/disallow-capabilities/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-capabilities/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-capabilities

--- a/pod-security-vpol/baseline/disallow-capabilities/disallow-capabilities.yaml
+++ b/pod-security-vpol/baseline/disallow-capabilities/disallow-capabilities.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-capabilities

--- a/pod-security-vpol/baseline/disallow-host-namespaces/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-host-namespaces/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-host-namespaces.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-host-namespaces

--- a/pod-security-vpol/baseline/disallow-host-namespaces/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-host-namespaces/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-namespaces

--- a/pod-security-vpol/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
+++ b/pod-security-vpol/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-namespaces

--- a/pod-security-vpol/baseline/disallow-host-path/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-host-path/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-host-path.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-host-path

--- a/pod-security-vpol/baseline/disallow-host-path/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-host-path/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-path

--- a/pod-security-vpol/baseline/disallow-host-path/disallow-host-path.yaml
+++ b/pod-security-vpol/baseline/disallow-host-path/disallow-host-path.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-path

--- a/pod-security-vpol/baseline/disallow-host-ports/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-host-ports/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-host-ports.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-host-ports

--- a/pod-security-vpol/baseline/disallow-host-ports/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-host-ports/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-ports

--- a/pod-security-vpol/baseline/disallow-host-ports/disallow-host-ports.yaml
+++ b/pod-security-vpol/baseline/disallow-host-ports/disallow-host-ports.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-ports

--- a/pod-security-vpol/baseline/disallow-host-process/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-host-process/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-host-process.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-host-process

--- a/pod-security-vpol/baseline/disallow-host-process/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-host-process/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-process

--- a/pod-security-vpol/baseline/disallow-host-process/disallow-host-process.yaml
+++ b/pod-security-vpol/baseline/disallow-host-process/disallow-host-process.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-process

--- a/pod-security-vpol/baseline/disallow-privileged-containers/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-privileged-containers/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-privileged-containers.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-privileged-containers

--- a/pod-security-vpol/baseline/disallow-privileged-containers/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-privileged-containers/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-privileged-containers

--- a/pod-security-vpol/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
+++ b/pod-security-vpol/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-privileged-containers

--- a/pod-security-vpol/baseline/disallow-proc-mount/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-proc-mount/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-proc-mount.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-proc-mount

--- a/pod-security-vpol/baseline/disallow-proc-mount/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-proc-mount/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-proc-mount

--- a/pod-security-vpol/baseline/disallow-proc-mount/disallow-proc-mount.yaml
+++ b/pod-security-vpol/baseline/disallow-proc-mount/disallow-proc-mount.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-proc-mount

--- a/pod-security-vpol/baseline/disallow-selinux/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-selinux/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-selinux.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-selinux

--- a/pod-security-vpol/baseline/disallow-selinux/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-selinux/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-selinux

--- a/pod-security-vpol/baseline/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security-vpol/baseline/disallow-selinux/disallow-selinux.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-selinux

--- a/pod-security-vpol/baseline/restrict-seccomp/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/restrict-seccomp/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../restrict-seccomp.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-seccomp

--- a/pod-security-vpol/baseline/restrict-seccomp/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/restrict-seccomp/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-seccomp

--- a/pod-security-vpol/baseline/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security-vpol/baseline/restrict-seccomp/restrict-seccomp.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-seccomp

--- a/pod-security-vpol/baseline/restrict-sysctls/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/restrict-sysctls/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../restrict-sysctls.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-sysctls

--- a/pod-security-vpol/baseline/restrict-sysctls/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/restrict-sysctls/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-sysctls

--- a/pod-security-vpol/baseline/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security-vpol/baseline/restrict-sysctls/restrict-sysctls.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-sysctls

--- a/pod-security-vpol/restricted/disallow-capabilities-strict/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/disallow-capabilities-strict/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-capabilities-strict.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-capabilities-strict

--- a/pod-security-vpol/restricted/disallow-capabilities-strict/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/disallow-capabilities-strict/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-capabilities-strict

--- a/pod-security-vpol/restricted/disallow-capabilities-strict/.kyverno-test/adding-capabilities-strict.yaml
+++ b/pod-security-vpol/restricted/disallow-capabilities-strict/.kyverno-test/adding-capabilities-strict.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: adding-capabilities-strict

--- a/pod-security-vpol/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
+++ b/pod-security-vpol/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-capabilities-strict

--- a/pod-security-vpol/restricted/disallow-privilege-escalation/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/disallow-privilege-escalation/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-privilege-escalation.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-privilege-escalation

--- a/pod-security-vpol/restricted/disallow-privilege-escalation/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/disallow-privilege-escalation/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-privilege-escalation

--- a/pod-security-vpol/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/pod-security-vpol/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-privilege-escalation

--- a/pod-security-vpol/restricted/require-run-as-non-root-user/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/require-run-as-non-root-user/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../require-run-as-non-root-user.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-run-as-non-root-user

--- a/pod-security-vpol/restricted/require-run-as-non-root-user/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/require-run-as-non-root-user/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-run-as-non-root-user

--- a/pod-security-vpol/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml
+++ b/pod-security-vpol/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-run-as-non-root-user

--- a/pod-security-vpol/restricted/require-run-as-nonroot/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/require-run-as-nonroot/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../require-run-as-nonroot.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-run-as-nonroot

--- a/pod-security-vpol/restricted/require-run-as-nonroot/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/require-run-as-nonroot/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-run-as-nonroot

--- a/pod-security-vpol/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/pod-security-vpol/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-run-as-nonroot

--- a/pod-security-vpol/restricted/restrict-seccomp-strict/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/restrict-seccomp-strict/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../restrict-seccomp-strict.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-seccomp-strict

--- a/pod-security-vpol/restricted/restrict-seccomp-strict/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/restrict-seccomp-strict/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-seccomp-strict

--- a/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
+++ b/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-seccomp-strict

--- a/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../restrict-volume-types.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-volume-types

--- a/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-volume-types

--- a/pod-security-vpol/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security-vpol/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-volume-types

--- a/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/policy-ready.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-privileged-existing-namespaces

--- a/psa-mpol/add-privileged-existing-namespaces/add-privileged-existing-namespaces.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/add-privileged-existing-namespaces.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-privileged-existing-namespaces

--- a/psa-mpol/add-psa-labels/.chainsaw-test/policy-ready.yaml
+++ b/psa-mpol/add-psa-labels/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-psa-labels

--- a/psa-mpol/add-psa-labels/add-psa-labels.yaml
+++ b/psa-mpol/add-psa-labels/add-psa-labels.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-psa-labels

--- a/psp-migration-mpol/add-apparmor/.chainsaw-test/policy-ready.yaml
+++ b/psp-migration-mpol/add-apparmor/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-apparmor-annotations

--- a/psp-migration-mpol/add-apparmor/add-apparmor.yaml
+++ b/psp-migration-mpol/add-apparmor/add-apparmor.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-apparmor-annotations

--- a/psp-migration-mpol/add-capabilities/.chainsaw-test/policy-ready.yaml
+++ b/psp-migration-mpol/add-capabilities/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-capabilities

--- a/psp-migration-mpol/add-capabilities/add-capabilities.yaml
+++ b/psp-migration-mpol/add-capabilities/add-capabilities.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-capabilities

--- a/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/policy-ready.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-runtimeclassname

--- a/psp-migration-mpol/add-runtimeClassName/add-runtimeClassName.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/add-runtimeClassName.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-runtimeclassname

--- a/velero-mpol/backup-all-volumes/.chainsaw-test/policy-ready.yaml
+++ b/velero-mpol/backup-all-volumes/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: backup-all-volumes

--- a/velero-mpol/backup-all-volumes/backup-all-volumes.yaml
+++ b/velero-mpol/backup-all-volumes/backup-all-volumes.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: backup-all-volumes


### PR DESCRIPTION
## Related issue

Fixes #1418

## Proposed Changes

Migrated CEL policies from `policies.kyverno.io/v1alpha1` to `policies.kyverno.io/v1` across security rules.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/policies/blob/main/CONTRIBUTING.md).
- [x] I have signed off my commits.