### PR TITLE
add karpenter do-not-disrupt policy for v1

### DIFF
--- a/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/chainsaw-test.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-karpenter-donot-disrupt
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../add-karpenter-donot-disrupt.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: ../.kyverno-test/resource.yaml
+    - apply:
+        file: resource-others.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: ../.kyverno-test/patched01.yaml
+    - assert:
+        file: ../.kyverno-test/patched02.yaml
+    - assert:
+        file: patched03.yaml
+    - assert:
+        file: patched04.yaml

--- a/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/patched03.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/patched03.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: addjob02
+spec:
+  template:
+    metadata:
+      annotations:
+        foo.bar.io/name: bar
+        karpenter.sh/do-not-disrupt: "true"
+    spec:
+      containers:
+      - name: busybox
+        image: ghcr.io/kyverno/test-busybox:1.35
+        command: ["sleep",  "3600"]
+      restartPolicy: Never
+  backoffLimit: 4

--- a/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/patched04.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/patched04.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: addcronjob02
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            foo.bar.io/name: bar
+            karpenter.sh/do-not-disrupt: "true"
+        spec:
+          containers:
+          - name: busybox
+            image: ghcr.io/kyverno/test-busybox:1.35
+            command: ["sleep",  "3600"]
+          restartPolicy: OnFailure

--- a/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/policy-ready.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-karpenter-donot-disrupt
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/resource-others.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.chainsaw-test/resource-others.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: addjob02
+spec:
+  template:
+    metadata:
+      annotations:
+        karpenter.sh/do-not-disrupt: "false"
+        foo.bar.io/name: bar
+    spec:
+      containers:
+      - name: busybox
+        image: ghcr.io/kyverno/test-busybox:1.35
+        command: ["sleep",  "3600"]
+      restartPolicy: Never
+  backoffLimit: 4
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: addcronjob02
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            foo.bar.io/name: bar
+            karpenter.sh/do-not-disrupt: "false"
+        spec:
+          containers:
+          - name: busybox
+            image: ghcr.io/kyverno/test-busybox:1.35
+            command: ["sleep",  "3600"]
+          restartPolicy: OnFailure

--- a/karpenter/add-karpenter-donot-disrupt/.kyverno-test/kyverno-test.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,23 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: add-karpenter-donot-disrupt
+policies:
+- ../add-karpenter-donot-disrupt.yaml
+resources:
+- resource.yaml
+results:
+- kind: CronJob
+  patchedResources: patched02.yaml
+  policy: add-karpenter-donot-disrupt
+  resources:
+  - addcronjob01
+  result: pass
+  rule: do-not-disrupt-cronjobs
+- kind: Job
+  patchedResources: patched01.yaml
+  policy: add-karpenter-donot-disrupt
+  resources:
+  - addjob01
+  result: pass
+  rule: do-not-disrupt-jobs

--- a/karpenter/add-karpenter-donot-disrupt/.kyverno-test/patched01.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.kyverno-test/patched01.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: addjob01
+spec:
+  template:
+    metadata:
+      annotations:
+        karpenter.sh/do-not-disrupt: "true"
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+  backoffLimit: 4

--- a/karpenter/add-karpenter-donot-disrupt/.kyverno-test/patched02.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.kyverno-test/patched02.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: addcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            karpenter.sh/do-not-disrupt: "true"
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure

--- a/karpenter/add-karpenter-donot-disrupt/.kyverno-test/resource.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/.kyverno-test/resource.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: addjob01
+spec:
+  template:
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+  backoffLimit: 4
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: addcronjob01
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure

--- a/karpenter/add-karpenter-donot-disrupt/add-karpenter-donot-disrupt.yaml
+++ b/karpenter/add-karpenter-donot-disrupt/add-karpenter-donot-disrupt.yaml
@@ -1,0 +1,50 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-karpenter-donot-disrupt
+  annotations:
+    policies.kyverno.io/title: Add Karpenter Do Not Disrupt
+    policies.kyverno.io/category: Karpenter, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.7.1
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/description: >- 
+      Starting with Karpenter v1.0, the `karpenter.sh/do-not-evict` annotation is replaced
+      by `karpenter.sh/do-not-disrupt`. If a Pod exists with the annotation
+      `karpenter.sh/do-not-disrupt: true` on a Node, and a request is made to disrupt
+      the Node, Karpenter will not drain any Pods from that Node or otherwise try to
+      delete the Node. This is useful for Pods that should run uninterrupted to completion.
+      This policy mutates Jobs and CronJobs so that Pods spawned by them will contain the
+      `karpenter.sh/do-not-disrupt: true` annotation.
+spec:
+  rules:
+  - name: do-not-disrupt-jobs
+    match:
+      any:
+      - resources:
+          kinds:
+          - Job
+    mutate:
+      patchStrategicMerge:
+        spec:
+          template:
+            metadata:
+              annotations:
+                karpenter.sh/do-not-disrupt: "true"
+  - name: do-not-disrupt-cronjobs
+    match:
+      any:
+      - resources:
+          kinds:
+          - CronJob
+    mutate:
+      patchStrategicMerge:
+        spec:
+          jobTemplate:
+            spec:
+              template:
+                metadata:
+                  annotations:
+                    karpenter.sh/do-not-disrupt: "true"

--- a/karpenter/add-karpenter-donot-disrupt/artifacthub-pkg.yml
+++ b/karpenter/add-karpenter-donot-disrupt/artifacthub-pkg.yml
@@ -1,0 +1,23 @@
+name: add-karpenter-donot-disrupt
+version: 1.0.0
+displayName: Add Karpenter Do Not Disrupt
+createdAt: "2026-01-29T00:00:00.000Z"
+description: >-
+  Starting with Karpenter v1.0, the `karpenter.sh/do-not-evict` annotation is replaced by `karpenter.sh/do-not-disrupt`. If a Pod exists with the annotation `karpenter.sh/do-not-disrupt: true` on a Node, and a request is made to disrupt the Node, Karpenter will not drain any Pods from that Node or otherwise try to delete the Node. This is useful for Pods that should run uninterrupted to completion. This policy mutates Jobs and CronJobs so that Pods spawned by them will contain the `karpenter.sh/do-not-disrupt: true` annotation.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/karpenter/add-karpenter-donot-disrupt/add-karpenter-donot-disrupt.yaml
+  ```
+keywords:
+  - kyverno
+  - Karpenter
+  - EKS Best Practices
+readme: |
+  Starting with Karpenter v1.0, the `karpenter.sh/do-not-evict` annotation is replaced by `karpenter.sh/do-not-disrupt`. If a Pod exists with the annotation `karpenter.sh/do-not-disrupt: true` on a Node, and a request is made to disrupt the Node, Karpenter will not drain any Pods from that Node or otherwise try to delete the Node. This is useful for Pods that should run uninterrupted to completion. This policy mutates Jobs and CronJobs so that Pods spawned by them will contain the `karpenter.sh/do-not-disrupt: true` annotation.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Karpenter, EKS Best Practices"
+  kyverno/kubernetesVersion: "1.23"
+  kyverno/subject: "Pod"
+digest: e465eaa012399e5b1197377017835f81ca90df442df74145073426d9dadb930e


### PR DESCRIPTION
## Related issue

Fixes #1191

## Proposed Changes

Add a new Karpenter policy `add-karpenter-donot-disrupt` for Karpenter v1.0+.

Starting with Karpenter v1.0, the `karpenter.sh/do-not-evict` annotation has been replaced by `karpenter.sh/do-not-disrupt`. This policy mutates Jobs and CronJobs so that Pods spawned by them will contain the `karpenter.sh/do-not-disrupt: true` annotation, preventing Karpenter from disrupting nodes running these workloads.

Reference: https://karpenter.sh/v1.0/upgrading/v1-migration/

## Checklist

- [x] I have read and followed the contributing guidelines
- [x] I have signed my commit with DCO
- [x] Tests have been added/updated