### PR TITLE
fix: make argo-vpol chainsaw test self-sufficient

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,43 +65,6 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           k8s-version: ${{ matrix.k8s-version }}
-      - name: Install Argo CD
-        shell: bash
-        run: |
-          set -e
-          kubectl create namespace argocd
-          kubectl apply -n argocd --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
-          kubectl wait --for=condition=available deployment \
-            -l app.kubernetes.io/part-of=argocd \
-            -n argocd \
-            --timeout=180s
-      - name: Grant Kyverno RBAC for argoproj resources
-        shell: bash
-        run: |
-          set -e
-          kubectl apply -f - <<EOF
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: ClusterRole
-          metadata:
-            name: kyverno:aggregate-to-admission-controller:argoproj
-            labels:
-              rbac.kyverno.io/aggregate-to-admission-controller: "true"
-          rules:
-            - apiGroups: [argoproj.io]
-              resources: [applications, appprojects]
-              verbs: [get, list, watch]
-          ---
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: ClusterRole
-          metadata:
-            name: kyverno:aggregate-to-reports-controller:argoproj
-            labels:
-              rbac.kyverno.io/aggregate-to-reports-controller: "true"
-          rules:
-            - apiGroups: [argoproj.io]
-              resources: [applications, appprojects]
-              verbs: [get, list, watch]
-          EOF
       - name: Run Tests
         uses: ./.github/actions/run-tests
         with:

--- a/argo-vpol/application-prevent-default-project/.chainsaw-test/chainsaw-test.yaml
+++ b/argo-vpol/application-prevent-default-project/.chainsaw-test/chainsaw-test.yaml
@@ -11,6 +11,8 @@ spec:
       try:
         - assert:
             file: crd-assert.yaml
+        - apply:
+            file: rbac.yaml
     - name: step-02
       try:
         - apply:

--- a/argo-vpol/application-prevent-default-project/.chainsaw-test/rbac.yaml
+++ b/argo-vpol/application-prevent-default-project/.chainsaw-test/rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:aggregate-to-admission-controller:argoproj
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+  - apiGroups: [argoproj.io]
+    resources: [applications, appprojects]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:aggregate-to-reports-controller:argoproj
+  labels:
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+rules:
+  - apiGroups: [argoproj.io]
+    resources: [applications, appprojects]
+    verbs: [get, list, watch]


### PR DESCRIPTION
## Related Issue(s)

- CI in `kyverno/kyverno` failing

## Description

The `argo-vpol/application-prevent-default-project` chainsaw test is failing in kyverno's CI  because the needed Kyverno RBAC grant for `argoproj.io` resources is only present in this repo's `test.yml` workflow.

This PR makes the test self-sufficient by adding rbacs to the chainsaw test and removing un-necessary code from the test workflow.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.