### PR TITLE
Convert old argo-cel clusterpolicy to validating policy

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -10,7 +10,7 @@ runs:
     - name: Setup Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: ~1.25.8
+        go-version: ~1.26.1
     - name: Install Tools
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go 
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.1
       - name: Test Policy
         run: go run ./cmd/cli/kubectl-kyverno test ../policies
         working-directory: kyverno
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go 
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: ~1.25.8
+          go-version: ~1.26.1
       - name: Lint policies
         run: |
           set -e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,24 @@ jobs:
       with:
         path: argo-cel
 
+  argo-vpol:
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [ v1.30.13, v1.31.9, v1.32.5, v1.33.1 ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+        with:
+          k8s-version: ${{ matrix.k8s-version }}
+      - name: Run Tests
+        uses: ./.github/actions/run-tests
+        with:
+          path: argo-vpol
+
   karpenter-mpol:
           strategy:
             fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,43 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           k8s-version: ${{ matrix.k8s-version }}
+      - name: Install Argo CD
+        shell: bash
+        run: |
+          set -e
+          kubectl create namespace argocd
+          kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+          kubectl wait --for=condition=available deployment \
+            -l app.kubernetes.io/part-of=argocd \
+            -n argocd \
+            --timeout=180s
+      - name: Grant Kyverno RBAC for argoproj resources
+        shell: bash
+        run: |
+          set -e
+          kubectl apply -f - <<EOF
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: kyverno:aggregate-to-admission-controller:argoproj
+            labels:
+              rbac.kyverno.io/aggregate-to-admission-controller: "true"
+          rules:
+            - apiGroups: [argoproj.io]
+              resources: [applications, appprojects]
+              verbs: [get, list, watch]
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: kyverno:aggregate-to-reports-controller:argoproj
+            labels:
+              rbac.kyverno.io/aggregate-to-reports-controller: "true"
+          rules:
+            - apiGroups: [argoproj.io]
+              resources: [applications, appprojects]
+              verbs: [get, list, watch]
+          EOF
       - name: Run Tests
         uses: ./.github/actions/run-tests
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           set -e
           kubectl create namespace argocd
-          kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+          kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
           kubectl wait --for=condition=available deployment \
             -l app.kubernetes.io/part-of=argocd \
             -n argocd \

--- a/argo-vpol/application-prevent-default-project/.chainsaw-test/bad-application.yaml
+++ b/argo-vpol/application-prevent-default-project/.chainsaw-test/bad-application.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: badapp
+  namespace: default
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+    targetRevision: HEAD
+    path: guestbook
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: guestbook

--- a/argo-vpol/application-prevent-default-project/.chainsaw-test/chainsaw-test.yaml
+++ b/argo-vpol/application-prevent-default-project/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: application-prevent-default-project
+spec:
+  template: false
+  steps:
+    - name: step-01
+      try:
+        - assert:
+            file: crd-assert.yaml
+    - name: step-02
+      try:
+        - apply:
+            file: ../application-prevent-default-project.yaml
+        - patch:
+            resource:
+              apiVersion: policies.kyverno.io/v1
+              kind: ValidatingPolicy
+              metadata:
+                name: application-prevent-default-project
+              spec:
+                validationActions: [Deny]
+        - assert:
+            file: policy-ready.yaml
+    - name: step-03
+      try:
+       - apply:
+           file: good-application.yaml
+       - apply:
+           expect:
+             - check:
+                 ($error != null): true
+           file: bad-application.yaml

--- a/argo-vpol/application-prevent-default-project/.chainsaw-test/crd-assert.yaml
+++ b/argo-vpol/application-prevent-default-project/.chainsaw-test/crd-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.argoproj.io
+spec: {}
+status:
+  acceptedNames:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    singular: application
+  storedVersions:
+    - v1alpha1

--- a/argo-vpol/application-prevent-default-project/.chainsaw-test/good-application.yaml
+++ b/argo-vpol/application-prevent-default-project/.chainsaw-test/good-application.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: goodapp
+  namespace: default
+spec:
+  project: biz
+  source:
+    repoURL: https://github.com/argoproj/argocd-example-apps.git
+    targetRevision: HEAD
+    path: guestbook
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: guestbook

--- a/argo-vpol/application-prevent-default-project/.chainsaw-test/policy-ready.yaml
+++ b/argo-vpol/application-prevent-default-project/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,15 @@
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: application-prevent-default-project
+status:
+  conditionStatus:
+    (conditions[?type == 'RBACPermissionsGranted']):
+      - message: Policy is ready for reporting.
+        reason: Succeeded
+        status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+      - message: Webhook configured.
+        reason: Succeeded
+        status: "True"
+        type: WebhookConfigured

--- a/argo-vpol/application-prevent-default-project/.kyverno-test/kyverno-test.yaml
+++ b/argo-vpol/application-prevent-default-project/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: application-prevent-default-project
+policies:
+  - ../application-prevent-default-project.yaml
+resources:
+  - ../.chainsaw-test/bad-application.yaml
+  - ../.chainsaw-test/good-application.yaml
+results:
+  - policy: application-prevent-default-project
+    rule: default-project
+    kind: Application
+    resources:
+      - badapp
+    result: fail
+  - policy: application-prevent-default-project
+    rule: default-project
+    kind: Application
+    resources:
+      - goodapp
+    result: pass

--- a/argo-vpol/application-prevent-default-project/application-prevent-default-project.yaml
+++ b/argo-vpol/application-prevent-default-project/application-prevent-default-project.yaml
@@ -1,0 +1,29 @@
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: application-prevent-default-project
+  annotations:
+    policies.kyverno.io/title: Prevent Use of Default Project in CEL expressions
+    policies.kyverno.io/category: Argo in CEL
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.17.0
+    policies.kyverno.io/minversion: 1.14.0
+    kyverno.io/kubernetes-version: "1.34-1.35"
+    policies.kyverno.io/subject: Application
+    policies.kyverno.io/description: >-
+      This policy prevents the use of the default project in an Application.
+spec:
+  validationActions:
+    - Audit
+  evaluation:
+    background:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["argoproj.io"]
+        apiVersions: [v1alpha1]
+        operations: [CREATE, UPDATE]
+        resources: [applications]
+  validations:
+    - message: "The default project may not be used in an Application."
+      expression: "object.spec.?project.orValue('') != 'default'"

--- a/argo-vpol/application-prevent-default-project/artifacthub-pkg.yml
+++ b/argo-vpol/application-prevent-default-project/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Argo in CEL"
   kyverno/kubernetesVersion: "1.34-1.35"
   kyverno/subject: "Application"
-Digest: 4adc299244578b4dc5677caa4e92f22dbfa42062eea4eb09d5c54445059d9c1e
+digest: 4adc299244578b4dc5677caa4e92f22dbfa42062eea4eb09d5c54445059d9c1e
 createdAt: "2026-04-02T03:33:39Z"

--- a/argo-vpol/application-prevent-default-project/artifacthub-pkg.yml
+++ b/argo-vpol/application-prevent-default-project/artifacthub-pkg.yml
@@ -1,0 +1,23 @@
+name: application-prevent-default-project-vpol
+version: 1.0.0
+displayName: Prevent Use of Default Project in CEL expressions
+description: >-
+  This policy prevents the use of the default project in an Application.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/argo-vpol/application-prevent-default-project/application-prevent-default-project.yaml
+  ```
+keywords:
+  - kyverno
+  - Argo
+  - CEL Expressions
+readme: |
+  This policy prevents the use of the default project in an Application.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Argo in CEL"
+  kyverno/kubernetesVersion: "1.34-1.35"
+  kyverno/subject: "Application"
+Digest: 4adc299244578b4dc5677caa4e92f22dbfa42062eea4eb09d5c54445059d9c1e
+createdAt: "2026-04-02T03:33:39Z"

--- a/other-vpol/allowed-annotations/.chainsaw-test/policy-ready.yaml
+++ b/other-vpol/allowed-annotations/.chainsaw-test/policy-ready.yaml
@@ -13,5 +13,3 @@ status:
       reason: Succeeded
       status: "True"
       type: WebhookConfigured
- 
-


### PR DESCRIPTION
## Related Issue(s)

Related #1463 

## Description

Cluster Policy is deprecated now in Kyverno v1.17 so, we are migrating `application-prevent-default-project` policy in `argo-cel` from ClusterPolicy to `ValidatingPolicy`

- [x] Create new argo-vpol directory
- [x] Convert `application-prevent-default-project` to vpol
- [x] add argo-vpol directory to CI tests

There are multiple ClusterPolicy I'd raise another PR for them later.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
