### PR TITLE
fix: Make secret type field optional for secret-service-account token policy

### DIFF
--- a/other-cel/deny-secret-service-account-token-type/.chainsaw-test/chainsaw-test.yaml
+++ b/other-cel/deny-secret-service-account-token-type/.chainsaw-test/chainsaw-test.yaml
@@ -27,6 +27,8 @@ spec:
     - apply:
         file: good-secret.yaml
     - apply:
+        file: no-type-secret.yaml
+    - apply:
         expect:
         - check:
             ($error != null): true

--- a/other-cel/deny-secret-service-account-token-type/.chainsaw-test/no-type-secret.yaml
+++ b/other-cel/deny-secret-service-account-token-type/.chainsaw-test/no-type-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: no-type-secret
+stringData:
+  username: admin
+  password: t0p-Secret

--- a/other-cel/deny-secret-service-account-token-type/.kyverno-test/kyverno-test.yaml
+++ b/other-cel/deny-secret-service-account-token-type/.kyverno-test/kyverno-test.yaml
@@ -19,4 +19,10 @@ results:
   - good-secret
   result: pass
   rule: deny-secret-service-account-token-type
+- kind: Secret
+  policy: deny-secret-service-account-token-type
+  resources:
+  - no-type-secret
+  result: pass
+  rule: deny-secret-service-account-token-type
 

--- a/other-cel/deny-secret-service-account-token-type/.kyverno-test/resource.yaml
+++ b/other-cel/deny-secret-service-account-token-type/.kyverno-test/resource.yaml
@@ -12,6 +12,13 @@ metadata:
   name: good-secret
 type: kubernetes.io/basic-auth
 stringData:
-  username: admin 
-  password: t0p-Secret 
-
+  username: admin
+  password: t0p-Secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: no-type-secret
+stringData:
+  username: admin
+  password: t0p-Secret

--- a/other-cel/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
+++ b/other-cel/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
@@ -31,6 +31,6 @@ spec:
     validate:
       cel:
         expressions:
-          - expression: "object.type != 'kubernetes.io/service-account-token'"
+          - expression: "!has(object.type) || object.type != 'kubernetes.io/service-account-token'"
             message: "Secret ServiceAccount token type is not allowed."
             

--- a/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/chainsaw-test.yaml
@@ -30,6 +30,8 @@ spec:
     - apply:
         file: good-secret.yaml
     - apply:
+        file: no-type-secret.yaml
+    - apply:
         expect:
         - check:
             ($error != null): true

--- a/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/no-type-secret.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/.chainsaw-test/no-type-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: no-type-secret
+stringData:
+  username: admin
+  password: t0p-Secret

--- a/other-vpol/deny-secret-service-account-token-type/.kyverno-test/kyverno-test.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/.kyverno-test/kyverno-test.yaml
@@ -19,4 +19,10 @@ results:
   resources:
   - good-secret
   result: pass
+- isValidatingPolicy: true
+  kind: Secret
+  policy: deny-secret-service-account-token-type
+  resources:
+  - no-type-secret
+  result: pass
 

--- a/other-vpol/deny-secret-service-account-token-type/.kyverno-test/resource.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/.kyverno-test/resource.yaml
@@ -12,6 +12,13 @@ metadata:
   name: good-secret
 type: kubernetes.io/basic-auth
 stringData:
-  username: admin 
-  password: t0p-Secret 
-
+  username: admin
+  password: t0p-Secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: no-type-secret
+stringData:
+  username: admin
+  password: t0p-Secret

--- a/other-vpol/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
+++ b/other-vpol/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
@@ -28,6 +28,6 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["secrets"]
   validations:
-    - expression: "object.type != 'kubernetes.io/service-account-token'"
+    - expression: "!has(object.type) || object.type != 'kubernetes.io/service-account-token'"
       message: "Secret ServiceAccount token type is not allowed."
             

--- a/other/deny-secret-service-account-token-type/.chainsaw-test/chainsaw-test.yaml
+++ b/other/deny-secret-service-account-token-type/.chainsaw-test/chainsaw-test.yaml
@@ -25,6 +25,8 @@ spec:
     - apply:
         file: good-secret.yaml
     - apply:
+        file: no-type-secret.yaml
+    - apply:
         expect:
         - check:
             ($error != null): true

--- a/other/deny-secret-service-account-token-type/.chainsaw-test/no-type-secret.yaml
+++ b/other/deny-secret-service-account-token-type/.chainsaw-test/no-type-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: no-type-secret
+stringData:
+  username: admin
+  password: t0p-Secret

--- a/other/deny-secret-service-account-token-type/.kyverno-test/kyverno-test.yaml
+++ b/other/deny-secret-service-account-token-type/.kyverno-test/kyverno-test.yaml
@@ -19,3 +19,9 @@ results:
   - good-secret
   result: pass
   rule: deny-secret-service-account-token-type
+- kind: Secret
+  policy: deny-secret-service-account-token-type
+  resources:
+  - no-type-secret
+  result: pass
+  rule: deny-secret-service-account-token-type

--- a/other/deny-secret-service-account-token-type/.kyverno-test/resource.yaml
+++ b/other/deny-secret-service-account-token-type/.kyverno-test/resource.yaml
@@ -14,3 +14,11 @@ type: kubernetes.io/basic-auth
 stringData:
   username: admin 
   password: t0p-Secret 
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: no-type-secret
+stringData:
+  username: admin 
+  password: t0p-Secret 

--- a/other/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
+++ b/other/deny-secret-service-account-token-type/deny-secret-service-account-token-type.yaml
@@ -28,4 +28,4 @@ spec:
     validate:
       message: "Secret ServiceAccount token type is not allowed."
       pattern:
-        type: "!kubernetes.io/service-account-token"
+        =(type): '!kubernetes.io/service-account-token'


### PR DESCRIPTION
## Related Issue(s)

#1368

## Description

Fix undesired behaviour where the secret-service-account token policy fails when a secret has no type. Type is an optional field in a kubernetes secret that will default to Opaque

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
