### PR TITLE
Add test that proves ensure-readonly-volumemounts bug

### DIFF
--- a/other-cel/ensure-readonly-hostpath/.chainsaw-test/podcontrollers-good.yaml
+++ b/other-cel/ensure-readonly-hostpath/.chainsaw-test/podcontrollers-good.yaml
@@ -72,4 +72,31 @@ spec:
             hostPath:
               path: /var/log
           restartPolicy: OnFailure
-
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: goodstatefulset01
+spec:
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybox
+        image: ghcr.io/kyverno/test-busybox:1.35
+        volumeMounts:
+        - mountPath: /some/dir
+          name: foo
+          readOnly: true
+      initContainers:
+      - name: busybox-init
+        image: ghcr.io/kyverno/test-busybox:1.35
+      volumes:
+      - name: foo
+        hostPath:
+          path: /var/log


### PR DESCRIPTION
## Description

When `initContainer` has non-existent `volumeMounts`, the rule `ensure-readonly-volummounts` will end up with error:

```bash
ensure-readonly-hostpath:
  autogen-ensure-hostpaths-readonly: 'expression ''variables.hostPathVolumes.all(hostPath,
    variables.allContainers.all(container,  container.volumeMounts.orValue([]).all(volume,
    (hostPath.name != volume.name) || volume.?readOnly.orValue(false) == true)))''
    resulted in error: no such key: volumeMounts'
```

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.