### PR TITLE
fix: not trigger webhook when pod update

### DIFF
--- a/other-mpol/add-nodeSelector/add-nodeSelector.yaml
+++ b/other-mpol/add-nodeSelector/add-nodeSelector.yaml
@@ -16,7 +16,7 @@ spec:
     resourceRules:
     - apiGroups: [""]
       apiVersions: ["v1"]
-      operations: ["CREATE", "UPDATE"]
+      operations: ["CREATE"]
       resources: ["pods"]
     - apiGroups: ["apps"]
       apiVersions: ["v1"]
@@ -39,7 +39,7 @@ spec:
             path: "/spec/nodeSelector",
             value: dyn({"foo": "bar", "color": "orange"})
           }
-        ] : 
+        ] :
         [
           JSONPatch{
             op: "add",
@@ -65,7 +65,7 @@ spec:
               path: "/spec/template/spec/nodeSelector",
               value: dyn({"foo": "bar", "color": "orange"})
             }
-          ] : 
+          ] :
           [
             JSONPatch{
               op: "add",
@@ -92,7 +92,7 @@ spec:
               path: "/spec/jobTemplate/spec/template/spec/nodeSelector",
               value: dyn({"foo": "bar", "color": "orange"})
             }
-          ] : 
+          ] :
           [
             JSONPatch{
               op: "add",


### PR DESCRIPTION
## Related Issue(s)



## Description

<!--
What does this PR do?
-->

not trigger webhook when pod update because nodeSelector can't be changed when pod update

https://kubernetes.io/docs/concepts/workloads/pods/#pod-update-and-replacement

>Pod updates may not change fields other than spec.containers[*].image, spec.initContainers[*].image, spec.activeDeadlineSeconds, spec.terminationGracePeriodSeconds, spec.tolerations or spec.schedulingGates. For spec.tolerations, you can only add new entries.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
