### PR TITLE
feat(pss): add image to allowed for restricted profile

### DIFF
--- a/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/pod-good.yaml
+++ b/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/pod-good.yaml
@@ -155,3 +155,20 @@ spec:
     secret:
       secretName: mysecret
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod10
+spec:
+  containers:
+  - name: container01
+    image: ghcr.io/kyverno/test-busybox:1.35
+    volumeMounts:
+    - mountPath: /myimage
+      name: myimage
+  volumes:
+  - name: myimage
+    image:
+      reference: ghcr.io/kyverno/test-busybox:1.35
+      pullPolicy: IfNotPresent
+---

--- a/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/podcontroller-good.yaml
+++ b/pod-security-cel/restricted/restrict-volume-types/.chainsaw-test/podcontroller-good.yaml
@@ -158,6 +158,33 @@ spec:
               expirationSeconds: 7200
               audience: vault
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # skipping right to 10 to keep consistent with pod-good.yaml
+  name: gooddeployment10
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: ghcr.io/kyverno/test-busybox:1.35
+        volumeMounts:
+        - mountPath: /myimage
+          name: myimage
+      volumes:
+      - name: myimage
+        image:
+          reference: ghcr.io/kyverno/test-busybox:1.35
+          pullPolicy: IfNotPresent
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -369,3 +396,26 @@ spec:
           - name: mysecret
             secret:
               secretName: mysecret
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob10
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: ghcr.io/kyverno/test-busybox:1.35
+            volumeMounts:
+            - mountPath: /myimage
+              name: myimage
+          volumes:
+          - name: myimage
+            image:
+              reference: ghcr.io/kyverno/test-busybox:1.35
+              pullPolicy: IfNotPresent

--- a/pod-security-cel/restricted/restrict-volume-types/.kyverno-test/kyverno-test.yaml
+++ b/pod-security-cel/restricted/restrict-volume-types/.kyverno-test/kyverno-test.yaml
@@ -94,6 +94,7 @@ results:
   - goodcronjob07
   - goodcronjob08
   - goodcronjob09
+  - goodcronjob10
   result: pass
   rule: restricted-volumes
 - kind: Deployment
@@ -108,6 +109,7 @@ results:
   - gooddeployment07
   - gooddeployment08
   - gooddeployment09
+  - gooddeployment10
   result: pass
   rule: restricted-volumes
 - kind: Pod
@@ -122,5 +124,6 @@ results:
   - goodpod07
   - goodpod08
   - goodpod09
+  - goodpod10
   result: pass
   rule: restricted-volumes

--- a/pod-security-cel/restricted/restrict-volume-types/.kyverno-test/resource.yaml
+++ b/pod-security-cel/restricted/restrict-volume-types/.kyverno-test/resource.yaml
@@ -497,6 +497,23 @@ spec:
     secret:
       secretName: mysecret
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod10
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+    volumeMounts:
+    - mountPath: /myimage
+      name: myimage
+  volumes:
+  - name: myimage
+    image:
+      reference: registry.example.com/my-image:latest
+      pullPolicy: IfNotPresent
+---
 ###### Deployments - Bad
 apiVersion: apps/v1
 kind: Deployment
@@ -1255,6 +1272,32 @@ spec:
         secret:
           secretName: mysecret
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment10
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+        volumeMounts:
+        - mountPath: /myimage
+          name: myimage
+      volumes:
+      - name: myimage
+        image:
+          reference: registry.example.com/my-image:latest
+          pullPolicy: IfNotPresent
+---
 ###### CronJobs - Bad
 apiVersion: batch/v1
 kind: CronJob
@@ -1927,3 +1970,26 @@ spec:
           - name: mysecret
             secret:
               secretName: mysecret
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob10
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+            volumeMounts:
+            - mountPath: /myimage
+              name: myimage
+          volumes:
+          - name: myimage
+            image:
+              reference: registry.example.com/my-image:latest
+              pullPolicy: IfNotPresent

--- a/pod-security-cel/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security-cel/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -37,9 +37,10 @@ spec:
                 has(vol.downwardAPI) ||
                 has(vol.emptyDir) ||
                 has(vol.ephemeral) ||
+                has(vol.image) ||
                 has(vol.persistentVolumeClaim) ||
                 has(vol.projected) ||
                 has(vol.secret))
               message: >-
                 Only the following types of volumes may be used: configMap, csi, downwardAPI,
-                emptyDir, ephemeral, persistentVolumeClaim, projected, and secret.
+                emptyDir, ephemeral, image, persistentVolumeClaim, projected, and secret.

--- a/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/pod-good.yaml
+++ b/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/pod-good.yaml
@@ -155,3 +155,20 @@ spec:
     secret:
       secretName: mysecret
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod10
+spec:
+  containers:
+  - name: container01
+    image: ghcr.io/kyverno/test-busybox:1.35
+    volumeMounts:
+    - mountPath: /myimage
+      name: myimage
+  volumes:
+  - name: myimage
+    image:
+      reference: ghcr.io/kyverno/test-busybox:1.35
+      pullPolicy: IfNotPresent
+---

--- a/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/podcontroller-good.yaml
+++ b/pod-security-vpol/restricted/restrict-volume-types/.chainsaw-test/podcontroller-good.yaml
@@ -158,6 +158,33 @@ spec:
               expirationSeconds: 7200
               audience: vault
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # skipping right to 10 to keep consistent with pod-good.yaml
+  name: gooddeployment10
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: ghcr.io/kyverno/test-busybox:1.35
+        volumeMounts:
+        - mountPath: /myimage
+          name: myimage
+      volumes:
+      - name: myimage
+        image:
+          reference: ghcr.io/kyverno/test-busybox:1.35
+          pullPolicy: IfNotPresent
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -369,3 +396,26 @@ spec:
           - name: mysecret
             secret:
               secretName: mysecret
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob10
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: ghcr.io/kyverno/test-busybox:1.35
+            volumeMounts:
+            - mountPath: /myimage
+              name: myimage
+          volumes:
+          - name: myimage
+            image:
+              reference: ghcr.io/kyverno/test-busybox:1.35
+              pullPolicy: IfNotPresent

--- a/pod-security-vpol/restricted/restrict-volume-types/.kyverno-test/kyverno-test.yaml
+++ b/pod-security-vpol/restricted/restrict-volume-types/.kyverno-test/kyverno-test.yaml
@@ -95,6 +95,7 @@ results:
   - goodcronjob07
   - goodcronjob08
   - goodcronjob09
+  - goodcronjob10
   result: pass
 - isValidatingPolicy: true
   kind: Deployment
@@ -109,6 +110,7 @@ results:
   - gooddeployment07
   - gooddeployment08
   - gooddeployment09
+  - gooddeployment10
   result: pass
 - isValidatingPolicy: true
   kind: Pod
@@ -123,4 +125,5 @@ results:
   - goodpod07
   - goodpod08
   - goodpod09
+  - goodpod10
   result: pass

--- a/pod-security-vpol/restricted/restrict-volume-types/.kyverno-test/resource.yaml
+++ b/pod-security-vpol/restricted/restrict-volume-types/.kyverno-test/resource.yaml
@@ -497,6 +497,23 @@ spec:
     secret:
       secretName: mysecret
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod10
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+    volumeMounts:
+    - mountPath: /myimage
+      name: myimage
+  volumes:
+  - name: myimage
+    image:
+      reference: registry.example.com/my-image:latest
+      pullPolicy: IfNotPresent
+---
 ###### Deployments - Bad
 apiVersion: apps/v1
 kind: Deployment
@@ -1255,6 +1272,32 @@ spec:
         secret:
           secretName: mysecret
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment10
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+        volumeMounts:
+        - mountPath: /myimage
+          name: myimage
+      volumes:
+      - name: myimage
+        image:
+          reference: registry.example.com/my-image:latest
+          pullPolicy: IfNotPresent
+---
 ###### CronJobs - Bad
 apiVersion: batch/v1
 kind: CronJob
@@ -1927,3 +1970,26 @@ spec:
           - name: mysecret
             secret:
               secretName: mysecret
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob10
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+            volumeMounts:
+            - mountPath: /myimage
+              name: myimage
+          volumes:
+          - name: myimage
+            image:
+              reference: registry.example.com/my-image:latest
+              pullPolicy: IfNotPresent

--- a/pod-security-vpol/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security-vpol/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -34,9 +34,10 @@ spec:
         has(vol.downwardAPI) ||
         has(vol.emptyDir) ||
         has(vol.ephemeral) ||
+        has(vol.image) ||
         has(vol.persistentVolumeClaim) ||
         has(vol.projected) ||
         has(vol.secret))
       message: >-
         Only the following types of volumes may be used: configMap, csi, downwardAPI,
-        emptyDir, ephemeral, persistentVolumeClaim, projected, and secret.
+        emptyDir, ephemeral, image, persistentVolumeClaim, projected, and secret.

--- a/pod-security/restricted/restrict-volume-types/.chainsaw-test/pod-good.yaml
+++ b/pod-security/restricted/restrict-volume-types/.chainsaw-test/pod-good.yaml
@@ -155,3 +155,20 @@ spec:
     secret:
       secretName: mysecret
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod10
+spec:
+  containers:
+  - name: container01
+    image: ghcr.io/kyverno/test-busybox:1.35
+    volumeMounts:
+    - mountPath: /myimage
+      name: myimage
+  volumes:
+  - name: myimage
+    image:
+      reference: ghcr.io/kyverno/test-busybox:1.35
+      pullPolicy: IfNotPresent
+---

--- a/pod-security/restricted/restrict-volume-types/.chainsaw-test/podcontroller-good.yaml
+++ b/pod-security/restricted/restrict-volume-types/.chainsaw-test/podcontroller-good.yaml
@@ -158,6 +158,33 @@ spec:
               expirationSeconds: 7200
               audience: vault
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # skipping right to 10 to keep consistent with pod-good.yaml
+  name: gooddeployment10
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: ghcr.io/kyverno/test-busybox:1.35
+        volumeMounts:
+        - mountPath: /myimage
+          name: myimage
+      volumes:
+      - name: myimage
+        image:
+          reference: ghcr.io/kyverno/test-busybox:1.35
+          pullPolicy: IfNotPresent
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -369,3 +396,27 @@ spec:
           - name: mysecret
             secret:
               secretName: mysecret
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob10
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: ghcr.io/kyverno/test-busybox:1.35
+            volumeMounts:
+            - mountPath: /myimage
+              name: myimage
+          volumes:
+          - name: myimage
+            image:
+              reference: ghcr.io/kyverno/test-busybox:1.35
+              pullPolicy: IfNotPresent
+---

--- a/pod-security/restricted/restrict-volume-types/.kyverno-test/kyverno-test.yaml
+++ b/pod-security/restricted/restrict-volume-types/.kyverno-test/kyverno-test.yaml
@@ -94,6 +94,7 @@ results:
   - goodcronjob07
   - goodcronjob08
   - goodcronjob09
+  - goodcronjob10
   result: pass
   rule: restricted-volumes
 - kind: Deployment
@@ -108,6 +109,7 @@ results:
   - gooddeployment07
   - gooddeployment08
   - gooddeployment09
+  - gooddeployment10
   result: pass
   rule: restricted-volumes
 - kind: Pod
@@ -122,5 +124,6 @@ results:
   - goodpod07
   - goodpod08
   - goodpod09
+  - goodpod10
   result: pass
   rule: restricted-volumes

--- a/pod-security/restricted/restrict-volume-types/.kyverno-test/resource.yaml
+++ b/pod-security/restricted/restrict-volume-types/.kyverno-test/resource.yaml
@@ -497,6 +497,23 @@ spec:
     secret:
       secretName: mysecret
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod10
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+    volumeMounts:
+    - mountPath: /myimage
+      name: myimage
+  volumes:
+  - name: myimage
+    image:
+      reference: registry.example.com/my-image:latest
+      pullPolicy: IfNotPresent
+---
 ###### Deployments - Bad
 apiVersion: apps/v1
 kind: Deployment
@@ -1255,6 +1272,32 @@ spec:
         secret:
           secretName: mysecret
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment10
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: container01
+        image: dummyimagename
+        volumeMounts:
+        - mountPath: /myimage
+          name: myimage
+      volumes:
+      - name: myimage
+        image:
+          reference: registry.example.com/my-image:latest
+          pullPolicy: IfNotPresent
+---
 ###### CronJobs - Bad
 apiVersion: batch/v1
 kind: CronJob
@@ -1927,3 +1970,26 @@ spec:
           - name: mysecret
             secret:
               secretName: mysecret
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob10
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: container01
+            image: dummyimagename
+            volumeMounts:
+            - mountPath: /myimage
+              name: myimage
+          volumes:
+          - name: myimage
+            image:
+              reference: registry.example.com/my-image:latest
+              pullPolicy: IfNotPresent

--- a/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -32,7 +32,7 @@ spec:
       validate:
         message: >-
           Only the following types of volumes may be used: configMap, csi, downwardAPI,
-          emptyDir, ephemeral, persistentVolumeClaim, projected, and secret.
+          emptyDir, ephemeral, image, persistentVolumeClaim, projected, and secret.
         deny:
           conditions:
             all:
@@ -45,6 +45,7 @@ spec:
               - downwardAPI
               - emptyDir
               - ephemeral
+              - image
               - persistentVolumeClaim
               - projected
               - secret


### PR DESCRIPTION
## Related Issue(s)

n/a — aligning policies with pss helm chart tracked in https://github.com/kyverno/kyverno/pull/15906

See that PR for more details.

## Description

Kubernetes v1.31 introduced the `image` volume type (OCI image volumes) as an alpha feature, and it is beta (enabled by default) starting in v1.35. The Pod Security Standards Restricted profile was updated upstream to allow this volume type, but the `restrict-volume-types` policies in this repo did not include it.

This means pods using `image` volumes are incorrectly blocked by the Restricted profile, even though the upstream PSS allows them.

This PR adds `image` to the allowed volume types across all three policy variants:

### `pod-security` — ClusterPolicy (`restrict-volume-types.yaml`)

- Added `image` to the `AnyNotIn` allow list in the deny rule
- Updated the user-facing message to include `image`

### `pod-security-cel` — ClusterPolicy with CEL (`restrict-volume-types.yaml`)

- Added `has(vol.image)` to the CEL `all()` expression
- Updated the user-facing message to include `image`

### `pod-security-vpol` — ValidatingPolicy (`restrict-volume-types.yaml`)

- Added `has(vol.image)` to the CEL `all()` expression
- Updated the user-facing message to include `image`

### Tests

- Added `goodpod10`, `gooddeployment10`, and `goodcronjob10` with `image` volumes to chainsaw and kyverno-test fixtures for all three variants

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [ ] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
  - I think I don't have to update this, but I wasn't sure... 
