### PR TITLE
fix: resources can't be used for ephemeral containers (#1335)

### DIFF
--- a/best-practices/require-pod-requests-limits/.chainsaw-test/good-pods.yaml
+++ b/best-practices/require-pod-requests-limits/.chainsaw-test/good-pods.yaml
@@ -14,6 +14,9 @@ spec:
         cpu: "100m"
       limits:
         memory: "100Mi"
+  ephemeralContainers:
+    - name: nginx-debug
+      image: nginx-debug
 ---
 apiVersion: v1
 kind: Pod

--- a/best-practices/require-pod-requests-limits/.kyverno-test/resource.yaml
+++ b/best-practices/require-pod-requests-limits/.kyverno-test/resource.yaml
@@ -14,6 +14,9 @@ spec:
         cpu: "0.5"
       limits:
         memory: "256Mi"
+  ephemeralContainers:
+    - name: nginx-debug
+      image: nginx-debug
 ---
 apiVersion: v1
 kind: Pod

--- a/best-practices/require-pod-requests-limits/require-pod-requests-limits.yaml
+++ b/best-practices/require-pod-requests-limits/require-pod-requests-limits.yaml
@@ -43,10 +43,3 @@ spec:
                 cpu: "?*"
               limits:
                 memory: "?*"
-          =(ephemeralContainers):
-          - resources:
-              requests:
-                memory: "?*"
-                cpu: "?*"
-              limits:
-                memory: "?*"


### PR DESCRIPTION
From the docs:

> Pod resource allocations are immutable, so setting resources is disallowed [on ephemeral containers]. 

https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/#what-is-an-ephemeral-container

## Related Issue(s)


#1335 

## Description

Fixes #1335, otherwise ephemeral containers can't be created with the require-resources policy

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
