### PR TITLE
fix: correct comparison operator in PDB replica policy example

### DIFF
--- a/other/deployment-replicas-higher-than-pdb/deployment-replicas-higher-than-pdb.yaml
+++ b/other/deployment-replicas-higher-than-pdb/deployment-replicas-higher-than-pdb.yaml
@@ -52,6 +52,6 @@ spec:
           deny:
             conditions:
               all:
-              - key: "{{ request.object.spec.minAvailable }}"
-                operator: GreaterThanOrEquals
-                value: "{{ element.spec.replicas }}"
+              - key: "{{ element.spec.replicas }}"
+                operator: LessThanOrEquals
+                value: "{{ request.object.spec.minAvailable }}"


### PR DESCRIPTION
## Related issue

Fixes #1662

## Proposed Changes

Corrected the comparison operator in the PDB replica policy.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/policies/blob/main/CONTRIBUTING.md).
- [x] I have signed off my commits.