### PR TITLE
feat: apparmor-profiles: native app-armor fields

### DIFF
--- a/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/chainsaw-test.yaml
@@ -36,3 +36,31 @@ spec:
         - check:
             ($error != null): true
         file: podcontroller-bad.yaml
+  - name: step-03
+    try:
+    - apply:
+        file: debug-pod.yaml
+    - wait:
+        apiVersion: v1
+        kind: Pod
+        name: apparmor-debug-pod
+        timeout: 1m
+        for:
+          condition:
+            name: Ready
+            value: 'true'
+    - script:
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        content: if ! kubectl debug apparmor-debug-pod -n "$NAMESPACE" --image=ghcr.io/kyverno/test-busybox:1.35 --target=busybox --profile=restricted --attach=false; then exit 1; else exit 0; fi;
+    - script:
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        content: if ! kubectl debug apparmor-debug-pod -n "$NAMESPACE" --image=ghcr.io/kyverno/test-busybox:1.35 --target=busybox --profile=restricted --custom=debug-custom-profile-allowed.yaml --attach=false; then exit 1; else exit 0; fi;
+    - script:
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        content: if kubectl debug apparmor-debug-pod -n "$NAMESPACE" --image=ghcr.io/kyverno/test-busybox:1.35 --target=busybox --profile=general --custom=debug-custom-profile-denied.yaml --attach=false; then exit 1; else exit 0; fi;

--- a/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/debug-custom-profile-allowed.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/debug-custom-profile-allowed.yaml
@@ -1,0 +1,3 @@
+securityContext:
+  appArmorProfile:
+    type: RuntimeDefault

--- a/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/debug-custom-profile-denied.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/debug-custom-profile-denied.yaml
@@ -1,0 +1,3 @@
+securityContext:
+  appArmorProfile:
+    type: Unconfined

--- a/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/debug-pod.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/debug-pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: apparmor-debug-pod
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    command: ["sleep", "300"]

--- a/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/pod-bad.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/pod-bad.yaml
@@ -32,3 +32,27 @@ spec:
   containers:
   - name: container01
     image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod-native-pod
+spec:
+  securityContext:
+    appArmorProfile:
+      type: Unconfined
+  containers:
+  - name: container01
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod-native-container
+spec:
+  containers:
+  - name: container01
+    image: ghcr.io/kyverno/test-busybox:1.35
+    securityContext:
+      appArmorProfile:
+        type: Unconfined

--- a/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/pod-good.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/pod-good.yaml
@@ -61,3 +61,28 @@ spec:
   containers:
   - name: container01
     image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod-native-pod
+spec:
+  securityContext:
+    appArmorProfile:
+      type: RuntimeDefault
+  containers:
+  - name: container01
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod-native-container
+spec:
+  containers:
+  - name: container01
+    image: ghcr.io/kyverno/test-busybox:1.35
+    securityContext:
+      appArmorProfile:
+        type: Localhost
+        localhostProfile: foo

--- a/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/podcontroller-bad.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/podcontroller-bad.yaml
@@ -76,3 +76,80 @@ spec:
           - name: container01
             image: ghcr.io/kyverno/test-busybox:1.35
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment-native-pod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      securityContext:
+        appArmorProfile:
+          type: Unconfined
+      containers:
+      - name: container01
+        image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment-native-container
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: ghcr.io/kyverno/test-busybox:1.35
+        securityContext:
+          appArmorProfile:
+            type: Unconfined
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob-native-pod
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            appArmorProfile:
+              type: Unconfined
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob-native-container
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: ghcr.io/kyverno/test-busybox:1.35
+            securityContext:
+              appArmorProfile:
+                type: Unconfined

--- a/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/podcontroller-good.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/.chainsaw-test/podcontroller-good.yaml
@@ -146,3 +146,83 @@ spec:
           containers:
           - name: container01
             image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment-native-pod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      securityContext:
+        appArmorProfile:
+          type: RuntimeDefault
+      containers:
+      - name: container01
+        image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment-native-container
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: ghcr.io/kyverno/test-busybox:1.35
+        securityContext:
+          appArmorProfile:
+            type: Localhost
+            localhostProfile: foo
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob-native-pod
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            appArmorProfile:
+              type: RuntimeDefault
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob-native-container
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: ghcr.io/kyverno/test-busybox:1.35
+            securityContext:
+              appArmorProfile:
+                type: Localhost
+                localhostProfile: foo

--- a/pod-security/baseline/restrict-apparmor-profiles/.kyverno-test/kyverno-test.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/.kyverno-test/kyverno-test.yaml
@@ -28,6 +28,48 @@ results:
 - kind: CronJob
   policy: restrict-apparmor-profiles
   resources:
+  - badcronjob02
+  result: fail
+  rule: app-armor-native-pod
+- kind: Deployment
+  policy: restrict-apparmor-profiles
+  resources:
+  - baddeployment02
+  result: fail
+  rule: app-armor-native-pod
+- kind: Pod
+  policy: restrict-apparmor-profiles
+  resources:
+  - badpod02
+  result: fail
+  rule: app-armor-native-pod
+- kind: CronJob
+  policy: restrict-apparmor-profiles
+  resources:
+  - badcronjob03
+  result: fail
+  rule: app-armor-native-containers
+- kind: Deployment
+  policy: restrict-apparmor-profiles
+  resources:
+  - baddeployment03
+  result: fail
+  rule: app-armor-native-containers
+- kind: Pod
+  policy: restrict-apparmor-profiles
+  resources:
+  - badpod03
+  result: fail
+  rule: app-armor-native-containers
+- kind: Pod
+  policy: restrict-apparmor-profiles
+  resources:
+  - badpod04
+  result: fail
+  rule: app-armor-native-containers
+- kind: CronJob
+  policy: restrict-apparmor-profiles
+  resources:
   - goodcronjob01
   - goodcronjob02
   - goodcronjob03
@@ -49,3 +91,45 @@ results:
   - goodpod03
   result: pass
   rule: app-armor
+- kind: CronJob
+  policy: restrict-apparmor-profiles
+  resources:
+  - goodcronjob04
+  result: pass
+  rule: app-armor-native-pod
+- kind: Deployment
+  policy: restrict-apparmor-profiles
+  resources:
+  - gooddeployment04
+  result: pass
+  rule: app-armor-native-pod
+- kind: Pod
+  policy: restrict-apparmor-profiles
+  resources:
+  - goodpod04
+  result: pass
+  rule: app-armor-native-pod
+- kind: CronJob
+  policy: restrict-apparmor-profiles
+  resources:
+  - goodcronjob05
+  result: pass
+  rule: app-armor-native-containers
+- kind: Deployment
+  policy: restrict-apparmor-profiles
+  resources:
+  - gooddeployment05
+  result: pass
+  rule: app-armor-native-containers
+- kind: Pod
+  policy: restrict-apparmor-profiles
+  resources:
+  - goodpod05
+  result: pass
+  rule: app-armor-native-containers
+- kind: Pod
+  policy: restrict-apparmor-profiles
+  resources:
+  - goodpod06
+  result: pass
+  rule: app-armor-native-containers

--- a/pod-security/baseline/restrict-apparmor-profiles/.kyverno-test/resource.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/.kyverno-test/resource.yaml
@@ -11,6 +11,45 @@ spec:
   - name: container01
     image: dummyimagename
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod02
+spec:
+  securityContext:
+    appArmorProfile:
+      type: Unconfined
+  containers:
+  - name: container01
+    image: dummyimagename
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod03
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      appArmorProfile:
+        type: Unconfined
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod04
+spec:
+  initContainers:
+  - name: init01
+    image: dummyimagename
+    securityContext:
+      appArmorProfile:
+        type: Unconfined
+  containers:
+  - name: container01
+    image: dummyimagename
+---
 ###### Pods - Good
 apiVersion: v1
 kind: Pod
@@ -43,6 +82,46 @@ spec:
   - name: container01
     image: dummyimagename
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod04
+spec:
+  securityContext:
+    appArmorProfile:
+      type: RuntimeDefault
+  containers:
+  - name: container01
+    image: dummyimagename
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod05
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      appArmorProfile:
+        type: Localhost
+        localhostProfile: foo
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod06
+spec:
+  initContainers:
+  - name: init01
+    image: dummyimagename
+    securityContext:
+      appArmorProfile:
+        type: RuntimeDefault
+  containers:
+  - name: container01
+    image: dummyimagename
+---
 ###### Deployments - Bad
 apiVersion: apps/v1
 kind: Deployment
@@ -63,6 +142,48 @@ spec:
       containers:
       - name: container01
         image: dummyimagename
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      securityContext:
+        appArmorProfile:
+          type: Unconfined
+      containers:
+      - name: container01
+        image: dummyimagename
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment03
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          appArmorProfile:
+            type: Unconfined
 ---
 ###### Deployments - Good
 apiVersion: apps/v1
@@ -123,6 +244,49 @@ spec:
       - name: container01
         image: dummyimagename
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment04
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      securityContext:
+        appArmorProfile:
+          type: RuntimeDefault
+      containers:
+      - name: container01
+        image: dummyimagename
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment05
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+        securityContext:
+          appArmorProfile:
+            type: Localhost
+            localhostProfile: localhost/foo
+---
 ###### CronJobs - Bad
 apiVersion: batch/v1
 kind: CronJob
@@ -141,6 +305,42 @@ spec:
           containers:
           - name: container01
             image: dummyimagename
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob02
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            appArmorProfile:
+              type: Unconfined
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob03
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+            securityContext:
+              appArmorProfile:
+                type: Unconfined
 ---
 ###### CronJobs - Good
 apiVersion: batch/v1
@@ -193,3 +393,40 @@ spec:
           containers:
           - name: container01
             image: dummyimagename
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob04
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            appArmorProfile:
+              type: RuntimeDefault
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob05
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+            securityContext:
+              appArmorProfile:
+                type: Localhost
+                localhostProfile: foo

--- a/pod-security/baseline/restrict-apparmor-profiles/artifacthub-pkg.yml
+++ b/pod-security/baseline/restrict-apparmor-profiles/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: restrict-apparmor-profiles
-version: 1.0.0
+version: 1.1.0
 displayName: Restrict AppArmor
 createdAt: "2023-04-10T23:12:01.000Z"
 description: >-
@@ -17,6 +17,6 @@ readme: |
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Pod Security Standards (Baseline)"
-  kyverno/kubernetesVersion: "1.22-1.23"
+  kyverno/kubernetesVersion: "1.22-1.34"
   kyverno/subject: "Pod, Annotation"
-digest: 56109f7eeea51659d606b7002c695b97a0177b0e94b7847c7aab652e0f93dadb
+digest: 83859993c8f0ade58141ca8b332373d7c908404017b0f5abe86f548e28e1e387

--- a/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
@@ -9,7 +9,7 @@ metadata:
     policies.kyverno.io/subject: Pod, Annotation
     policies.kyverno.io/minversion: 1.3.0
     kyverno.io/kyverno-version: 1.6.0
-    kyverno.io/kubernetes-version: "1.22-1.23"
+    kyverno.io/kubernetes-version: "1.22-1.34"
     policies.kyverno.io/description: >-
       On supported hosts, the 'runtime/default' AppArmor profile is applied by default.
       The default policy should prevent overriding or disabling the policy, or restrict
@@ -34,3 +34,44 @@ spec:
           =(metadata):
             =(annotations):
               =(container.apparmor.security.beta.kubernetes.io/*): "runtime/default | localhost/*"
+    - name: app-armor-native-pod
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Specifying other AppArmor profiles is disallowed. The field
+          `spec.securityContext.appArmorProfile.type` if defined
+          must be set to `RuntimeDefault` or `Localhost`.
+        pattern:
+          =(spec):
+            =(securityContext):
+              =(appArmorProfile):
+                type: "RuntimeDefault | Localhost"
+    - name: app-armor-native-containers
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Specifying other AppArmor profiles is disallowed. The field
+          `spec.containers[*].securityContext.appArmorProfile.type` if defined
+          must be set to `RuntimeDefault` or `Localhost`.
+        pattern:
+          spec:
+            =(containers):
+            - =(securityContext):
+                =(appArmorProfile):
+                  type: "RuntimeDefault | Localhost"
+            =(initContainers):
+            - =(securityContext):
+                =(appArmorProfile):
+                  type: "RuntimeDefault | Localhost"
+            =(ephemeralContainers):
+            - =(securityContext):
+                =(appArmorProfile):
+                  type: "RuntimeDefault | Localhost"


### PR DESCRIPTION
## Related Issue(s)

#1413 

## Description

Kubernetes 1.30 introduced native AppArmor field in the seccomp, but up to Kubernetes 1.34 the apiserver was still setting legacy annotations on Pods from those fields.

Support those native fileds but check old annotations for backwards compatibility.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
