### PR TITLE
Upgrade CEL policies to apiVersion policies.kyverno.io/v1 (fix #1418)

### DIFF
--- a/best-practices-gpol/add-network-policy/.chainsaw-test/policy-ready.yaml
+++ b/best-practices-gpol/add-network-policy/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-networkpolicy

--- a/best-practices-gpol/add-network-policy/add-network-policy.yaml
+++ b/best-practices-gpol/add-network-policy/add-network-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-networkpolicy

--- a/best-practices-gpol/add-network-policy/artifacthub-pkg.yml
+++ b/best-practices-gpol/add-network-policy/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ readme: |
 annotations:
   kyverno/category: "Multi-Tenancy, EKS Best Practices"
   kyverno/subject: "NetworkPolicy"
-digest: c170f219c9faec11f53a8bf6b468d7df2b2ba730d12b08de755ac905e28c2886
+digest: 6f5a28179bf3f1974ed5bdd92d33ba6a44acad0c0f7c951b40edce4e7506fe86

--- a/best-practices-gpol/add-ns-quota/.chainsaw-test/policy-ready.yaml
+++ b/best-practices-gpol/add-ns-quota/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-ns-quota

--- a/best-practices-gpol/add-ns-quota/add-ns-quota.yaml
+++ b/best-practices-gpol/add-ns-quota/add-ns-quota.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-ns-quota

--- a/best-practices-gpol/add-ns-quota/artifacthub-pkg.yml
+++ b/best-practices-gpol/add-ns-quota/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ readme: |
 annotations:
   kyverno/category: "Multi-Tenancy, EKS Best Practices"
   kyverno/subject: "ResourceQuota, LimitRange"
-digest: f1af01b69545f9e0b4cac276f7da42c86db36ed9c7a99e158da53042f6d9b2ab
+digest: e4666c1253261b56f767b7b3c6a85c9a44d818c6b5ab06c82b9a4d34ba3b8439

--- a/best-practices-gpol/add-rolebinding/.chainsaw-test/policy-ready.yaml
+++ b/best-practices-gpol/add-rolebinding/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-rolebinding

--- a/best-practices-gpol/add-rolebinding/add-rolebinding.yaml
+++ b/best-practices-gpol/add-rolebinding/add-rolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: add-rolebinding

--- a/best-practices-gpol/add-rolebinding/artifacthub-pkg.yml
+++ b/best-practices-gpol/add-rolebinding/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Multi-Tenancy"
   kyverno/subject: "RoleBinding"
-digest: c6b906028599cfff6b870b699fffa0712dffdfc12af760f94f2310525cdffe4b
+digest: 2f4cb839e05831c06330e51bb01dce5384d795cec01cfa26b4e2bd28d0acd97d

--- a/best-practices-mpol/add-safe-to-evict/.chainsaw-test/policy-ready.yaml
+++ b/best-practices-mpol/add-safe-to-evict/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-safe-to-evict

--- a/best-practices-mpol/add-safe-to-evict/add-safe-to-evict.yaml
+++ b/best-practices-mpol/add-safe-to-evict/add-safe-to-evict.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-safe-to-evict

--- a/best-practices-mpol/add-safe-to-evict/artifacthub-pkg.yml
+++ b/best-practices-mpol/add-safe-to-evict/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Other"
   kyverno/subject: "Pod,Annotation"
-digest: 73ca07d90a4a25045d2a7e239ab01f37d4c19885eb78186ed899973523ddef81
+digest: 0de1d0360480debe3ec084d43603604904fcd00d0473b32f151685de9a42d585

--- a/castai-mpol/add-castai-removal-disabled/.chainsaw-test/policy-ready.yaml
+++ b/castai-mpol/add-castai-removal-disabled/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-castai-removal-disabled

--- a/castai-mpol/add-castai-removal-disabled/add-castai-removal-disabled.yaml
+++ b/castai-mpol/add-castai-removal-disabled/add-castai-removal-disabled.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-castai-removal-disabled

--- a/castai-mpol/add-castai-removal-disabled/artifacthub-pkg.yml
+++ b/castai-mpol/add-castai-removal-disabled/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "CAST AI"
   kyverno/kubernetesVersion: "1.25"
   kyverno/subject: "Job, CronJob"
-digest: 833eed6664314850866dd1bd27127964abf44a27e29f14d1c893ec5b1e3318c3
+digest: f99b18cd01db269ee882df718ab01688a966d6291157a955f8ed1d94e7158f5c

--- a/cleanup-dpol/cleanup-bare-pods/.chainsaw-test/chainsaw-step-02-assert-1.yaml
+++ b/cleanup-dpol/cleanup-bare-pods/.chainsaw-test/chainsaw-step-02-assert-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: DeletingPolicy
 metadata:
   name: clean-bare-pods

--- a/cleanup-dpol/cleanup-bare-pods/.chainsaw-test/chainsaw-test.yaml
+++ b/cleanup-dpol/cleanup-bare-pods/.chainsaw-test/chainsaw-test.yaml
@@ -21,7 +21,7 @@ spec:
             file: ../cleanup-bare-pods.yaml
         - patch:
             resource:
-              apiVersion: policies.kyverno.io/v1alpha1
+              apiVersion: policies.kyverno.io/v1
               kind: DeletingPolicy
               metadata:
                 name: clean-bare-pods

--- a/cleanup-dpol/cleanup-bare-pods/artifacthub-pkg.yml
+++ b/cleanup-dpol/cleanup-bare-pods/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.27"
   kyverno/subject: "Pod"
-digest: eade0e2be28c0a923eb6ff314bac7d36eac0b14d8d2b31f38e855d9e59a09e70
+digest: 6e8290dc7ad0b9816edfb5340ad3887db786358f96903b8fce83cee3d084cbdb

--- a/cleanup-dpol/cleanup-bare-pods/cleanup-bare-pods.yaml
+++ b/cleanup-dpol/cleanup-bare-pods/cleanup-bare-pods.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: DeletingPolicy
 metadata:
   name: clean-bare-pods

--- a/cleanup-dpol/cleanup-empty-replicasets/artifacthub-pkg.yml
+++ b/cleanup-dpol/cleanup-empty-replicasets/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.27"
   kyverno/subject: "ReplicaSet"
-digest: 2315c32d97bd451b2d797cc10007b9ec44de37b1725aacec15f013b18b2eb030
+digest: 03572f61994a58e2a2eadf12eb2366eb17d98e91761c008eada7315ae1f96314
 

--- a/cleanup-dpol/cleanup-empty-replicasets/cleanup-empty-replicasets.yaml
+++ b/cleanup-dpol/cleanup-empty-replicasets/cleanup-empty-replicasets.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: DeletingPolicy
 metadata:
   name: cleanup-empty-replicasets

--- a/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/policy-ready.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ambient-mode-namespace

--- a/istio-mpol/add-ambient-mode-namespace/add-ambient-mode-namespace.yaml
+++ b/istio-mpol/add-ambient-mode-namespace/add-ambient-mode-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ambient-mode-namespace

--- a/istio-mpol/add-ambient-mode-namespace/artifacthub-pkg.yml
+++ b/istio-mpol/add-ambient-mode-namespace/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Istio"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Namespace"
-digest: b80af3050cf024227d75a554d51c62922f7afe3ce54a0c8c0e6207f1945a4059
+digest: c504fc310ce2f292b9bb88359a73d19d5a490fce63296269020f324cd9987c65

--- a/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/policy-ready.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-sidecar-injection-namespace

--- a/istio-mpol/add-sidecar-injection-namespace/add-sidecar-injection-namespace.yaml
+++ b/istio-mpol/add-sidecar-injection-namespace/add-sidecar-injection-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-sidecar-injection-namespace

--- a/istio-mpol/add-sidecar-injection-namespace/artifacthub-pkg.yml
+++ b/istio-mpol/add-sidecar-injection-namespace/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Istio"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Namespace"
-digest: a7bbd0db4a12cd5b39126dd95d8a5cd055e5e5b43fe71be9ee4285fdc1660634
+digest: 3cfd9234f03a1a2764b25b2298f0717f09401424f6b031dd63338e810de98bce

--- a/karpenter-mpol/add-karpenter-daemonset-priority-class/.chainsaw-test/policy-ready.yaml
+++ b/karpenter-mpol/add-karpenter-daemonset-priority-class/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-daemonset-priority-class

--- a/karpenter-mpol/add-karpenter-daemonset-priority-class/add-karpenter-daemonset-priority-class.yaml
+++ b/karpenter-mpol/add-karpenter-daemonset-priority-class/add-karpenter-daemonset-priority-class.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-daemonset-priority-class

--- a/karpenter-mpol/add-karpenter-daemonset-priority-class/artifacthub-pkg.yml
+++ b/karpenter-mpol/add-karpenter-daemonset-priority-class/artifacthub-pkg.yml
@@ -27,4 +27,4 @@ annotations:
   kyverno/category: "Karpenter"
   kyverno/kubernetesVersion: "1.26"
   kyverno/subject: "DaemonSet"
-digest: c2eb8e9fbe5cb962c927d67b38c3d47064431f0657a5ceb20286c1f73dcedf3a
+digest: 226c36761ed4b7dfc68e24136a7ca08eb89879eda0ee7bd02de64ba5ab7aa06c

--- a/karpenter-mpol/add-karpenter-donot-evict/.chainsaw-test/policy-ready.yaml
+++ b/karpenter-mpol/add-karpenter-donot-evict/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-donot-evict

--- a/karpenter-mpol/add-karpenter-donot-evict/add-karpenter-donot-evict.yaml
+++ b/karpenter-mpol/add-karpenter-donot-evict/add-karpenter-donot-evict.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-donot-evict

--- a/karpenter-mpol/add-karpenter-donot-evict/artifacthub-pkg.yml
+++ b/karpenter-mpol/add-karpenter-donot-evict/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ annotations:
   kyverno/category: "Karpenter, EKS Best Practices"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: f5fc20488f075315c8273d735a18347cb9920e9cdf44f690d86d6101f17b9856
+digest: 0714fffc22f53a8bf8db8e04f078f01a45df2272f04cdeb610ee0ea9c8c12484

--- a/karpenter-mpol/add-karpenter-nodeselector/.chainsaw-test/policy-ready.yaml
+++ b/karpenter-mpol/add-karpenter-nodeselector/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-nodeselector

--- a/karpenter-mpol/add-karpenter-nodeselector/add-karpenter-nodeselector.yaml
+++ b/karpenter-mpol/add-karpenter-nodeselector/add-karpenter-nodeselector.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-karpenter-nodeselector

--- a/karpenter-mpol/add-karpenter-nodeselector/artifacthub-pkg.yml
+++ b/karpenter-mpol/add-karpenter-nodeselector/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ annotations:
   kyverno/category: "Karpenter, EKS Best Practices"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: 1bff51bef229f6439864e2634fb74890bd85044cd3dc582a33ce03b84d7e817e
+digest: 125956b9a91d612fa97ae3874d12e60e5e4e4beaa5b77f5d17f07038a09ed17d

--- a/karpenter-mpol/set-karpenter-non-cpu-limits/.chainsaw-test/policy-ready.yaml
+++ b/karpenter-mpol/set-karpenter-non-cpu-limits/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: set-karpenter-non-cpu-limits

--- a/karpenter-mpol/set-karpenter-non-cpu-limits/artifacthub-pkg.yml
+++ b/karpenter-mpol/set-karpenter-non-cpu-limits/artifacthub-pkg.yml
@@ -24,4 +24,4 @@ annotations:
   kyverno/category: "Karpenter, EKS Best Practices"
   kyverno/kubernetesVersion: "1.26"
   kyverno/subject: "Pod"
-digest: 2410b9ad110a6629b94a6a0ac700a70eb4666d3cb842a1d0c05a04cd5a1cb870
+digest: 06b6726a720c98465b5085e4a07fee31326e12f7d4ebf750b5018bb44113dd20

--- a/karpenter-mpol/set-karpenter-non-cpu-limits/set-karpenter-non-cpu-limits.yaml
+++ b/karpenter-mpol/set-karpenter-non-cpu-limits/set-karpenter-non-cpu-limits.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: set-karpenter-non-cpu-limits

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/.chainsaw-test/policy-ready.yaml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: enable-kubecost-continuous-rightsizing

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/artifacthub-pkg.yml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Kubecost"
   kyverno/subject: "Deployment,Annotation"
-digest: 56f74fa0dd6e6973b2582f3f4347f47d13ce575389206a859070bb8396d06265
+digest: 2ad78855dca0814057fbcecd81fe22d1480671bba54f5a2dee69a7eeae71c946

--- a/kubecost-mpol/enable-kubecost-continuous-rightsizing/enable-kubecost-continuous-rightsizing.yaml
+++ b/kubecost-mpol/enable-kubecost-continuous-rightsizing/enable-kubecost-continuous-rightsizing.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: enable-kubecost-continuous-rightsizing

--- a/kubevirt-gpol/add-services/.chainsaw-test/policy-ready.yaml
+++ b/kubevirt-gpol/add-services/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: k6t-add-services

--- a/kubevirt-gpol/add-services/add-services.yaml
+++ b/kubevirt-gpol/add-services/add-services.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: k6t-add-services

--- a/kubevirt-gpol/add-services/artifacthub-pkg.yml
+++ b/kubevirt-gpol/add-services/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "KubeVirt"
   kyverno/kubernetesVersion: "1.24-1.25"
   kyverno/subject: "VirtualMachineInstance"
-digest: e23e259806c44a4da9d1ee2b721a3e4ceab9e6fcfef3875a4de9bb74737c287e
+digest: 79fefc86c3bdcd497988bfa6f0072c3f6b40bbfc33f8b82fade64a297d85288f

--- a/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/policy-ready.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-linkerd-mesh-injection

--- a/linkerd-mpol/add-linkerd-mesh-injection/add-linkerd-mesh-injection.yaml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/add-linkerd-mesh-injection.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-linkerd-mesh-injection

--- a/linkerd-mpol/add-linkerd-mesh-injection/artifacthub-pkg.yml
+++ b/linkerd-mpol/add-linkerd-mesh-injection/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Linkerd"
   kyverno/subject: "Namespace, Annotation"
-digest: 5e18439276cc351a9ce37e69dfb184583bff718c95275733bd0a47c9608ec738
+digest: cc8fa860468e157de7c3adcd006c51fb94c7e2d65e395597f3222dd7027e5c2b

--- a/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/policy-ready.yaml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-linkerd-policy-annotation

--- a/linkerd-mpol/add-linkerd-policy-annotation/add-linkerd-policy-annotation.yaml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/add-linkerd-policy-annotation.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-linkerd-policy-annotation

--- a/linkerd-mpol/add-linkerd-policy-annotation/artifacthub-pkg.yml
+++ b/linkerd-mpol/add-linkerd-policy-annotation/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Linkerd"
   kyverno/subject: "Namespace,Annotation"
-digest: 1c258570deeff0c7f8354d5d5973168651942b01dc37b7ee9a573ca83048e191
+digest: aeb686e30efc4f414314139a3f3e0b8dca8ca4b80244989a81f62789917e26cd

--- a/other-gpol/create-default-pdb/.chainsaw-test/policy-ready.yaml
+++ b/other-gpol/create-default-pdb/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: create-default-pdb

--- a/other-gpol/create-default-pdb/artifacthub-pkg.yml
+++ b/other-gpol/create-default-pdb/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Deployment"
-digest: a594a9e2be639ca70dc76d12cc7d9a18c51fac91c65c62bbf3ab4c8b0faa7159
+digest: f70a948308e9b9cadecdb4e9e6be83b4f8e26706c946bffe7d30f9f8eba2cdae

--- a/other-gpol/create-default-pdb/create-default-pdb.yaml
+++ b/other-gpol/create-default-pdb/create-default-pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: GeneratingPolicy
 metadata:
   name: create-default-pdb

--- a/other-mpol/add-certificates-volume/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-certificates-volume/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-certificates-volume

--- a/other-mpol/add-certificates-volume/add-certificates-volume.yaml
+++ b/other-mpol/add-certificates-volume/add-certificates-volume.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-certificates-volume

--- a/other-mpol/add-certificates-volume/artifacthub-pkg.yml
+++ b/other-mpol/add-certificates-volume/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Sample"
   kyverno/kubernetesVersion: "1.21"
   kyverno/subject: "Pod,Volume"
-digest: bd9688d51cf92ff4b1ce1a0a986c8b7cc0961398cdf72abf2b66d3c25ab0768d
+digest: f5cca07fc3e8103f3d9bd2209590ab67b2868327f4c17994a551bff3650d1baa

--- a/other-mpol/add-default-resources/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-default-resources/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-default-resources

--- a/other-mpol/add-default-resources/add-default-resources.yaml
+++ b/other-mpol/add-default-resources/add-default-resources.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-default-resources

--- a/other-mpol/add-default-resources/artifacthub-pkg.yml
+++ b/other-mpol/add-default-resources/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.26"
   kyverno/subject: "Pod"
-digest: 35d86a06f3eb1be9aead32b6e0b35f9a0ff48edc113bc94381b781112a357e0d
+digest: c87cd9b7c96c1c07866a5b717660faae1e597c44cc90fb8e62ce66b9a61db65a

--- a/other-mpol/add-default-securitycontext/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-default-securitycontext/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-default-securitycontext

--- a/other-mpol/add-default-securitycontext/add-default-securitycontext.yaml
+++ b/other-mpol/add-default-securitycontext/add-default-securitycontext.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-default-securitycontext

--- a/other-mpol/add-default-securitycontext/artifacthub-pkg.yml
+++ b/other-mpol/add-default-securitycontext/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: 73c6adaa177f4950cd6cf00afd556551c0fff38d602d32788e2775233a092679
+digest: 93c3e81728eb56b18d4e3ae16291355d7fd686dc868a360813069e890442ef6b

--- a/other-mpol/add-emptydir-sizelimit/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-emptydir-sizelimit/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-emptydir-sizelimit

--- a/other-mpol/add-emptydir-sizelimit/add-emptydir-sizelimit.yaml
+++ b/other-mpol/add-emptydir-sizelimit/add-emptydir-sizelimit.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-emptydir-sizelimit

--- a/other-mpol/add-emptydir-sizelimit/artifacthub-pkg.yml
+++ b/other-mpol/add-emptydir-sizelimit/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Pod"
-digest: 7f393eaa65141f29e6ca3b971c48932b9fe2228145adcc366c2de49502952946
+digest: 277506ad06637cf779e9901d88aa6e4735c23d094caa2e96c00205d7a100a7b3

--- a/other-mpol/add-env-vars-from-cm/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-env-vars-from-cm/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-env-vars-from-cm

--- a/other-mpol/add-env-vars-from-cm/add-env-vars-from-cm.yaml
+++ b/other-mpol/add-env-vars-from-cm/add-env-vars-from-cm.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-env-vars-from-cm

--- a/other-mpol/add-env-vars-from-cm/artifacthub-pkg.yml
+++ b/other-mpol/add-env-vars-from-cm/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Other"
   kyverno/subject: "Pod"
-digest: 90c01134029d7da45334d6d4e78b7cd458be8458324727a0eb4251146838b42f
+digest: 4afc85f260e65937020bdba8c49d0f3852d57d0f893b6d68ae0078e6d0b5f940

--- a/other-mpol/add-image-as-env-var/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-image-as-env-var/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-image-as-env-var

--- a/other-mpol/add-image-as-env-var/add-image-as-env-var.yaml
+++ b/other-mpol/add-image-as-env-var/add-image-as-env-var.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-image-as-env-var

--- a/other-mpol/add-image-as-env-var/artifacthub-pkg.yml
+++ b/other-mpol/add-image-as-env-var/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.26"
   kyverno/subject: "Pod"
-digest: df743c49ab9d1f24faf08317bed6dd783bbcc0e006750c3940a1f1fd2450768a
+digest: bbbc788a6ec764c8f5418397b51bfeb7bc5ec9ea51d0a10d154d762f4f991d9f

--- a/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-imagepullsecrets-for-containers-and-initcontainers

--- a/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/add-imagepullsecrets-for-containers-and-initcontainers.yaml
+++ b/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/add-imagepullsecrets-for-containers-and-initcontainers.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-imagepullsecrets-for-containers-and-initcontainers

--- a/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/artifacthub-pkg.yml
+++ b/other-mpol/add-imagepullsecrets-for-containers-and-initcontainers/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Sample"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: 5878f35af01bd09413d4aa8325f73870b4b39b2d396a8bb6fc344c8ae38e340b
+digest: 8772324fc9a935e1894ae0422f3c803c6fcadfb3ca7d052781bf21d4453a3a73

--- a/other-mpol/add-imagepullsecrets/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-imagepullsecrets/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-imagepullsecrets

--- a/other-mpol/add-imagepullsecrets/add-imagepullsecrets.yaml
+++ b/other-mpol/add-imagepullsecrets/add-imagepullsecrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-imagepullsecrets

--- a/other-mpol/add-imagepullsecrets/artifacthub-pkg.yml
+++ b/other-mpol/add-imagepullsecrets/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: 441aad3476e40a018570686ab9cef9949cc7265453bed933aa508eacac80fe39
+digest: 4654a579719b501b48dc28b27ff7baa219aefa739f0a422341a604935758cb17

--- a/other-mpol/add-labels/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-labels/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-labels

--- a/other-mpol/add-labels/add-labels.yaml
+++ b/other-mpol/add-labels/add-labels.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-labels

--- a/other-mpol/add-labels/artifacthub-pkg.yml
+++ b/other-mpol/add-labels/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Label"
-digest: d2d4079fd3b52d1e3c8cfd7b103bd898bb0e5aa0c4e0bc3805385ba573dfe06e
+digest: 19e04a8d53c8e06b590db15b831461a1bab550e97534df798a97dc093a04da63

--- a/other-mpol/add-ndots/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-ndots/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ndots

--- a/other-mpol/add-ndots/add-ndots.yaml
+++ b/other-mpol/add-ndots/add-ndots.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ndots

--- a/other-mpol/add-ndots/artifacthub-pkg.yml
+++ b/other-mpol/add-ndots/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: 1895b3d2a428b11fdbf6e9163dc0de386cc085e3b5d7b8a42144e1fb1dc6ff9b
+digest: fe949eab93b15cdb47d1c8b6f53525bec8dcbbb8a864dae5e2d81d6e1491d560

--- a/other-mpol/add-nodeSelector/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-nodeSelector/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-nodeselector

--- a/other-mpol/add-nodeSelector/add-nodeSelector.yaml
+++ b/other-mpol/add-nodeSelector/add-nodeSelector.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-nodeselector

--- a/other-mpol/add-nodeSelector/artifacthub-pkg.yml
+++ b/other-mpol/add-nodeSelector/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: e6cb8a951c80b1902bfce3a2d1d6ff0c235818f56082dbbd03a0d7f9f1545c1c
+digest: 08c4006cd0c9bab634876c02419eb955f2ccd900b6f4e08269f8a7e0954f8eb8

--- a/other-mpol/add-pod-priorityclassname/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-pod-priorityclassname/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-pod-priorityclassname

--- a/other-mpol/add-pod-priorityclassname/add-pod-priorityclassname.yaml
+++ b/other-mpol/add-pod-priorityclassname/add-pod-priorityclassname.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-pod-priorityclassname

--- a/other-mpol/add-pod-priorityclassname/artifacthub-pkg.yml
+++ b/other-mpol/add-pod-priorityclassname/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: d5b4dd3d4f5e9a9d8e446c50e32048d637547a78d0fb9f5056df4a9f2f446c30
+digest: 840ec50ab0efb0d010aa2f1cc0a4a84a343d03163e97d472df9af20f6d8c73fc

--- a/other-mpol/add-pod-proxies/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-pod-proxies/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-pod-proxies

--- a/other-mpol/add-pod-proxies/add-pod-proxies.yaml
+++ b/other-mpol/add-pod-proxies/add-pod-proxies.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-pod-proxies

--- a/other-mpol/add-pod-proxies/artifacthub-pkg.yml
+++ b/other-mpol/add-pod-proxies/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: b9b23ec53e4573af79103483e484761a9da3ccf5a18dc1937f763b030d865aa6
+digest: 378cbe0d9fa1e7091ac8f76b53c2241f59791980152424b40e03a01d955bd3ef

--- a/other-mpol/add-tolerations/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-tolerations/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-tolerations

--- a/other-mpol/add-tolerations/add-tolerations.yaml
+++ b/other-mpol/add-tolerations/add-tolerations.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-tolerations

--- a/other-mpol/add-tolerations/artifacthub-pkg.yml
+++ b/other-mpol/add-tolerations/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: f54d4177b971c128f98e9a9cd9ca524e49a88ac66cbde0c7e9fd997210e09a7a
+digest: 86f57cf47ae6f7bb44c4a4f3df3e6a3e6e122db3e45fd7d7e192e41459e12ed0

--- a/other-mpol/add-ttl-jobs/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-ttl-jobs/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ttl-jobs

--- a/other-mpol/add-ttl-jobs/add-ttl-jobs.yaml
+++ b/other-mpol/add-ttl-jobs/add-ttl-jobs.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-ttl-jobs

--- a/other-mpol/add-ttl-jobs/artifacthub-pkg.yml
+++ b/other-mpol/add-ttl-jobs/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Job"
-digest: 37dc10c3310058d7e02fa6a0bb2f2050a5bdd072871dcc9e1e703cca1dc9a482
+digest: b3a6e6599b5da798662cbed44b09ead6abc5aee6515333dce792239747e52ba9

--- a/other-mpol/add-volume-deployment/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/add-volume-deployment/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-volume

--- a/other-mpol/add-volume-deployment/add-volume-deployment.yaml
+++ b/other-mpol/add-volume-deployment/add-volume-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-volume

--- a/other-mpol/add-volume-deployment/artifacthub-pkg.yml
+++ b/other-mpol/add-volume-deployment/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Deployment, Volume"
-digest: 25bf1e7dc76ca86d4f0904b8a0a86c5c71d8bc8b4e8704d7c735d302fa98d475
+digest: f680826e48743266e64fc1c0bef0274579d746e4afd78ec876f0f01851ac63c1

--- a/other-mpol/always-pull-images/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/always-pull-images/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: always-pull-images

--- a/other-mpol/always-pull-images/always-pull-images.yaml
+++ b/other-mpol/always-pull-images/always-pull-images.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: always-pull-images

--- a/other-mpol/always-pull-images/artifacthub-pkg.yml
+++ b/other-mpol/always-pull-images/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: a83a12824898a83cc165e860cf8cc15240ff0720e876789b9cdb2a076a7eb86e
+digest: 7502ca2cf2fec82a4767b0b86779b95da8111c8775d26cb6ba6e66c71b4a9516

--- a/other-mpol/annotate-base-images/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/annotate-base-images/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: annotate-base-images

--- a/other-mpol/annotate-base-images/annotate-base-images.yaml
+++ b/other-mpol/annotate-base-images/annotate-base-images.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: annotate-base-images

--- a/other-mpol/annotate-base-images/artifacthub-pkg.yml
+++ b/other-mpol/annotate-base-images/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: c3872584d816f86e79e78a4ed25c58c78a1e5d79589296aa708b9f346d0ee017
+digest: 49b86db41917a3ec8cb70948ba94f7788047e2cb3e237389d586add905525ef4

--- a/other-mpol/apply-pss-restricted-profile/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/apply-pss-restricted-profile/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: apply-pss-restricted-profile

--- a/other-mpol/apply-pss-restricted-profile/apply-pss-restricted-profile.yaml
+++ b/other-mpol/apply-pss-restricted-profile/apply-pss-restricted-profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: apply-pss-restricted-profile

--- a/other-mpol/apply-pss-restricted-profile/artifacthub-pkg.yml
+++ b/other-mpol/apply-pss-restricted-profile/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: 5f389ef44d59a81ba076b360a23ba1908e5601fbe1942ba96e3f07540c15517a
+digest: ac333306cfea3e9552728c4c9e7f1c03ff45054a640c60bbe859b23d744b7685

--- a/other-mpol/disable-automountserviceaccounttoken/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/disable-automountserviceaccounttoken/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: disable-automountserviceaccounttoken

--- a/other-mpol/disable-automountserviceaccounttoken/artifacthub-pkg.yml
+++ b/other-mpol/disable-automountserviceaccounttoken/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ annotations:
   kyverno/category: "Other, EKS Best Practices"
   kyverno/kubernetesVersion: "1.21"
   kyverno/subject: "ServiceAccount"
-digest: b5b5288d761727769ef634826a6239592e0c328d87b9ef841d2abeff9579a92e
+digest: 55106f156107ec5a92282d57882b0da46257159517d90a0b1751c21a2c7efcb0

--- a/other-mpol/disable-automountserviceaccounttoken/disable-automountserviceaccounttoken.yaml
+++ b/other-mpol/disable-automountserviceaccounttoken/disable-automountserviceaccounttoken.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: disable-automountserviceaccounttoken

--- a/other-mpol/disable-service-discovery/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/disable-service-discovery/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: disable-service-discovery

--- a/other-mpol/disable-service-discovery/artifacthub-pkg.yml
+++ b/other-mpol/disable-service-discovery/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ annotations:
   kyverno/category: "Other, EKS Best Practices"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Pod"
-digest: 8481b47386e837c0007e49dc2541c70a8a6deb1cb921d1c9f716105462ce62bd
+digest: 36f55b45e4ef7585307a854a0c4627a87c59ea1a2bb10375215674a13c7c427e

--- a/other-mpol/disable-service-discovery/disable-service-discovery.yaml
+++ b/other-mpol/disable-service-discovery/disable-service-discovery.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: disable-service-discovery

--- a/other-mpol/inject-sidecar-deployment/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/inject-sidecar-deployment/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: inject-sidecar

--- a/other-mpol/inject-sidecar-deployment/artifacthub-pkg.yml
+++ b/other-mpol/inject-sidecar-deployment/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod,Volume"
-digest: 39e2426329ef4bf0ff15c0b06857ad107b16a7590c2c1149c29cef155da730f2
+digest: 57c24e4314790b9f2b46fbd2f26fdfe13cf855008e28d0ad708c346f1bcb95de

--- a/other-mpol/inject-sidecar-deployment/inject-sidecar-deployment.yaml
+++ b/other-mpol/inject-sidecar-deployment/inject-sidecar-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: inject-sidecar

--- a/other-mpol/label-existing-namespaces/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/label-existing-namespaces/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: label-existing-namespaces

--- a/other-mpol/label-existing-namespaces/artifacthub-pkg.yml
+++ b/other-mpol/label-existing-namespaces/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Namespace"
-digest: 67e0d2cbf3ea0f64e06c48c506387d554b84c3be1a21a495a1fdd374c9230ac6
+digest: 417dbabbfae37530d08a02903c8d2b6e1c76a68b5d250b9d22946d33e22456f4

--- a/other-mpol/label-existing-namespaces/label-existing-namespaces.yaml
+++ b/other-mpol/label-existing-namespaces/label-existing-namespaces.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: label-existing-namespaces

--- a/other-mpol/label-nodes-cri/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/label-nodes-cri/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: label-nodes-cri

--- a/other-mpol/label-nodes-cri/artifacthub-pkg.yml
+++ b/other-mpol/label-nodes-cri/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Node, Label"
-digest: 0f7032f03cd968d37ef1525c52574f77f4278477023de26537f86855311b45b6
+digest: 7c98a6ae27d0611f0b2d6e34f2163bbd1713416479e62e2d04c8aebcf65e72bb

--- a/other-mpol/label-nodes-cri/label-nodes-cri.yaml
+++ b/other-mpol/label-nodes-cri/label-nodes-cri.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: label-nodes-cri

--- a/other-mpol/mitigate-log4shell/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/mitigate-log4shell/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: log4shell-mitigation

--- a/other-mpol/mitigate-log4shell/artifacthub-pkg.yml
+++ b/other-mpol/mitigate-log4shell/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Sample"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: b3b4d783c4460b064cacf6c32dcd5ec8c495db2c2955ef7bdcb1d2ae59ee0d1b
+digest: c75fbadf4da083587cf298885ad097c4f1fb12b9a36f731fe1fb0485f98e9bac

--- a/other-mpol/mitigate-log4shell/mitigate-log4shell.yaml
+++ b/other-mpol/mitigate-log4shell/mitigate-log4shell.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: log4shell-mitigation

--- a/other-mpol/mutate-large-termination-gps/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/mutate-large-termination-gps/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: mutate-termination-grace-period-seconds

--- a/other-mpol/mutate-large-termination-gps/artifacthub-pkg.yml
+++ b/other-mpol/mutate-large-termination-gps/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Sample"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: 3ed82366981cd53da29d59884997b3b2357d2516b9029255f4f0b220333440dd
+digest: 9d524faa70c2d8ebf39f2a73118b04cb34bd9d47b95449a5022be4b48bb559f1

--- a/other-mpol/mutate-large-termination-gps/mutate-large-termination-gps.yaml
+++ b/other-mpol/mutate-large-termination-gps/mutate-large-termination-gps.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: mutate-termination-grace-period-seconds

--- a/other-mpol/prepend-image-registry/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/prepend-image-registry/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: prepend-registry

--- a/other-mpol/prepend-image-registry/artifacthub-pkg.yml
+++ b/other-mpol/prepend-image-registry/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.21"
   kyverno/subject: "Pod"
-digest: 98be245cfcca9dcbf59b778067f79956e09570e59aa6f7eb403c79c895eb8f58
+digest: 0ad92f18a8a08ba054639bd225a8f49a3cf7cb80573abfd54b93559da8e64d04

--- a/other-mpol/prepend-image-registry/prepend-image-registry.yaml
+++ b/other-mpol/prepend-image-registry/prepend-image-registry.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: prepend-registry

--- a/other-mpol/remove-hostpath-volumes/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/remove-hostpath-volumes/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: remove-hostpath-volumes

--- a/other-mpol/remove-hostpath-volumes/artifacthub-pkg.yml
+++ b/other-mpol/remove-hostpath-volumes/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.25"
   kyverno/subject: "Pod,Volume"
-digest: 9f648bb5ea45a2342e7e93f06f655968bb8b7292b16e1839821f99697e3493fe
+digest: d8427f9cd2da2bf7f73422abd763e3a1b2bdee8cfe20bb82b68cf3b2e1f65f03

--- a/other-mpol/remove-hostpath-volumes/remove-hostpath-volumes.yaml
+++ b/other-mpol/remove-hostpath-volumes/remove-hostpath-volumes.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: remove-hostpath-volumes

--- a/other-mpol/replace-image-registry/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/replace-image-registry/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: replace-image-registry

--- a/other-mpol/replace-image-registry/artifacthub-pkg.yml
+++ b/other-mpol/replace-image-registry/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Sample"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: a7b24b4fde1fbde486a5658f6cb17bf1d4e4d1c9420fc9801aceec39a66a6782
+digest: 3a55b7c363950109cbde675193da2b56cda7f9e339bcd591a539b1392c2f884b

--- a/other-mpol/replace-image-registry/replace-image-registry.yaml
+++ b/other-mpol/replace-image-registry/replace-image-registry.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: replace-image-registry

--- a/other-mpol/replace-ingress-hosts/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/replace-ingress-hosts/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: replace-ingress-hosts

--- a/other-mpol/replace-ingress-hosts/artifacthub-pkg.yml
+++ b/other-mpol/replace-ingress-hosts/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Ingress"
-digest: 3e0ce0322eb5b494d719a96cfd57120a18e3e9c1ed6e1e391029472f14060f98
+digest: 1b4488ab0902e4f55335f04913744b2120e22f222a959841ef8ed6717e23309f

--- a/other-mpol/replace-ingress-hosts/replace-ingress-hosts.yaml
+++ b/other-mpol/replace-ingress-hosts/replace-ingress-hosts.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: replace-ingress-hosts

--- a/other-mpol/resolve-image-to-digest/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/resolve-image-to-digest/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: resolve-image-to-digest

--- a/other-mpol/resolve-image-to-digest/artifacthub-pkg.yml
+++ b/other-mpol/resolve-image-to-digest/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: 312dd9f10b075d799492d84ec94d53e506aad086792d01102856d9876f7aea9a
+digest: 04c6f841a81597f63a6c3592e93b6302a442da778b0fed525a8e9ecf8f123256

--- a/other-mpol/resolve-image-to-digest/resolve-image-to-digest.yaml
+++ b/other-mpol/resolve-image-to-digest/resolve-image-to-digest.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: resolve-image-to-digest

--- a/other-mpol/spread-pods-across-topology/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/spread-pods-across-topology/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: spread-pods

--- a/other-mpol/spread-pods-across-topology/artifacthub-pkg.yml
+++ b/other-mpol/spread-pods-across-topology/artifacthub-pkg.yml
@@ -18,4 +18,4 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Deployment, Pod"
-digest: 6b1d9c7c56e3bc9cfea43987abce610875f94fb5c04bedcb9b05d69f829d502b
+digest: f8ee910385111516ad84b2de53f6f57f0f9efa871942f78989cdd46e4ce600fd

--- a/other-mpol/spread-pods-across-topology/spread-pods-across-topology.yaml
+++ b/other-mpol/spread-pods-across-topology/spread-pods-across-topology.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: spread-pods

--- a/other-mpol/update-image-tag/.chainsaw-test/policy-ready.yaml
+++ b/other-mpol/update-image-tag/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: update-image-tag

--- a/other-mpol/update-image-tag/artifacthub-pkg.yml
+++ b/other-mpol/update-image-tag/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Deployment"
-digest: d102b19ea287c4f9e23bd60b96d74da0f038c81ae5684a55692ef7e723b34fdc
+digest: f80c4faad49897526b3ac2844463a8c38d98475974e85e6bd16c86d082e5ecc7

--- a/other-mpol/update-image-tag/update-image-tag.yaml
+++ b/other-mpol/update-image-tag/update-image-tag.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: update-image-tag

--- a/other-vpol/advanced-restrict-image-registries/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/advanced-restrict-image-registries/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../advanced-restrict-image-registries.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: advanced-restrict-image-registries

--- a/other-vpol/advanced-restrict-image-registries/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/advanced-restrict-image-registries/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: advanced-restrict-image-registries

--- a/other-vpol/advanced-restrict-image-registries/advanced-restrict-image-registries.yaml
+++ b/other-vpol/advanced-restrict-image-registries/advanced-restrict-image-registries.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: advanced-restrict-image-registries

--- a/other-vpol/advanced-restrict-image-registries/artifacthub-pkg.yml
+++ b/other-vpol/advanced-restrict-image-registries/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 2b57470e59f3e630311cf189035ae37df3e1361588d0890eecc19ef6f1f601cb
+digest: 4b12bcf412d728bc47fdeae5bf9a48baff68db66d628e40f3c16ce5a6c6246eb
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/allowed-annotations/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/allowed-annotations/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../allowed-annotations.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: allowed-annotations

--- a/other-vpol/allowed-annotations/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/allowed-annotations/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-annotations

--- a/other-vpol/allowed-annotations/allowed-annotations.yaml
+++ b/other-vpol/allowed-annotations/allowed-annotations.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-annotations

--- a/other-vpol/allowed-annotations/artifacthub-pkg.yml
+++ b/other-vpol/allowed-annotations/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod, Annotation"
-digest: 6c8485f93f339ad4cd78855d375cb89a163275e54436f48c7cbf89f0907b4f94
+digest: d825a11ee9f5a836b21c93254753c12fcf123af89cf2233e5defafb7d77f060c
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/allowed-base-images/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other-vpol/allowed-base-images/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-base-images

--- a/other-vpol/allowed-base-images/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/allowed-base-images/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../allowed-base-images.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: allowed-base-images

--- a/other-vpol/allowed-base-images/allowed-base-images.yaml
+++ b/other-vpol/allowed-base-images/allowed-base-images.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-base-images

--- a/other-vpol/allowed-base-images/artifacthub-pkg.yml
+++ b/other-vpol/allowed-base-images/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: 6447e7042d01ecf4221b36bf16ee9be7882475dc9eb15060f0301eeac32d915e
+digest: 8cc10adafec22a1155d8b755deadb35b4b15313f2babfb51a8a0adada46bc889
 createdAt: "2025-11-24T17:13:08Z"

--- a/other-vpol/allowed-image-repos/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other-vpol/allowed-image-repos/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-image-repos

--- a/other-vpol/allowed-image-repos/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/allowed-image-repos/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../allowed-image-repos.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: allowed-image-repos

--- a/other-vpol/allowed-image-repos/allowed-image-repos.yaml
+++ b/other-vpol/allowed-image-repos/allowed-image-repos.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-image-repos

--- a/other-vpol/allowed-image-repos/artifacthub-pkg.yml
+++ b/other-vpol/allowed-image-repos/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Pod"
-digest: b8ac9d48ead88ed285c1c6f6972fee5c68361ccb6eb888ccea9722aaaddbc5d9
+digest: 9a78a1b1e0869eeb3fd6a72a0aab27f79613c638e384ad5ff68ce8e8815e74f1
 createdAt: "2025-11-24T17:13:07Z"

--- a/other-vpol/allowed-pod-priorities/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/allowed-pod-priorities/.chainsaw-test/chainsaw-test.yaml
@@ -20,7 +20,7 @@ spec:
         file: ../allowed-pod-priorities.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: allowed-podpriorities

--- a/other-vpol/allowed-pod-priorities/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/allowed-pod-priorities/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-podpriorities

--- a/other-vpol/allowed-pod-priorities/allowed-pod-priorities.yaml
+++ b/other-vpol/allowed-pod-priorities/allowed-pod-priorities.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: allowed-podpriorities

--- a/other-vpol/allowed-pod-priorities/artifacthub-pkg.yml
+++ b/other-vpol/allowed-pod-priorities/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 67324ef06e08c4ca43d9700b2de674833ad3489510dbb6cf186b2061a5762a1f
+digest: db61d3478ca9b1dfdb46dda64a848eb090c365afc38633369b817808776bf337
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/block-cluster-admin-from-ns/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-cluster-admin-from-ns/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-cluster-admin-from-ns

--- a/other-vpol/block-cluster-admin-from-ns/artifacthub-pkg.yml
+++ b/other-vpol/block-cluster-admin-from-ns/artifacthub-pkg.yml
@@ -21,4 +21,4 @@ annotations:
   kyverno/category: Other
   kyverno/subject: Namespace, ClusterRole, User
   kyverno/version: "1.15.0"
-digest: f59b39ec27931b28e479f3525f42dc6d6014bc928fed77784113b48dc966e1e0
+digest: 680e4088cb17da417b97ef9727ca98068c6112a0518b6f346218593755f948e6

--- a/other-vpol/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
+++ b/other-vpol/block-cluster-admin-from-ns/block-cluster-admin-from-ns.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-cluster-admin-from-ns

--- a/other-vpol/block-ephemeral-containers/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/block-ephemeral-containers/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../block-ephemeral-containers.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: block-ephemeral-containers

--- a/other-vpol/block-ephemeral-containers/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-ephemeral-containers/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-ephemeral-containers

--- a/other-vpol/block-ephemeral-containers/artifacthub-pkg.yml
+++ b/other-vpol/block-ephemeral-containers/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 20ba872d7f176b42b8d4f04ed4f663bdb80d75efaa14cd6ed53855181b63acc3
+digest: 01563100c555e1bdf4c6e8d12d6c8bfd087240d67b031d162d5bad5c33997e11
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/block-ephemeral-containers/block-ephemeral-containers.yaml
+++ b/other-vpol/block-ephemeral-containers/block-ephemeral-containers.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-ephemeral-containers

--- a/other-vpol/block-images-with-volumes/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/block-images-with-volumes/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../block-images-with-volumes.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: block-images-with-volumes

--- a/other-vpol/block-images-with-volumes/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-images-with-volumes/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-images-with-volumes

--- a/other-vpol/block-images-with-volumes/artifacthub-pkg.yml
+++ b/other-vpol/block-images-with-volumes/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ annotations:
   kyverno/category: "Other in ValidatingPolicy"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: 9de23fe2ece640f3a66fa5c62304cf15917d1168692bd3d4ae185879917fb1c3
+digest: d0d42d751708f673c579a9e95f05a8c03264125024078afe1e6b82f479eeddd5

--- a/other-vpol/block-images-with-volumes/block-images-with-volumes.yaml
+++ b/other-vpol/block-images-with-volumes/block-images-with-volumes.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-images-with-volumes

--- a/other-vpol/block-kubectl-cp/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-kubectl-cp/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-kubectl-cp

--- a/other-vpol/block-kubectl-cp/artifacthub-pkg.yml
+++ b/other-vpol/block-kubectl-cp/artifacthub-pkg.yml
@@ -20,5 +20,5 @@ annotations:
   kyverno/category: "Sample"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 01a721b4a1ef2584aef21bcfbafa392ec3b6181054b331f11e570b146a0a9c6d
+digest: ce0931f91c6a0f693e097d1dbec0284b4484510a7f2827433ffa8f3a42b85ed8
 createdAt: "2025-12-02T13:59:47Z"

--- a/other-vpol/block-kubectl-cp/block-kubectl-cp.yaml
+++ b/other-vpol/block-kubectl-cp/block-kubectl-cp.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-kubectl-cp

--- a/other-vpol/block-large-images/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/block-large-images/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../block-large-images.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: block-large-images

--- a/other-vpol/block-large-images/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-large-images/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-large-images

--- a/other-vpol/block-large-images/artifacthub-pkg.yml
+++ b/other-vpol/block-large-images/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Other in ValidatingPolicy"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: 5158f76ea09ff1677b46b8655a22045b106ad4f8715e87b3d0998af2589f6290
+digest: 46b7b3dcdec260d5a4ee3a6cebc79bce010776267ae35b619ac20b46baba37a3
 createdAt: "2025-11-27T18:39:22Z"

--- a/other-vpol/block-large-images/block-large-images.yaml
+++ b/other-vpol/block-large-images/block-large-images.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-large-images

--- a/other-vpol/block-pod-exec-by-namespace-label/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-namespace-label/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-namespace-label

--- a/other-vpol/block-pod-exec-by-namespace-label/artifacthub-pkg.yml
+++ b/other-vpol/block-pod-exec-by-namespace-label/artifacthub-pkg.yml
@@ -18,5 +18,5 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: d9803a950735297992c70a861003ec6dfd659dd0660e4a60b908734ed4f38eeb
+digest: 702da642b6761da323f2ee2cb2ef2a498d7f7ac16490b76fa27e7c6ebdd33e70
 createdAt: "2025-12-10T14:21:28Z"

--- a/other-vpol/block-pod-exec-by-namespace-label/block-pod-exec-by-namespace-label.yaml
+++ b/other-vpol/block-pod-exec-by-namespace-label/block-pod-exec-by-namespace-label.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-namespace-label

--- a/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-namespace/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-namespace-name

--- a/other-vpol/block-pod-exec-by-namespace/artifacthub-pkg.yml
+++ b/other-vpol/block-pod-exec-by-namespace/artifacthub-pkg.yml
@@ -18,5 +18,5 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: 87239d5197cdad615045ecaa971112fce7b26f386474a7b766c084386f861488
+digest: 5cd42000c2ed82936cea9e7d3c8145518bed05588eb6ce1dac10813ee467895c
 createdAt: "2025-12-02T13:59:47Z"

--- a/other-vpol/block-pod-exec-by-namespace/block-pod-exec-by-namespace.yaml
+++ b/other-vpol/block-pod-exec-by-namespace/block-pod-exec-by-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-namespace-name

--- a/other-vpol/block-pod-exec-by-pod-and-container/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-pod-and-container/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-and-container

--- a/other-vpol/block-pod-exec-by-pod-and-container/artifacthub-pkg.yml
+++ b/other-vpol/block-pod-exec-by-pod-and-container/artifacthub-pkg.yml
@@ -18,5 +18,5 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: 79b43725be3bb6bde87bb21331dcae4a1af6c012906d1bc71b05515e8084136b
+digest: aa78d1ff6e6faa02c1a714026dcd574b75719eb1728b264c69d2b6587bc584ef
 createdAt: "2025-12-10T14:21:28Z"

--- a/other-vpol/block-pod-exec-by-pod-and-container/block-pod-exec-by-pod-and-container.yaml
+++ b/other-vpol/block-pod-exec-by-pod-and-container/block-pod-exec-by-pod-and-container.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-and-container

--- a/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-pod-label/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-label

--- a/other-vpol/block-pod-exec-by-pod-label/artifacthub-pkg.yml
+++ b/other-vpol/block-pod-exec-by-pod-label/artifacthub-pkg.yml
@@ -18,5 +18,5 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: 6a600b7b9ddb201b36a4911443642fa0c4158499678c17d08bf285695a3c42b7
+digest: dc906c403c6b337f62f41a4d15491c25c729dfe55b3edfe2d32962d41c075baa
 createdAt: "2025-12-02T13:59:46Z"

--- a/other-vpol/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.yaml
+++ b/other-vpol/block-pod-exec-by-pod-label/block-pod-exec-by-pod-label.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-label

--- a/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-pod-exec-by-pod-name/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-name

--- a/other-vpol/block-pod-exec-by-pod-name/artifacthub-pkg.yml
+++ b/other-vpol/block-pod-exec-by-pod-name/artifacthub-pkg.yml
@@ -18,5 +18,5 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Pod"
-digest: e4648f22588be1ffb8b9c966956f4000ef39307a469ec65161a167c7afb6d463
+digest: 3ee0505be89fed45b6dc9630184bb0e251e93cd5db83f677e6c191150281518c
 createdAt: "2025-12-02T13:59:47Z"

--- a/other-vpol/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.yaml
+++ b/other-vpol/block-pod-exec-by-pod-name/block-pod-exec-by-pod-name.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-exec-by-pod-name

--- a/other-vpol/block-updates-deletes/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/block-updates-deletes/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-updates-deletes

--- a/other-vpol/block-updates-deletes/artifacthub-pkg.yml
+++ b/other-vpol/block-updates-deletes/artifacthub-pkg.yml
@@ -18,5 +18,5 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "RBAC"
-digest: df87b8de8c76c4b70e6b67f628c2491f65f36c9806a76d19c2fa7aed975be814
+digest: 2e18d919329a98692cb62b829f372d16b34ce0d647fc7e665eda74950219214a
 createdAt: "2025-12-10T14:28:58Z"

--- a/other-vpol/block-updates-deletes/block-updates-deletes.yaml
+++ b/other-vpol/block-updates-deletes/block-updates-deletes.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: block-updates-deletes

--- a/other-vpol/check-env-vars/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-env-vars/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../check-env-vars.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-env-vars

--- a/other-vpol/check-env-vars/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-env-vars/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-env-vars

--- a/other-vpol/check-env-vars/artifacthub-pkg.yml
+++ b/other-vpol/check-env-vars/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: f0b3e03403ba19143270b9af25ab76f33446f3476e88a54f0b4cdba3d322da61
+digest: 0663cb0725030bc24afd18507228fc722af7da834543360b8d077a6c90c2e97e
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/check-env-vars/check-env-vars.yaml
+++ b/other-vpol/check-env-vars/check-env-vars.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-env-vars

--- a/other-vpol/check-hpa-exists/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-hpa-exists/.chainsaw-test/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
         file: ../check-hpa-exists.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-hpa-exists

--- a/other-vpol/check-hpa-exists/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-hpa-exists/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-hpa-exists

--- a/other-vpol/check-hpa-exists/artifacthub-pkg.yml
+++ b/other-vpol/check-hpa-exists/artifacthub-pkg.yml
@@ -18,5 +18,5 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Deployment,ReplicaSet,StatefulSet,DaemonSet"
-digest: 875f1e82e9add601e313d8c59e8d687eeffb6f5d58a8b49959dc2b61927bc792
+digest: ec7f50f0dc04c70d4d4e1e07d8d91fb586a6dacb7dd206967b32a2c2bca74019
 createdAt: "2025-12-12T14:35:08Z"

--- a/other-vpol/check-hpa-exists/check-hpa-exists.yaml
+++ b/other-vpol/check-hpa-exists/check-hpa-exists.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-hpa-exists

--- a/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/.chainsaw-test/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
     try:
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-ingress-nginx-controller-version-and-annotation-policy

--- a/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-ingress-nginx-controller-version-and-annotation-policy

--- a/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/artifacthub-pkg.yml
+++ b/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/artifacthub-pkg.yml
@@ -18,5 +18,5 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Deployment,ReplicaSet,StatefulSet,DaemonSet,Ingress"
-digest: 8b02c387abaf2942ec87dbd0ec5b826495ac60aac66e9dd8c670fb1262ae647a
+digest: 9f99193453c0817542755cdee6396bf94c1d660c0b06e4aeefe4ac0b27c15b87
 createdAt: "2025-12-12T14:35:08Z"

--- a/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/check-ingress-nginx-controller-version-and-annotation-policy.yaml
+++ b/other-vpol/check-ingress-nginx-controller-version-and-annotation-policy/check-ingress-nginx-controller-version-and-annotation-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-ingress-nginx-controller-version-and-annotation-policy

--- a/other-vpol/check-node-for-cve-2022-0185/artifacthub-pkg.yml
+++ b/other-vpol/check-node-for-cve-2022-0185/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Node"
-digest: 3916cd2dcab226ace12583eef58eb4399c4ac9ae9c12dc1eb24f48c4825421e5
+digest: 96253ee4fbd0986c6fc0107b697cbd1e01611a14307163597797c13f246df652
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.yaml
+++ b/other-vpol/check-node-for-cve-2022-0185/check-node-for-cve-2022-0185.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-kernel

--- a/other-vpol/check-nvidia-gpu/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-nvidia-gpu/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../check-nvidia-gpu.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-nvidia-gpus

--- a/other-vpol/check-nvidia-gpu/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-nvidia-gpu/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-nvidia-gpus

--- a/other-vpol/check-nvidia-gpu/artifacthub-pkg.yml
+++ b/other-vpol/check-nvidia-gpu/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "Pod"
-digest: 34578aa14437f9793084b896267fca5c2456aa7bc69ce2f38fdd5204f604901b
+digest: 122ea380074c42fcc3016036f833b65b4995392cabb1a63ae64f909fa727ef40
 createdAt: "2025-12-15T12:37:33Z"

--- a/other-vpol/check-nvidia-gpu/check-nvidia-gpu.yaml
+++ b/other-vpol/check-nvidia-gpu/check-nvidia-gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-nvidia-gpus

--- a/other-vpol/check-serviceaccount-secrets/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-serviceaccount-secrets/.chainsaw-test/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
         file :  ../check-serviceaccount-secrets.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-serviceaccount-secrets
@@ -37,7 +37,7 @@ spec:
     try:
     - delete:
         ref:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           name: check-serviceaccount-secrets
 

--- a/other-vpol/check-serviceaccount-secrets/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-serviceaccount-secrets/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-serviceaccount-secrets

--- a/other-vpol/check-serviceaccount-secrets/check-serviceaccount-secrets.yaml
+++ b/other-vpol/check-serviceaccount-secrets/check-serviceaccount-secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-serviceaccount-secrets

--- a/other-vpol/check-serviceaccount/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-serviceaccount/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../check-serviceaccount.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-sa

--- a/other-vpol/check-serviceaccount/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-serviceaccount/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-sa

--- a/other-vpol/check-serviceaccount/artifacthub-pkg.yml
+++ b/other-vpol/check-serviceaccount/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Sample"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod,ServiceAccount"
-digest: ffe728ccb86fcd7bcb1470bc42481e86cd7e30076e4987061265f15730f74555
+digest: 5e04638790d85da87c3f4c1962ec37e974ec321f4e439b9e0d6b220c0ac91f4a
 createdAt: "2025-12-15T12:37:33Z"

--- a/other-vpol/check-serviceaccount/check-serviceaccount.yaml
+++ b/other-vpol/check-serviceaccount/check-serviceaccount.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-sa

--- a/other-vpol/check-subjectaccessreview/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/check-subjectaccessreview/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../check-subjectaccessreview.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: check-subjectaccessreview

--- a/other-vpol/check-subjectaccessreview/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/check-subjectaccessreview/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-subjectaccessreview

--- a/other-vpol/check-subjectaccessreview/artifacthub-pkg.yml
+++ b/other-vpol/check-subjectaccessreview/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Other"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "SubjectAccessReview"
-digest: e6a8073f6ee2607caffece145bfe4a9c1ee1999c06737a1af2d5fdcf4d782c48
+digest: 28e46e1f2c9a2a66cc7870012cca3dd2959f0292826e3c155b8f6e2fb7abb635
 createdAt: "2025-12-15T12:37:33Z"

--- a/other-vpol/check-subjectaccessreview/check-subjectaccessreview.yaml
+++ b/other-vpol/check-subjectaccessreview/check-subjectaccessreview.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-subjectaccessreview

--- a/other-vpol/deny-commands-in-exec-probe/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/deny-commands-in-exec-probe/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../deny-commands-in-exec-probe.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: deny-commands-in-exec-probe

--- a/other-vpol/deny-commands-in-exec-probe/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/deny-commands-in-exec-probe/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-commands-in-exec-probe

--- a/other-vpol/deny-commands-in-exec-probe/artifacthub-pkg.yml
+++ b/other-vpol/deny-commands-in-exec-probe/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: c7551017103eaef746d4f4fe5d94dbc18ddf1168518943cf162f173b615137b6
+digest: 9405a1c3aac9b483450aa92dbddac62334b3fed69deba17d21bfb34414c256fd
 
 
 createdAt: "2025-05-11T17:46:10Z"

--- a/other-vpol/deny-commands-in-exec-probe/deny-commands-in-exec-probe.yaml
+++ b/other-vpol/deny-commands-in-exec-probe/deny-commands-in-exec-probe.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-commands-in-exec-probe

--- a/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../deny-secret-service-account-token-type.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: deny-secret-service-account-token-type

--- a/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-secret-service-account-token-type

--- a/other-vpol/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deny-secret-service-account-token-type

--- a/other-vpol/disallow-all-secrets/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/disallow-all-secrets/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-all-secrets.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: no-secrets

--- a/other-vpol/disallow-all-secrets/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/disallow-all-secrets/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-secrets

--- a/other-vpol/disallow-all-secrets/artifacthub-pkg.yml
+++ b/other-vpol/disallow-all-secrets/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod, Secret"
-digest: a50258e11e339d0266a1f48423a06cbda27b62ed95949560f6688eb15b2c678d
+digest: 4a90e4c9fea23af8936566b4c4392385920b1052988f871a08fb025aa0889011
 
 
 createdAt: "2025-05-11T17:46:10Z"

--- a/other-vpol/disallow-all-secrets/disallow-all-secrets.yaml
+++ b/other-vpol/disallow-all-secrets/disallow-all-secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-secrets

--- a/other-vpol/disallow-localhost-services/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/disallow-localhost-services/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-localhost-services.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: no-localhost-service

--- a/other-vpol/disallow-localhost-services/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/disallow-localhost-services/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-localhost-service

--- a/other-vpol/disallow-localhost-services/artifacthub-pkg.yml
+++ b/other-vpol/disallow-localhost-services/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Service"
-digest: a0fa1b44283e98fab50a2cd480e8bfa29aa9f1d49b93c8aa08b02fc0616b57b2
+digest: b0b25f68f651ebf62beb329b90d6e06b956db83c373401f3a68fee92100ba942
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/disallow-localhost-services/disallow-localhost-services.yaml
+++ b/other-vpol/disallow-localhost-services/disallow-localhost-services.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-localhost-service

--- a/other-vpol/disallow-secrets-from-env-vars/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/disallow-secrets-from-env-vars/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-secrets-from-env-vars.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: secrets-not-from-env-vars

--- a/other-vpol/disallow-secrets-from-env-vars/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/disallow-secrets-from-env-vars/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: secrets-not-from-env-vars

--- a/other-vpol/disallow-secrets-from-env-vars/artifacthub-pkg.yml
+++ b/other-vpol/disallow-secrets-from-env-vars/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Sample, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod, Secret"
-digest: 1044dacc107a91956f6077c4c48151075628e195d3a17f2b075c1014537ce992
+digest: 31ce0fbaf392f4f298a874d9c847a4ab66136f08a02c16b265101be25ada8305
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml
+++ b/other-vpol/disallow-secrets-from-env-vars/disallow-secrets-from-env-vars.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: secrets-not-from-env-vars

--- a/other-vpol/docker-socket-requires-label/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/docker-socket-requires-label/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../docker-socket-requires-label.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: docker-socket-check

--- a/other-vpol/docker-socket-requires-label/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/docker-socket-requires-label/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: docker-socket-check

--- a/other-vpol/docker-socket-requires-label/artifacthub-pkg.yml
+++ b/other-vpol/docker-socket-requires-label/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 75c9c48c54990d231b20e0575e775210d2893143190e6a37c41680e678e91f40
+digest: 5c37bbb9f60da2e29b37bda50c1ab5b3c29d705731c9737ada2c58edb739a8fd
 
 
 createdAt: "2025-05-11T17:46:10Z"

--- a/other-vpol/docker-socket-requires-label/docker-socket-requires-label.yaml
+++ b/other-vpol/docker-socket-requires-label/docker-socket-requires-label.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: docker-socket-check

--- a/other-vpol/enforce-pod-duration/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/enforce-pod-duration/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../enforce-pod-duration.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: pod-lifetime

--- a/other-vpol/enforce-pod-duration/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/enforce-pod-duration/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: pod-lifetime

--- a/other-vpol/enforce-pod-duration/artifacthub-pkg.yml
+++ b/other-vpol/enforce-pod-duration/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 406f52b1099dee5914c60f155138702f3ef51af25bb3ff7e0b7ca27fbc6b48ea
+digest: 0138a50baffbdc211349db8936fd6fdba08928a94d2e0e446964adc30a936172
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/enforce-pod-duration/enforce-pod-duration.yaml
+++ b/other-vpol/enforce-pod-duration/enforce-pod-duration.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: pod-lifetime

--- a/other-vpol/enforce-readwriteonce-pod/artifacthub-pkg.yml
+++ b/other-vpol/enforce-readwriteonce-pod/artifacthub-pkg.yml
@@ -29,7 +29,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "PersistentVolumeClaims"
-digest: 03d7ae40c94064e2b0b066f8d099c46f11ae48e50e91c9c80685d97e0feaff8a
+digest: 3f51fcccad7614547d799c6484a396bfa2450c0dcf5a656becd7247428ae4a62
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/enforce-readwriteonce-pod/enforce-readwriteonce-pod.yaml
+++ b/other-vpol/enforce-readwriteonce-pod/enforce-readwriteonce-pod.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: readwriteonce-pod

--- a/other-vpol/ensure-probes-different/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/ensure-probes-different/.chainsaw-test/chainsaw-test.yaml
@@ -16,7 +16,7 @@ spec:
         file: ../ensure-probes-different.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: validate-probes

--- a/other-vpol/ensure-probes-different/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/ensure-probes-different/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: validate-probes

--- a/other-vpol/ensure-probes-different/artifacthub-pkg.yml
+++ b/other-vpol/ensure-probes-different/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: ebc10399c0cbbaa689f326a5a60177304fa09068f31ee82460d97d4727ed3314
+digest: 43847442eabc0b22871d6208988185eac4e57036a5609b3c1e44e8cb40c4588c
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/ensure-probes-different/ensure-probes-different.yaml
+++ b/other-vpol/ensure-probes-different/ensure-probes-different.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: validate-probes

--- a/other-vpol/ensure-readonly-hostpath/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/ensure-readonly-hostpath/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../ensure-readonly-hostpath.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: ensure-readonly-hostpath

--- a/other-vpol/ensure-readonly-hostpath/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/ensure-readonly-hostpath/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: ensure-readonly-hostpath

--- a/other-vpol/ensure-readonly-hostpath/artifacthub-pkg.yml
+++ b/other-vpol/ensure-readonly-hostpath/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 6dde8fbd62f97bae41a1fcb2619e1fc813bc4dad56e2a7464902cfc4ade2f54d
+digest: 362e2da930073125f22c18db3c09fab4ac0757a6837df0db5ad8b3787e2ea021
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
+++ b/other-vpol/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: ensure-readonly-hostpath

--- a/other-vpol/exclude-namespaces-dynamically/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/exclude-namespaces-dynamically/.chainsaw-test/chainsaw-test.yaml
@@ -16,7 +16,7 @@ spec:
         file: ../exclude-namespaces-dynamically.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: exclude-namespaces-example

--- a/other-vpol/exclude-namespaces-dynamically/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/exclude-namespaces-dynamically/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: exclude-namespaces-example

--- a/other-vpol/exclude-namespaces-dynamically/artifacthub-pkg.yml
+++ b/other-vpol/exclude-namespaces-dynamically/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Namespace, Pod"
-digest: 21a98a0fb852b2b00642d90cf5f1b3fb8155cc28bd47461a0ff3e5345220ae79
+digest: 9768b1fc0e927f8066919fee0bc67f5d9418053ce8a9905628dca0af9383ccab
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/exclude-namespaces-dynamically/exclude-namespaces-dynamically.yaml
+++ b/other-vpol/exclude-namespaces-dynamically/exclude-namespaces-dynamically.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: exclude-namespaces-example

--- a/other-vpol/forbid-cpu-limits/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/forbid-cpu-limits/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../forbid-cpu-limits.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: forbid-cpu-limits

--- a/other-vpol/forbid-cpu-limits/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/forbid-cpu-limits/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: forbid-cpu-limits

--- a/other-vpol/forbid-cpu-limits/artifacthub-pkg.yml
+++ b/other-vpol/forbid-cpu-limits/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: bb2d2ebf54f281ebfc7204bb19e11c94bb68375cff47dc9a17e61ba1bab0482b
+digest: 37c26ef589c194876df6cc6af6714a50ff0bde700fff5094926686d8aa86f223
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/forbid-cpu-limits/forbid-cpu-limits.yaml
+++ b/other-vpol/forbid-cpu-limits/forbid-cpu-limits.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: forbid-cpu-limits

--- a/other-vpol/imagepullpolicy-always/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/imagepullpolicy-always/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../imagepullpolicy-always.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: imagepullpolicy-always

--- a/other-vpol/imagepullpolicy-always/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/imagepullpolicy-always/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: imagepullpolicy-always

--- a/other-vpol/imagepullpolicy-always/artifacthub-pkg.yml
+++ b/other-vpol/imagepullpolicy-always/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 0edb45c4ea9314d5fbc1fdaacbbd83a30458224419f05bc393b6bae445edc3ad
+digest: 47da3d56e65224387fdd0727555c7d576c7d5c944e180801349492c2977ca906
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/imagepullpolicy-always/imagepullpolicy-always.yaml
+++ b/other-vpol/imagepullpolicy-always/imagepullpolicy-always.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: imagepullpolicy-always

--- a/other-vpol/ingress-host-match-tls/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/ingress-host-match-tls/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../ingress-host-match-tls.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: ingress-host-match-tls

--- a/other-vpol/ingress-host-match-tls/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/ingress-host-match-tls/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: ingress-host-match-tls

--- a/other-vpol/ingress-host-match-tls/artifacthub-pkg.yml
+++ b/other-vpol/ingress-host-match-tls/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Ingress"
-digest: e1fa776f4860c5fb2148aa41329136b5824dfad95d4ac4f5ff46fee1b6af1b8a
+digest: 938561fec927bf13e5a7464a9e94cd63cf7bb49fc0fb0afa64de3d10f86df8e8
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/ingress-host-match-tls/ingress-host-match-tls.yaml
+++ b/other-vpol/ingress-host-match-tls/ingress-host-match-tls.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: ingress-host-match-tls

--- a/other-vpol/limit-containers-per-pod/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/limit-containers-per-pod/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../limit-containers-per-pod.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: limit-containers-per-pod

--- a/other-vpol/limit-containers-per-pod/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/limit-containers-per-pod/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-containers-per-pod

--- a/other-vpol/limit-containers-per-pod/artifacthub-pkg.yml
+++ b/other-vpol/limit-containers-per-pod/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 29f9bb021c3c5089dbc7268992d63a867e2e9057b4a950fce88a51fd2ab1c132
+digest: b97601242b74449a7307bdd1c6a4f2a66f4df087ff899833a4e1fea295511ba7
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/limit-containers-per-pod/limit-containers-per-pod.yaml
+++ b/other-vpol/limit-containers-per-pod/limit-containers-per-pod.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-containers-per-pod

--- a/other-vpol/limit-hostpath-type-pv/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/limit-hostpath-type-pv/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../limit-hostpath-type-pv.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: limit-hostpath-type-pv

--- a/other-vpol/limit-hostpath-type-pv/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/limit-hostpath-type-pv/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-hostpath-type-pv

--- a/other-vpol/limit-hostpath-type-pv/artifacthub-pkg.yml
+++ b/other-vpol/limit-hostpath-type-pv/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "PersistentVolume"
-digest: da9d05f714acdd36ae2e34caf0891fed80743c581239603db9fb2cfb5e1d99f9
+digest: 36f9d43d49d8f41d87a842cd497ad05da270ca2a16d5cb28450c10317978ae91
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/limit-hostpath-type-pv/limit-hostpath-type-pv.yaml
+++ b/other-vpol/limit-hostpath-type-pv/limit-hostpath-type-pv.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-hostpath-type-pv

--- a/other-vpol/limit-hostpath-vols/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/limit-hostpath-vols/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../limit-hostpath-vols.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: limit-hostpath-vols

--- a/other-vpol/limit-hostpath-vols/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/limit-hostpath-vols/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-hostpath-vols

--- a/other-vpol/limit-hostpath-vols/artifacthub-pkg.yml
+++ b/other-vpol/limit-hostpath-vols/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 0ffc603116acf05b9479f5f38b5fcf3cb8bbf6a16f05430cc3c434043bbeab43
+digest: b153cd72327ecef753921a19c6a08808c83b97d8d3ad36b98c75c545464e0588
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/limit-hostpath-vols/limit-hostpath-vols.yaml
+++ b/other-vpol/limit-hostpath-vols/limit-hostpath-vols.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: limit-hostpath-vols

--- a/other-vpol/memory-requests-equal-limits/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/memory-requests-equal-limits/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../memory-requests-equal-limits.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: memory-requests-equal-limits

--- a/other-vpol/memory-requests-equal-limits/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/memory-requests-equal-limits/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: memory-requests-equal-limits

--- a/other-vpol/memory-requests-equal-limits/artifacthub-pkg.yml
+++ b/other-vpol/memory-requests-equal-limits/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 36d4cefe4caa31ad7bc76b37090494de7a2926491d638aafa93168915072b955
+digest: 2e410063bba0d17990e05df1a407eeef498117780656a6d06b1571c2021c895e
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/memory-requests-equal-limits/memory-requests-equal-limits.yaml
+++ b/other-vpol/memory-requests-equal-limits/memory-requests-equal-limits.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: memory-requests-equal-limits

--- a/other-vpol/metadata-match-regex/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/metadata-match-regex/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../metadata-match-regex.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: metadata-match-regex

--- a/other-vpol/metadata-match-regex/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/metadata-match-regex/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: metadata-match-regex

--- a/other-vpol/metadata-match-regex/artifacthub-pkg.yml
+++ b/other-vpol/metadata-match-regex/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod, Label"
-digest: 5cb0bdd387f91f119efb3f90854a789e8c91c8dd3b55827b60a20d01f39d757d
+digest: 04dad86edcb2de575931d774a459cac6655505f40983afa053cb734ac87a8201
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/metadata-match-regex/metadata-match-regex.yaml
+++ b/other-vpol/metadata-match-regex/metadata-match-regex.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: metadata-match-regex

--- a/other-vpol/pdb-maxunavailable/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/pdb-maxunavailable/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../pdb-maxunavailable.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: pdb-maxunavailable

--- a/other-vpol/pdb-maxunavailable/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/pdb-maxunavailable/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: pdb-maxunavailable

--- a/other-vpol/pdb-maxunavailable/artifacthub-pkg.yml
+++ b/other-vpol/pdb-maxunavailable/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "PodDisruptionBudget"
-digest: bfd3b4357a2dd202d818a9c89cd81060741393fe442a1730cbab37d802df1481
+digest: cce5c51b7c86affaad655408dab8ec8681ae96f963548d15a1a8e488bd66e7a3
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/pdb-maxunavailable/pdb-maxunavailable.yaml
+++ b/other-vpol/pdb-maxunavailable/pdb-maxunavailable.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: pdb-maxunavailable

--- a/other-vpol/prevent-bare-pods/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/prevent-bare-pods/.chainsaw-test/chainsaw-test.yaml
@@ -16,7 +16,7 @@ spec:
         file: ../prevent-bare-pods.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: prevent-bare-pods

--- a/other-vpol/prevent-bare-pods/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/prevent-bare-pods/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: prevent-bare-pods

--- a/other-vpol/prevent-bare-pods/artifacthub-pkg.yml
+++ b/other-vpol/prevent-bare-pods/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Other, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: f5ede43b6c327796489c2d9b413ef96b31dcea607368ff651e57be79d5b3bee0
+digest: de52bc85a96b970e36a5b55a84dcb08002339a512a85d4ba36ec4983f1ae491a
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/prevent-bare-pods/prevent-bare-pods.yaml
+++ b/other-vpol/prevent-bare-pods/prevent-bare-pods.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: prevent-bare-pods

--- a/other-vpol/prevent-cr8escape/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/prevent-cr8escape/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: prevent-cr8escape

--- a/other-vpol/prevent-cr8escape/artifacthub-pkg.yml
+++ b/other-vpol/prevent-cr8escape/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 4ccac2032a49b457efcbfdf9ce4f6134b945b44a2f39ad2c40dd187359a23df7
+digest: 122a2eb9a5d073049073c51e11e2248f2d63cf117e7cb62c0c9d20e7b1b26223
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/prevent-cr8escape/prevent-cr8escape.yaml
+++ b/other-vpol/prevent-cr8escape/prevent-cr8escape.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: prevent-cr8escape

--- a/other-vpol/require-annotations/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-annotations/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-annotations.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-annotations

--- a/other-vpol/require-annotations/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-annotations/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-annotations

--- a/other-vpol/require-annotations/artifacthub-pkg.yml
+++ b/other-vpol/require-annotations/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod, Annotation"
-digest: 6c01587f075a7e71c7fe887eb2edcd33685ee030347b3526ee1730cdca048356
+digest: a5f69da817ecd400908bc21ff3aa7a22b70143239a27553c02eda2631ed80551
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/require-annotations/require-annotations.yaml
+++ b/other-vpol/require-annotations/require-annotations.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-annotations

--- a/other-vpol/require-container-port-names/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-container-port-names/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-container-port-names.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-container-port-names

--- a/other-vpol/require-container-port-names/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-container-port-names/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-container-port-names

--- a/other-vpol/require-container-port-names/artifacthub-pkg.yml
+++ b/other-vpol/require-container-port-names/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: f01d5e67f16c51ded869cb4a5b33adc54ac3794b898a46cfb5aa4500eb1a444b
+digest: 92dbb0a28cab307e0d640a9a28b712da2500a8d58c41a009d614c2b141d784e4
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/require-container-port-names/require-container-port-names.yaml
+++ b/other-vpol/require-container-port-names/require-container-port-names.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-container-port-names

--- a/other-vpol/require-deployments-have-multiple-replicas/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-deployments-have-multiple-replicas/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-deployments-have-multiple-replicas.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: deployment-has-multiple-replicas

--- a/other-vpol/require-deployments-have-multiple-replicas/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-deployments-have-multiple-replicas/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deployment-has-multiple-replicas

--- a/other-vpol/require-deployments-have-multiple-replicas/artifacthub-pkg.yml
+++ b/other-vpol/require-deployments-have-multiple-replicas/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Deployment"
-digest: 87c639ea203c26a74b81eb47757006cbbd540343ede5cd6ecc617b856a6532b6
+digest: 8bf57425be3f18e12d4c9e005906f0a772229daad75a1a18dbe2e6abe9ae13e5
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.yaml
+++ b/other-vpol/require-deployments-have-multiple-replicas/require-deployments-have-multiple-replicas.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: deployment-has-multiple-replicas

--- a/other-vpol/require-emptydir-requests-limits/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-emptydir-requests-limits/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-emptydir-requests-limits.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-emptydir-requests-and-limits

--- a/other-vpol/require-emptydir-requests-limits/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-emptydir-requests-limits/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-emptydir-requests-and-limits

--- a/other-vpol/require-emptydir-requests-limits/artifacthub-pkg.yml
+++ b/other-vpol/require-emptydir-requests-limits/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 7aef0435224cb1730b8c34bd783d872334bb12dbeb0a405b6ea3e45bd7766392
+digest: 748a4097d384af210151b73def3754af5edd4dd42f5fa086c5ba85f1fab35ad0
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/require-emptydir-requests-limits/require-emptydir-requests-limits.yaml
+++ b/other-vpol/require-emptydir-requests-limits/require-emptydir-requests-limits.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-emptydir-requests-and-limits

--- a/other-vpol/require-image-checksum/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-image-checksum/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-image-checksum.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-image-checksum

--- a/other-vpol/require-image-checksum/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-image-checksum/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-image-checksum

--- a/other-vpol/require-image-checksum/artifacthub-pkg.yml
+++ b/other-vpol/require-image-checksum/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 8ada9e6310cbfce82f3bc9e0013778d1c0dfacf2264a1ae29063b8ca860b2612
+digest: 777a5056d31fd32105d833d2246f5ff4b6f863fdc53b58902d919b22a91376cd
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/require-image-checksum/require-image-checksum.yaml
+++ b/other-vpol/require-image-checksum/require-image-checksum.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-image-checksum

--- a/other-vpol/require-ingress-https/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-ingress-https/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-ingress-https.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-ingress-https

--- a/other-vpol/require-ingress-https/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-ingress-https/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-ingress-https

--- a/other-vpol/require-ingress-https/artifacthub-pkg.yml
+++ b/other-vpol/require-ingress-https/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Ingress"
-digest: f376bd565b0df4c1e9c82264a5396d6aea866fc72b1ab123214e751b326077bc
+digest: bbb2567963de64c2989a1875c5449a5a43762d194b4b903d92bfa4885abf9ff4
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/require-ingress-https/require-ingress-https.yaml
+++ b/other-vpol/require-ingress-https/require-ingress-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-ingress-https

--- a/other-vpol/require-non-root-groups/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-non-root-groups/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../require-non-root-groups.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-non-root-groups

--- a/other-vpol/require-non-root-groups/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-non-root-groups/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-non-root-groups

--- a/other-vpol/require-non-root-groups/.kyverno-test/check-fsgroup.yaml
+++ b/other-vpol/require-non-root-groups/.kyverno-test/check-fsgroup.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-fsgroup

--- a/other-vpol/require-non-root-groups/.kyverno-test/check-supplementalgroups.yaml
+++ b/other-vpol/require-non-root-groups/.kyverno-test/check-supplementalgroups.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: check-supplementalgroups

--- a/other-vpol/require-non-root-groups/artifacthub-pkg.yml
+++ b/other-vpol/require-non-root-groups/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Sample, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: ebc9fbf4a5d52e2adbf9e5c14a082e631164d06665bfb0fd77f2d2d80e362787
+digest: f96258c86a01240f0cd7b290c18f764cebe87bc8d4f53c67776490a5d97e5180
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/require-non-root-groups/require-non-root-groups.yaml
+++ b/other-vpol/require-non-root-groups/require-non-root-groups.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-non-root-groups

--- a/other-vpol/require-pod-priorityclassname/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-pod-priorityclassname/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-pod-priorityclassname.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-pod-priorityclassname

--- a/other-vpol/require-pod-priorityclassname/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-pod-priorityclassname/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-pod-priorityclassname

--- a/other-vpol/require-pod-priorityclassname/artifacthub-pkg.yml
+++ b/other-vpol/require-pod-priorityclassname/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Multi-Tenancy, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: aa225b636f6c9bac717de71269f8cc2c72865f83e529030baa25b4f69cc43795
+digest: 4738b2d04a0a875f97e3119f2fae4a9794a6ec2cb2132b398775be551aec2185
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/require-pod-priorityclassname/require-pod-priorityclassname.yaml
+++ b/other-vpol/require-pod-priorityclassname/require-pod-priorityclassname.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-pod-priorityclassname

--- a/other-vpol/require-qos-burstable/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-qos-burstable/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-qos-burstable.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-qos-burstable

--- a/other-vpol/require-qos-burstable/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-qos-burstable/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-qos-burstable

--- a/other-vpol/require-qos-burstable/artifacthub-pkg.yml
+++ b/other-vpol/require-qos-burstable/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Other, Multi-Tenancy in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 2483a2118982f62867e26cbf9d46dd08b06f231d00200662b262776f3e7b3418
+digest: 5a0998b6d039f7381fcd851d0f82a3a0b74fa34617e735e0883915af3f7504f2
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/require-qos-burstable/require-qos-burstable.yaml
+++ b/other-vpol/require-qos-burstable/require-qos-burstable.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-qos-burstable

--- a/other-vpol/require-qos-guaranteed/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-qos-guaranteed/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-qos-guaranteed.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-qos-guaranteed

--- a/other-vpol/require-qos-guaranteed/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-qos-guaranteed/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-qos-guaranteed

--- a/other-vpol/require-qos-guaranteed/artifacthub-pkg.yml
+++ b/other-vpol/require-qos-guaranteed/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Other, Multi-Tenancy in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 175a5a5cea8e5443f2cf9a808b4383d2db74230dbd3496ea266852ac902094c8
+digest: de04f13c427f062b34470103c85629ccd1f75ff25b570e34729067cd44542189
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/require-qos-guaranteed/require-qos-guaranteed.yaml
+++ b/other-vpol/require-qos-guaranteed/require-qos-guaranteed.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-qos-guaranteed

--- a/other-vpol/require-storageclass/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/require-storageclass/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../require-storageclass.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-storageclass

--- a/other-vpol/require-storageclass/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/require-storageclass/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-storageclass

--- a/other-vpol/require-storageclass/artifacthub-pkg.yml
+++ b/other-vpol/require-storageclass/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Other, Multi-Tenancy in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "PersistentVolumeClaim, StatefulSet"
-digest: f70e21e5a74441f1921e9547cfd7a86d236eb6c9dd9f19ade87b1610dfb118b9
+digest: 0ef95314ceb4b5abd30744be7e757d2e0ccf9d93fa297a594a41145765cf0ff5
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/require-storageclass/require-storageclass.yaml
+++ b/other-vpol/require-storageclass/require-storageclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-storageclass

--- a/other-vpol/restrict-annotations/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-annotations/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-annotations.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-annotations

--- a/other-vpol/restrict-annotations/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-annotations/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-annotations

--- a/other-vpol/restrict-annotations/artifacthub-pkg.yml
+++ b/other-vpol/restrict-annotations/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod, Annotation"
-digest: bcab17b257477d511f49cbe8fc9a769fca5dbd4f391a7cd8ab063540aa3cde22
+digest: 980352bbc2d007a9b7553c8de861902c9450083bc38604ade63161da89300efe
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-annotations/restrict-annotations.yaml
+++ b/other-vpol/restrict-annotations/restrict-annotations.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-annotations

--- a/other-vpol/restrict-binding-clusteradmin/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-binding-clusteradmin/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-binding-clusteradmin.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-binding-clusteradmin

--- a/other-vpol/restrict-binding-clusteradmin/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-binding-clusteradmin/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-binding-clusteradmin

--- a/other-vpol/restrict-binding-clusteradmin/artifacthub-pkg.yml
+++ b/other-vpol/restrict-binding-clusteradmin/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Security in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "RoleBinding, ClusterRoleBinding, RBAC"
-digest: ca27d2048323e386405077bdcbe97322ffffdca4a58ee780e266f56e940a3c4f
+digest: 1aefd541120cd0653b5c56b5486f6ce57f5abe75e13296b096b3336260845399
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml
+++ b/other-vpol/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-binding-clusteradmin

--- a/other-vpol/restrict-binding-system-groups/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-binding-system-groups/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-binding-system-groups.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-binding-system-groups

--- a/other-vpol/restrict-binding-system-groups/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-binding-system-groups/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-binding-system-groups

--- a/other-vpol/restrict-binding-system-groups/artifacthub-pkg.yml
+++ b/other-vpol/restrict-binding-system-groups/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Security, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "RoleBinding, ClusterRoleBinding, RBAC"
-digest: 9696b546b9c1be6ce7b87ea664d07a74d730a8267af028a1187b98814806ba3b
+digest: 694bdfdf5e93f3a12fa544779bd95e8349503bdc76211ff44efe0cd212e4d011
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.yaml
+++ b/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-binding-system-groups

--- a/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-clusterrole-nodesproxy.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-clusterrole-nodesproxy

--- a/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-clusterrole-nodesproxy

--- a/other-vpol/restrict-clusterrole-nodesproxy/artifacthub-pkg.yml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "ClusterRole, RBAC"
-digest: b686a5c559918a918a61a7c744e29e09e8e4b363c32e0430d7faf1c51007ee1b
+digest: 1337fed95f20764d40f27b82361a86325ce1c47d4960066fd2dd45ece88dfd12
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-clusterrole-nodesproxy

--- a/other-vpol/restrict-controlplane-scheduling/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-controlplane-scheduling/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-controlplane-scheduling.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-controlplane-scheduling

--- a/other-vpol/restrict-controlplane-scheduling/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-controlplane-scheduling/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-controlplane-scheduling

--- a/other-vpol/restrict-controlplane-scheduling/artifacthub-pkg.yml
+++ b/other-vpol/restrict-controlplane-scheduling/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 4a562382ee0095f449a1f7443bae20a7dbf88a9fdd0157b0db7c7625df2b0533
+digest: e2e593f872581eec7c1487bcd20e5e9bb537a89c99ae6e3814daf5d5985b9e9e
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml
+++ b/other-vpol/restrict-controlplane-scheduling/restrict-controlplane-scheduling.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-controlplane-scheduling

--- a/other-vpol/restrict-deprecated-registry/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-deprecated-registry/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-deprecated-registry

--- a/other-vpol/restrict-deprecated-registry/artifacthub-pkg.yml
+++ b/other-vpol/restrict-deprecated-registry/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Best Practices, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.27-1.28"
   kyverno/subject: "Pod"
-digest: fe5d0ce2e47c44cc406ddba59b0b59184d304902e228c7093bdae4d359799985
+digest: 433bdd69423eac439b2010cec00337f3e6c9efecd5e46f1f83f798a3f53759e1
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-deprecated-registry/restrict-deprecated-registry.yaml
+++ b/other-vpol/restrict-deprecated-registry/restrict-deprecated-registry.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-deprecated-registry

--- a/other-vpol/restrict-edit-for-endpoints/artifacthub-pkg.yml
+++ b/other-vpol/restrict-edit-for-endpoints/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Security in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "ClusterRole"
-digest: 4501fc696db216e18a0aee77db2172794958cc485c46073b5fc3b3e5b9fe29db
+digest: c6c99c6ef3023ce14a783b0c47986f3e985ebc0a97d0478143e367c2f47832d3
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml
+++ b/other-vpol/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-edit-for-endpoints

--- a/other-vpol/restrict-escalation-verbs-roles/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-escalation-verbs-roles/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-escalation-verbs-roles.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-escalation-verbs-roles

--- a/other-vpol/restrict-escalation-verbs-roles/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-escalation-verbs-roles/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-escalation-verbs-roles

--- a/other-vpol/restrict-escalation-verbs-roles/artifacthub-pkg.yml
+++ b/other-vpol/restrict-escalation-verbs-roles/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Security in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Role, ClusterRole, RBAC"
-digest: a26cb647dab19f806b82f72d9fae59217f2a88d53a8f637fc723aa9551628733
+digest: 9471f965ba28269a120207afa4627ab3e99c5c3edee28a03c06c118b2c9193a0
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
+++ b/other-vpol/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-escalation-verbs-roles

--- a/other-vpol/restrict-ingress-classes/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-ingress-classes/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-ingress-classes.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-ingress-classes

--- a/other-vpol/restrict-ingress-classes/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-ingress-classes/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-classes

--- a/other-vpol/restrict-ingress-classes/artifacthub-pkg.yml
+++ b/other-vpol/restrict-ingress-classes/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Ingress"
-digest: 6a137548f57074c56ca1bdb9ea475a83b3ecf984c518b3edf97a686861a2fdbf
+digest: 1504d402b327bd24cb8831094c173fbc7d7a25fd51effd3a20a7fb80bf41c23b
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/restrict-ingress-classes/restrict-ingress-classes.yaml
+++ b/other-vpol/restrict-ingress-classes/restrict-ingress-classes.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-classes

--- a/other-vpol/restrict-ingress-defaultbackend/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-ingress-defaultbackend/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-ingress-defaultbackend.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-ingress-defaultbackend

--- a/other-vpol/restrict-ingress-defaultbackend/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-ingress-defaultbackend/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-defaultbackend

--- a/other-vpol/restrict-ingress-defaultbackend/artifacthub-pkg.yml
+++ b/other-vpol/restrict-ingress-defaultbackend/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Ingress"
-digest: d01778e39cf50535a5d7cf01bcebd1e251d0d2dc05f47ccacd000edabd88f387
+digest: bac634455ccfc52af9fa03d75067f4627adc32808485efe479bf86130225786a
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.yaml
+++ b/other-vpol/restrict-ingress-defaultbackend/restrict-ingress-defaultbackend.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-defaultbackend

--- a/other-vpol/restrict-ingress-wildcard/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-ingress-wildcard/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-ingress-wildcard.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-ingress-wildcard

--- a/other-vpol/restrict-ingress-wildcard/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-ingress-wildcard/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-wildcard

--- a/other-vpol/restrict-ingress-wildcard/artifacthub-pkg.yml
+++ b/other-vpol/restrict-ingress-wildcard/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Ingress"
-digest: ae23cf7c35e7053d9d4c64289011f82beac0a239d0fd45a65040b1b2f619ce8a
+digest: 60e4ceef1d386239eb275d8c54d8f14e1619010e4dba2a45211e39b54c3c1051
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
+++ b/other-vpol/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-ingress-wildcard

--- a/other-vpol/restrict-jobs/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-jobs/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-jobs

--- a/other-vpol/restrict-jobs/artifacthub-pkg.yml
+++ b/other-vpol/restrict-jobs/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Job"
-digest: df2f56da0dfb1d6210ddc231792bcb3498c291edaeafe8ac7ca475c8071303fc
+digest: 4b6b948cd40c8b68c57a5ca639406bdcdb74d587c4ed5b6c39338f426bfecc42
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/restrict-jobs/restrict-jobs.yaml
+++ b/other-vpol/restrict-jobs/restrict-jobs.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-jobs

--- a/other-vpol/restrict-loadbalancer/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-loadbalancer/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-loadbalancer.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: no-loadbalancer-service

--- a/other-vpol/restrict-loadbalancer/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-loadbalancer/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-loadbalancer-service

--- a/other-vpol/restrict-loadbalancer/artifacthub-pkg.yml
+++ b/other-vpol/restrict-loadbalancer/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Service"
-digest: e6e40094dc8d2595f31af3bb63f5c53d2bae790d3ac3d3023283e5d599b4ff67
+digest: eb12f105875136ef4454db2bfa7439d63699e319855c7ca563b0502d81c1780c
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-loadbalancer/restrict-loadbalancer.yaml
+++ b/other-vpol/restrict-loadbalancer/restrict-loadbalancer.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: no-loadbalancer-service

--- a/other-vpol/restrict-networkpolicy-empty-podselector/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-networkpolicy-empty-podselector/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-networkpolicy-empty-podselector.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-networkpolicy-empty-podselector

--- a/other-vpol/restrict-networkpolicy-empty-podselector/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-networkpolicy-empty-podselector/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-networkpolicy-empty-podselector

--- a/other-vpol/restrict-networkpolicy-empty-podselector/artifacthub-pkg.yml
+++ b/other-vpol/restrict-networkpolicy-empty-podselector/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Other, Multi-Tenancy in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "NetworkPolicy"
-digest: 651400131dcd861efba8af8511b15b1d8e7e4318f7b36ea0f631fb3546d50885
+digest: 983222478ec9c7e7244834362963f7ccc01fc60abc06bf22b39bc2ab2c90586d
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.yaml
+++ b/other-vpol/restrict-networkpolicy-empty-podselector/restrict-networkpolicy-empty-podselector.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-networkpolicy-empty-podselector

--- a/other-vpol/restrict-node-affinity/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-node-affinity/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-node-affinity.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-node-affinity

--- a/other-vpol/restrict-node-affinity/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-node-affinity/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-node-affinity

--- a/other-vpol/restrict-node-affinity/artifacthub-pkg.yml
+++ b/other-vpol/restrict-node-affinity/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: bb250f711b431ddcf7e0a5381b7d736f030573bd762a4e0e78ac79b13086c446
+digest: 9888243af9941cc7f8b2c103453f4f6f2c2253b6b2e24a0d3aef4d342c80773f
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-node-affinity/restrict-node-affinity.yaml
+++ b/other-vpol/restrict-node-affinity/restrict-node-affinity.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-node-affinity

--- a/other-vpol/restrict-node-label-creation/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-node-label-creation/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-node-label-creation

--- a/other-vpol/restrict-node-label-creation/artifacthub-pkg.yml
+++ b/other-vpol/restrict-node-label-creation/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Node, Label"
-digest: 0e5ded13f1a7b95646ee51df4f38f7b6657dd315b9183ba87d3297ca890b2d5d
+digest: 092838113d3ad103e26d06a9c968640001b173609d4896453b053e589b68ae62
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-node-label-creation/restrict-node-label-creation.yaml
+++ b/other-vpol/restrict-node-label-creation/restrict-node-label-creation.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-node-label-creation

--- a/other-vpol/restrict-pod-controller-serviceaccount-updates/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-pod-controller-serviceaccount-updates/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-pod-controller-serviceaccount-updates.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-pod-controller-serviceaccount-updates

--- a/other-vpol/restrict-pod-controller-serviceaccount-updates/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-pod-controller-serviceaccount-updates/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-pod-controller-serviceaccount-updates

--- a/other-vpol/restrict-pod-controller-serviceaccount-updates/artifacthub-pkg.yml
+++ b/other-vpol/restrict-pod-controller-serviceaccount-updates/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 0da6e8e6111f1a4da3b4babf2d451082c5cd7f2349418615bf986701020dd163
+digest: cdd5970862e066912502f07607b67ba65bb04ed2ac2566400df037c55b5ff934
 
 createdAt: "2025-05-11T17:46:10Z"

--- a/other-vpol/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.yaml
+++ b/other-vpol/restrict-pod-controller-serviceaccount-updates/restrict-pod-controller-serviceaccount-updates.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-pod-controller-serviceaccount-updates

--- a/other-vpol/restrict-sa-automount-sa-token/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-sa-automount-sa-token/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-sa-automount-sa-token.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-sa-automount-sa-token

--- a/other-vpol/restrict-sa-automount-sa-token/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-sa-automount-sa-token/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-sa-automount-sa-token

--- a/other-vpol/restrict-sa-automount-sa-token/artifacthub-pkg.yml
+++ b/other-vpol/restrict-sa-automount-sa-token/artifacthub-pkg.yml
@@ -27,7 +27,7 @@ annotations:
   kyverno/category: "Security in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "ServiceAccount"
-digest: 079c37b81020edfdd7f314bab8dca96793d7c0367652b05206b9244443c786b7
+digest: ebeab19d38f785eb612a4891080f5ea538ad7ec7bf2d9b7df6233540b1a1f816
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
+++ b/other-vpol/restrict-sa-automount-sa-token/restrict-sa-automount-sa-token.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-sa-automount-sa-token

--- a/other-vpol/restrict-secret-role-verbs/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-secret-role-verbs/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-secret-role-verbs.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-secret-role-verbs

--- a/other-vpol/restrict-secret-role-verbs/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-secret-role-verbs/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-secret-role-verbs

--- a/other-vpol/restrict-secret-role-verbs/artifacthub-pkg.yml
+++ b/other-vpol/restrict-secret-role-verbs/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Security in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Role, ClusterRole, RBAC"
-digest: 4cc686aa39e12082c230f81eeb1d8971fa814a3c3a4d1a8a5d9c16fe72ee2dbe
+digest: 36b6107302a973bf3052a11fdf3322669425cfa5504a38aba87662fbb34b0f1e
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
+++ b/other-vpol/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-secret-role-verbs

--- a/other-vpol/restrict-secrets-by-name/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-secrets-by-name/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../restrict-secrets-by-name.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-secrets-by-name

--- a/other-vpol/restrict-secrets-by-name/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-secrets-by-name/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-secrets-by-name

--- a/other-vpol/restrict-secrets-by-name/artifacthub-pkg.yml
+++ b/other-vpol/restrict-secrets-by-name/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod, Secret"
-digest: b578fe5041e7b2102d9ea62ac26cb5be40ed113243b50d9bfd914cc5b5f7e27d
+digest: d15178f55cd194d3ce33c8d321744fa1421dd427ec6b05ad714024cf4f07f5ad
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-secrets-by-name/restrict-secrets-by-name.yaml
+++ b/other-vpol/restrict-secrets-by-name/restrict-secrets-by-name.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-secrets-by-name

--- a/other-vpol/restrict-service-port-range/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-service-port-range/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-service-port-range.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-service-port-range

--- a/other-vpol/restrict-service-port-range/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-service-port-range/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-service-port-range

--- a/other-vpol/restrict-service-port-range/artifacthub-pkg.yml
+++ b/other-vpol/restrict-service-port-range/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Other in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Service"
-digest: f568d97c004b88e5c19eb275d006c3cd15d1945caebe2fe263108883f6cece7d
+digest: 8a4d031c3f0ddd1a331f2b7f17c5152b0c074eacc0a060e26a406c92720e73a8
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/restrict-service-port-range/restrict-service-port-range.yaml
+++ b/other-vpol/restrict-service-port-range/restrict-service-port-range.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-service-port-range

--- a/other-vpol/restrict-storageclass/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-storageclass/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-storageclass.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-storageclass

--- a/other-vpol/restrict-storageclass/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-storageclass/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-storageclass

--- a/other-vpol/restrict-storageclass/artifacthub-pkg.yml
+++ b/other-vpol/restrict-storageclass/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Other, Multi-Tenancy in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "StorageClass"
-digest: 07e30c0531366c9f4628c984d05489194358fc2fba6106743a1f96979c9bb8b9
+digest: 7d17c8c08b78c463fba7393a172dd2fa3590fcc7a490d31aef8ec53aa4e35ea4
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/restrict-storageclass/restrict-storageclass.yaml
+++ b/other-vpol/restrict-storageclass/restrict-storageclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-storageclass

--- a/other-vpol/restrict-usergroup-fsgroup-id/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-usergroup-fsgroup-id/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-usergroup-fsgroup-id.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: validate-userid-groupid-fsgroup

--- a/other-vpol/restrict-usergroup-fsgroup-id/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-usergroup-fsgroup-id/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: validate-userid-groupid-fsgroup

--- a/other-vpol/restrict-usergroup-fsgroup-id/artifacthub-pkg.yml
+++ b/other-vpol/restrict-usergroup-fsgroup-id/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: 69045833620980daf219fd1741e4af32132601e6a4ca651d0449c80e45c2e2fe
+digest: 096305a2e0e0cb5f92c4759f93a67882067e9daea1843dbfc44198699acbc9e3
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml
+++ b/other-vpol/restrict-usergroup-fsgroup-id/restrict-usergroup-fsgroup-id.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: validate-userid-groupid-fsgroup

--- a/other-vpol/restrict-wildcard-resources/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-wildcard-resources/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-wildcard-resources.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-wildcard-resources

--- a/other-vpol/restrict-wildcard-resources/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-wildcard-resources/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-wildcard-resources

--- a/other-vpol/restrict-wildcard-resources/artifacthub-pkg.yml
+++ b/other-vpol/restrict-wildcard-resources/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Security, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "ClusterRole, Role, RBAC"
-digest: 2e3606f23a81d1d7150909a038976c777b4e56e2e74c66010c3d51040175f75f
+digest: 4faf74f05897bbaf34a381b7c8dd7fb1d51e25d9ceca6a097ea26e48772c40ba
 
 
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/restrict-wildcard-resources/restrict-wildcard-resources.yaml
+++ b/other-vpol/restrict-wildcard-resources/restrict-wildcard-resources.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-wildcard-resources

--- a/other-vpol/restrict-wildcard-verbs/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-wildcard-verbs/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../restrict-wildcard-verbs.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-wildcard-verbs

--- a/other-vpol/restrict-wildcard-verbs/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/restrict-wildcard-verbs/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-wildcard-verbs

--- a/other-vpol/restrict-wildcard-verbs/artifacthub-pkg.yml
+++ b/other-vpol/restrict-wildcard-verbs/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Security, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Role, ClusterRole, RBAC"
-digest: 11c353aa1dff4cab3268c727ac1fa86724b92731204bb01dc6a09d3d010439fb
+digest: e15e4f0f60bc5c27be3e81cadf7d46462589acf0d7a2d80f577699ef6ef65a05
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
+++ b/other-vpol/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-wildcard-verbs

--- a/other-vpol/topologyspreadconstraints-policy/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/topologyspreadconstraints-policy/.chainsaw-test/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
         file: ../topologyspreadconstraints-policy.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: topologyspreadconstraints-policy

--- a/other-vpol/topologyspreadconstraints-policy/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/topologyspreadconstraints-policy/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: topologyspreadconstraints-policy

--- a/other-vpol/topologyspreadconstraints-policy/artifacthub-pkg.yml
+++ b/other-vpol/topologyspreadconstraints-policy/artifacthub-pkg.yml
@@ -19,7 +19,7 @@ annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Deployment, StatefulSet"
-digest: fff2168e59c23e561f08ef54bf617a3f64ff7bf3c550f827bf3eeec1bdf5c01f
+digest: c4a5ad8b3b8bec5d18ce5a9299b16830c80e30659927dde4273fcb9b7040b5a4
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/topologyspreadconstraints-policy/topologyspreadconstraints-policy.yaml
+++ b/other-vpol/topologyspreadconstraints-policy/topologyspreadconstraints-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: topologyspreadconstraints-policy

--- a/other-vpol/unique-ingress-paths/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other-vpol/unique-ingress-paths/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name:  unique-ingress-path

--- a/other-vpol/unique-ingress-paths/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/unique-ingress-paths/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../unique-ingress-paths.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: unique-ingress-path

--- a/other-vpol/unique-ingress-paths/artifacthub-pkg.yml
+++ b/other-vpol/unique-ingress-paths/artifacthub-pkg.yml
@@ -17,6 +17,6 @@ readme: |
 annotations:
   kyverno/category: "Sample"
   kyverno/subject: "Ingress"
-digest: 412d2690486d6a22b9918ee4852ac0749f1b4f7b98dec3d7e8cce471346600f7
+digest: 34bfbecf564954e65cce51185d3434a27897b0eec6cbf57c2d045bbc4d5552c9
 
 createdAt: "2025-05-11T17:46:10Z"

--- a/other-vpol/unique-ingress-paths/unique-ingress-paths.yaml
+++ b/other-vpol/unique-ingress-paths/unique-ingress-paths.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: unique-ingress-path

--- a/other/verify-image-ivpol/.chainsaw-test/policy-ready.yaml
+++ b/other/verify-image-ivpol/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ImageValidatingPolicy
 metadata:
   name: verify-image-ivpol

--- a/other/verify-image-ivpol/artifacthub-pkg.yml
+++ b/other/verify-image-ivpol/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ readme: |
 annotations:
   kyverno/category: "Software Supply Chain Security, EKS Best Practices"
   kyverno/subject: "Pod"
-digest: 1209421396e95a711908a3061e482fa06734fa474e90701222a8daa835f984d9
+digest: d8b3b97757c26761e3f1680c47a21f4d75bd21780485f8bed94b2b1369be68aa

--- a/other/verify-image-ivpol/verify-image-ivpol.yaml
+++ b/other/verify-image-ivpol/verify-image-ivpol.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ImageValidatingPolicy
 metadata:
   name: verify-image-ivpol

--- a/pod-security-vpol/baseline/disallow-capabilities/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-capabilities/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-capabilities.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-capabilities

--- a/pod-security-vpol/baseline/disallow-capabilities/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-capabilities/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-capabilities

--- a/pod-security-vpol/baseline/disallow-capabilities/artifacthub-pkg.yml
+++ b/pod-security-vpol/baseline/disallow-capabilities/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in ValidatingPolicy"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: c3f6295560b98e950604e45dc7622ebf3d886be2eff7a8b84cd8f1e925e1726e
+digest: f1f6afd6ccf1f0679cb9da21aebe3d5870b8643f740e766295491d58e3d1c0d8
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/baseline/disallow-capabilities/disallow-capabilities.yaml
+++ b/pod-security-vpol/baseline/disallow-capabilities/disallow-capabilities.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-capabilities

--- a/pod-security-vpol/baseline/disallow-host-namespaces/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-host-namespaces/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-host-namespaces.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-host-namespaces

--- a/pod-security-vpol/baseline/disallow-host-namespaces/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-host-namespaces/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-namespaces

--- a/pod-security-vpol/baseline/disallow-host-namespaces/artifacthub-pkg.yml
+++ b/pod-security-vpol/baseline/disallow-host-namespaces/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in ValidatingPolicy"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: 2fdd6bb3cdb9b8d3637f28dde1a30ea8fc0fc15251bc69359077cd7a96a85ca5
+digest: c67322a7da97c04d234e52f6e6e80bc5daea0e0423195d3bda6bcc97db990d64
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
+++ b/pod-security-vpol/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-namespaces

--- a/pod-security-vpol/baseline/disallow-host-path/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-host-path/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-host-path.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-host-path

--- a/pod-security-vpol/baseline/disallow-host-path/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-host-path/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-path

--- a/pod-security-vpol/baseline/disallow-host-path/artifacthub-pkg.yml
+++ b/pod-security-vpol/baseline/disallow-host-path/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline)"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod,Volume"
-digest: 915c0e61c7fd0eda1a542bdc28df24ccdef15e351d5e6517b0dec319aa83dfb2
+digest: e65d8c4c29dec3a870db972f0bb4d7769c5f18d2e26f796f7b812ad1c43b0c3a
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/baseline/disallow-host-path/disallow-host-path.yaml
+++ b/pod-security-vpol/baseline/disallow-host-path/disallow-host-path.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-path

--- a/pod-security-vpol/baseline/disallow-host-ports/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-host-ports/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-host-ports.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-host-ports

--- a/pod-security-vpol/baseline/disallow-host-ports/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-host-ports/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-ports

--- a/pod-security-vpol/baseline/disallow-host-ports/artifacthub-pkg.yml
+++ b/pod-security-vpol/baseline/disallow-host-ports/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in ValidatingPolicy"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: 5464984bb6a2ba254e765800c57a2826723ee1b58f71170339d1ba5b2e4ebd5c
+digest: d3ee5766aa1fcb5e7399e8518fd9e65b8511512a6e70608181c06cacd3966f38
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/baseline/disallow-host-ports/disallow-host-ports.yaml
+++ b/pod-security-vpol/baseline/disallow-host-ports/disallow-host-ports.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-ports

--- a/pod-security-vpol/baseline/disallow-host-process/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-host-process/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-host-process.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-host-process

--- a/pod-security-vpol/baseline/disallow-host-process/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-host-process/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-process

--- a/pod-security-vpol/baseline/disallow-host-process/artifacthub-pkg.yml
+++ b/pod-security-vpol/baseline/disallow-host-process/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in ValidatingPolicy"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: ac13472565c9895dd209794780571faed0390e85d441dc87f21763c064523fae
+digest: 1756391c3a52323d9ab8f9b152dc6b0ee59bd6e59d2e886c3cba4907fda94afc
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/baseline/disallow-host-process/disallow-host-process.yaml
+++ b/pod-security-vpol/baseline/disallow-host-process/disallow-host-process.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-host-process

--- a/pod-security-vpol/baseline/disallow-privileged-containers/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-privileged-containers/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-privileged-containers.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-privileged-containers

--- a/pod-security-vpol/baseline/disallow-privileged-containers/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-privileged-containers/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-privileged-containers

--- a/pod-security-vpol/baseline/disallow-privileged-containers/artifacthub-pkg.yml
+++ b/pod-security-vpol/baseline/disallow-privileged-containers/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in ValidatingPolicy"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: 124f0a0dd39102ba9e8e839b6c3e7ed043b9787078009578900bfde6b2a8e4a3
+digest: c4c1931526361b080697c5c67ce977d6d25c57d10dadb8ec5f026888b34e369f
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
+++ b/pod-security-vpol/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-privileged-containers

--- a/pod-security-vpol/baseline/disallow-proc-mount/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-proc-mount/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-proc-mount.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-proc-mount

--- a/pod-security-vpol/baseline/disallow-proc-mount/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-proc-mount/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-proc-mount

--- a/pod-security-vpol/baseline/disallow-proc-mount/artifacthub-pkg.yml
+++ b/pod-security-vpol/baseline/disallow-proc-mount/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in ValidatingPolicy"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: ca2b4d326b482d2f06f28005f8ae61bb36bd0715d6bb8dce05b362694e46fc2d
+digest: 27c8ee0f24ecc3195a229bb0869b3a9d53b3e8619340c7998b356aa7c19b1e53
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/baseline/disallow-proc-mount/disallow-proc-mount.yaml
+++ b/pod-security-vpol/baseline/disallow-proc-mount/disallow-proc-mount.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-proc-mount

--- a/pod-security-vpol/baseline/disallow-selinux/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/disallow-selinux/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-selinux.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-selinux

--- a/pod-security-vpol/baseline/disallow-selinux/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/disallow-selinux/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-selinux

--- a/pod-security-vpol/baseline/disallow-selinux/artifacthub-pkg.yml
+++ b/pod-security-vpol/baseline/disallow-selinux/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in ValidatingPolicy"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: ad59896a7228ba5d73ed483b54b034c9948a9247c4bb2872c34d0831040aecae
+digest: 74cd0d1fca2130502ec1d374e74729c7571ef489e88150aaf603ff13f3091b97
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/baseline/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security-vpol/baseline/disallow-selinux/disallow-selinux.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-selinux

--- a/pod-security-vpol/baseline/restrict-seccomp/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/restrict-seccomp/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../restrict-seccomp.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-seccomp

--- a/pod-security-vpol/baseline/restrict-seccomp/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/restrict-seccomp/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-seccomp

--- a/pod-security-vpol/baseline/restrict-seccomp/artifacthub-pkg.yml
+++ b/pod-security-vpol/baseline/restrict-seccomp/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in ValidatingPolicy"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: 73e6b0f687a2dd14f44aeba3bdab793a6c8a70dbe17df055faf39420dbd15b06
+digest: 0f70f7d4b52507b27452dbf8e912b1719dc3b9b7ed199542ab684d29c479fc3b
 createdAt: "2025-03-13T23:50:13Z"

--- a/pod-security-vpol/baseline/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security-vpol/baseline/restrict-seccomp/restrict-seccomp.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-seccomp

--- a/pod-security-vpol/baseline/restrict-sysctls/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/baseline/restrict-sysctls/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../restrict-sysctls.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-sysctls

--- a/pod-security-vpol/baseline/restrict-sysctls/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/baseline/restrict-sysctls/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-sysctls

--- a/pod-security-vpol/baseline/restrict-sysctls/artifacthub-pkg.yml
+++ b/pod-security-vpol/baseline/restrict-sysctls/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Baseline) in ValidatingPolicy"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: 9d9c55f27afab5d6871a622ce79e820db15bb4dca177c0f85c1d69b071949b2d
+digest: a2ccf7158b6b2d8f18af544f6764ba8cf0d433526afbb6abe42c4ef19fa1d518
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/baseline/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security-vpol/baseline/restrict-sysctls/restrict-sysctls.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-sysctls

--- a/pod-security-vpol/restricted/disallow-capabilities-strict/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/disallow-capabilities-strict/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-capabilities-strict.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-capabilities-strict

--- a/pod-security-vpol/restricted/disallow-capabilities-strict/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/disallow-capabilities-strict/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-capabilities-strict

--- a/pod-security-vpol/restricted/disallow-capabilities-strict/.kyverno-test/adding-capabilities-strict.yaml
+++ b/pod-security-vpol/restricted/disallow-capabilities-strict/.kyverno-test/adding-capabilities-strict.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: adding-capabilities-strict

--- a/pod-security-vpol/restricted/disallow-capabilities-strict/artifacthub-pkg.yml
+++ b/pod-security-vpol/restricted/disallow-capabilities-strict/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: 02d04ffeff88bea30d31f4b52e54fdb2892ed076055302ed5a18586be771ef22
+digest: 5c8bdc6d6f93aa765545a4ae4f8105ee794349c6cf42427027b789f1961aafda
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
+++ b/pod-security-vpol/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-capabilities-strict

--- a/pod-security-vpol/restricted/disallow-privilege-escalation/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/disallow-privilege-escalation/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../disallow-privilege-escalation.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: disallow-privilege-escalation

--- a/pod-security-vpol/restricted/disallow-privilege-escalation/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/disallow-privilege-escalation/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-privilege-escalation

--- a/pod-security-vpol/restricted/disallow-privilege-escalation/artifacthub-pkg.yml
+++ b/pod-security-vpol/restricted/disallow-privilege-escalation/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: fdf72c371267c5f40c8c495e2b867431a642304e51e677859cb45854215be009
+digest: 34d8b9c94b408fa00ce3ad872aade4cd89a089f6569dc7019e7c95f6fb4812cc
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/pod-security-vpol/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: disallow-privilege-escalation

--- a/pod-security-vpol/restricted/require-run-as-non-root-user/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/require-run-as-non-root-user/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../require-run-as-non-root-user.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-run-as-non-root-user

--- a/pod-security-vpol/restricted/require-run-as-non-root-user/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/require-run-as-non-root-user/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-run-as-non-root-user

--- a/pod-security-vpol/restricted/require-run-as-non-root-user/artifacthub-pkg.yml
+++ b/pod-security-vpol/restricted/require-run-as-non-root-user/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: d78df403e9573faf2fbf026175e5ac970ad8a7a891bbc139aee519b85728b916
+digest: 256b1395854cd66ed05ea5d5cc8a11cd48ac91ef7f14da930cf1a663f4834451
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml
+++ b/pod-security-vpol/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-run-as-non-root-user

--- a/pod-security-vpol/restricted/require-run-as-nonroot/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/require-run-as-nonroot/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../require-run-as-nonroot.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: require-run-as-nonroot

--- a/pod-security-vpol/restricted/require-run-as-nonroot/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/require-run-as-nonroot/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-run-as-nonroot

--- a/pod-security-vpol/restricted/require-run-as-nonroot/artifacthub-pkg.yml
+++ b/pod-security-vpol/restricted/require-run-as-nonroot/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: a4bc5aaea4de1c5d3d2c304764e3e4fa57e8dd21e42e7a1ffeb724ea0be8b9b7
+digest: 46fa659b5a41f1aa10ad2a83f3df9241c2a015a3b52d1959c346a146145571ca
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/pod-security-vpol/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: require-run-as-nonroot

--- a/pod-security-vpol/restricted/restrict-seccomp-strict/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/restrict-seccomp-strict/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../restrict-seccomp-strict.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-seccomp-strict

--- a/pod-security-vpol/restricted/restrict-seccomp-strict/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/restrict-seccomp-strict/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-seccomp-strict

--- a/pod-security-vpol/restricted/restrict-seccomp-strict/artifacthub-pkg.yml
+++ b/pod-security-vpol/restricted/restrict-seccomp-strict/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: 6dbd155991db3646193dd8e31f76a3e6a661afbf989def8a84a58390bb3aed6d
+digest: fc3966aa755864496f873f718af9ba2f3ab4383fa64ee818706b1d496a5419a0
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
+++ b/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-seccomp-strict

--- a/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
         file: ../restrict-volume-types.yaml
     - patch:
         resource:
-          apiVersion: policies.kyverno.io/v1alpha1
+          apiVersion: policies.kyverno.io/v1
           kind: ValidatingPolicy
           metadata:
             name: restrict-volume-types

--- a/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-volume-types

--- a/pod-security-vpol/restricted/restrict-volume-types/artifacthub-pkg.yml
+++ b/pod-security-vpol/restricted/restrict-volume-types/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod,Volume"
-digest: 100539592f4aa5e2ca3f65938ab97fe7f0d4afd0ff4b654f3242fcd0691780db
+digest: be1f376a19900337657ab7f2b79ba41a19b0aeab90c4e80de5dbb9ec7992ecd5
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security-vpol/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: ValidatingPolicy
 metadata:
   name: restrict-volume-types

--- a/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/policy-ready.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-privileged-existing-namespaces

--- a/psa-mpol/add-privileged-existing-namespaces/add-privileged-existing-namespaces.yaml
+++ b/psa-mpol/add-privileged-existing-namespaces/add-privileged-existing-namespaces.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-privileged-existing-namespaces

--- a/psa-mpol/add-privileged-existing-namespaces/artifacthub-pkg.yml
+++ b/psa-mpol/add-privileged-existing-namespaces/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Pod Security Admission"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Namespace"
-digest: 4dbcb99060e4b67a77460820be6de7cef31ff83a87f978342b656acbbf7f7d74
+digest: b8a9c673c1df1c60f581d303101f672891204bcc1b1b3cd06cdbaec57a7c2a95

--- a/psa-mpol/add-psa-labels/.chainsaw-test/policy-ready.yaml
+++ b/psa-mpol/add-psa-labels/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-psa-labels

--- a/psa-mpol/add-psa-labels/add-psa-labels.yaml
+++ b/psa-mpol/add-psa-labels/add-psa-labels.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-psa-labels

--- a/psa-mpol/add-psa-labels/artifacthub-pkg.yml
+++ b/psa-mpol/add-psa-labels/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ annotations:
   kyverno/category: "Pod Security Admission, EKS Best Practices"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Namespace"
-digest: 2c901e8fd195193f336eb91fed91e34530ad416174274199328a7aff4017c72d
+digest: 4f7071b4b8c5304eac285da727408a288d6d2de237b3c3aa0e355a8565d7ae54

--- a/psp-migration-mpol/add-apparmor/.chainsaw-test/policy-ready.yaml
+++ b/psp-migration-mpol/add-apparmor/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-apparmor-annotations

--- a/psp-migration-mpol/add-apparmor/add-apparmor.yaml
+++ b/psp-migration-mpol/add-apparmor/add-apparmor.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-apparmor-annotations

--- a/psp-migration-mpol/add-apparmor/artifacthub-pkg.yml
+++ b/psp-migration-mpol/add-apparmor/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "PSP Migration"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Pod,Annotation"
-digest: 49adbca02cda7890487110f36b73645a2d79576e6b83dbb175e9a8fef1ad9e2a
+digest: 210db03e68bc604b60d0ffe1f408a40cc51c97f086e891c120aa1df57c18a2cc

--- a/psp-migration-mpol/add-capabilities/.chainsaw-test/policy-ready.yaml
+++ b/psp-migration-mpol/add-capabilities/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-capabilities

--- a/psp-migration-mpol/add-capabilities/add-capabilities.yaml
+++ b/psp-migration-mpol/add-capabilities/add-capabilities.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-capabilities

--- a/psp-migration-mpol/add-capabilities/artifacthub-pkg.yml
+++ b/psp-migration-mpol/add-capabilities/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "PSP Migration"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Pod"
-digest: b6ad02411766fc28f2fc403d0e7ac26204ed8eace482f26d18a5e4b62e428f65
+digest: 5a4d390bc892adbfeb4b20d05df6687157ef04aa71ed6c3d78673e078599bdcc

--- a/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/policy-ready.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-runtimeclassname

--- a/psp-migration-mpol/add-runtimeClassName/add-runtimeClassName.yaml
+++ b/psp-migration-mpol/add-runtimeClassName/add-runtimeClassName.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: add-runtimeclassname

--- a/psp-migration-mpol/add-runtimeClassName/artifacthub-pkg.yml
+++ b/psp-migration-mpol/add-runtimeClassName/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "PSP Migration"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Pod"
-digest: 043d33822a1e157affe8db07640e1a15d9295f4c878c34e1426ff71f4a8537c2
+digest: 8c712977f473d2eff14f68ead2de739ddcd201f678fa5eb076fd98803901d979

--- a/velero-mpol/backup-all-volumes/.chainsaw-test/policy-ready.yaml
+++ b/velero-mpol/backup-all-volumes/.chainsaw-test/policy-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: backup-all-volumes

--- a/velero-mpol/backup-all-volumes/artifacthub-pkg.yml
+++ b/velero-mpol/backup-all-volumes/artifacthub-pkg.yml
@@ -30,4 +30,4 @@ annotations:
   kyverno/category: "Velero"
   kyverno/kubernetesVersion: "1.25"
   kyverno/subject: "Pod, Annotation"
-digest: 255170d885c182879285664a3ae614ae76835f8cf7ab2f6bde4e1b7fa78c17b2
+digest: 72ebf5e9553ce341a54de68014a72a3d6e5603e9314dcf61c7e80f236f1d7106

--- a/velero-mpol/backup-all-volumes/backup-all-volumes.yaml
+++ b/velero-mpol/backup-all-volumes/backup-all-volumes.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kyverno.io/v1alpha1
+apiVersion: policies.kyverno.io/v1
 kind: MutatingPolicy
 metadata:
   name: backup-all-volumes


### PR DESCRIPTION
## Summary

Upgrades all CEL policy examples from apiVersion `policies.kyverno.io/v1alpha1` to `policies.kyverno.io/v1`.

## Why

The v1 API is the stable version for Kyverno CEL policies. Updating these examples keeps the policy library current and prevents users from relying on deprecated API versions.

## Changes

- Updated apiVersion fields across CEL policy YAML files
- No functional logic changes
- Version-only upgrade

Fixes #1418
