### PR TITLE
fix: use optional access for volumeMounts in ensure-readonly-hostpath…

### DIFF
--- a/other-cel/ensure-readonly-hostpath/artifacthub-pkg.yml
+++ b/other-cel/ensure-readonly-hostpath/artifacthub-pkg.yml
@@ -19,6 +19,6 @@ annotations:
   kyverno/category: "Other in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: c0acb4aa284ff94ed26e343502b35bc959bbe45d2d8f3d7b4fbb6780e0e27828
+digest: 1b173e713bb7ec74165853c1697e911a3e19721b9431c32f0ff64e57a70c8224
 createdAt: "2024-04-05T17:39:16Z"
 

--- a/other-cel/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
+++ b/other-cel/ensure-readonly-hostpath/ensure-readonly-hostpath.yaml
@@ -40,6 +40,6 @@ spec:
         expressions:
           - expression: >-
               variables.hostPathVolumes.all(hostPath, variables.allContainers.all(container, 
-              container.volumeMounts.orValue([]).all(volume, (hostPath.name != volume.name) || volume.?readOnly.orValue(false) == true)))
+              container.?volumeMounts.orValue([]).all(volume, (hostPath.name != volume.name) || volume.?readOnly.orValue(false) == true)))
             message: All hostPath volumes must be mounted as readOnly.
       


### PR DESCRIPTION

## Related Issue(s)

https://github.com/kyverno/policies/issues/1443


## Description

Fix the issue related to empty or non existing `volumeMounts`field.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
