### PR TITLE
Convert Old SLSA provenance ClusterPolicy to IVPOL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -854,6 +854,24 @@ jobs:
         shard-index: ${{ matrix.shard-index }}
         shard-count: 9
 
+  other-ivpol:
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [v1.30.13, v1.31.9, v1.32.5, v1.33.1]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Setup Environment
+      uses: ./.github/actions/setup-env
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+    - name: Run Tests
+      uses: ./.github/actions/run-tests
+      with:
+        path: other-ivpol
+
   pod-security:
     strategy:
       fail-fast: false

--- a/other-ivpol/verify-image-slsa/.chainsaw-test/bad.yaml
+++ b/other-ivpol/verify-image-slsa/.chainsaw-test/bad.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-pod
+spec:
+  containers:
+    - name: test-container
+      image: 'myreg.org/path/repo:v1'
+      imagePullPolicy: Always

--- a/other-ivpol/verify-image-slsa/.chainsaw-test/chainsaw-test.yaml
+++ b/other-ivpol/verify-image-slsa/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: verify-image-slsa
+spec:
+  template: false
+
+  steps:
+    - name: step-01
+      try:
+        - apply:
+            file: ../verify-image-slsa.yaml
+        - assert:
+            file: policy.yaml
+    - name: step-02
+      try:
+        - create:
+            file: good.yaml
+            timeout: 60s
+        - create:
+            timeout: 60s
+            expect:
+              - check:
+                  ($error != null): true
+            file: bad.yaml

--- a/other-ivpol/verify-image-slsa/.chainsaw-test/good.yaml
+++ b/other-ivpol/verify-image-slsa/.chainsaw-test/good.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+spec:
+  containers:
+    - name: test-container
+      image: 'nginx:latest'
+      imagePullPolicy: Always

--- a/other-ivpol/verify-image-slsa/.chainsaw-test/policy.yaml
+++ b/other-ivpol/verify-image-slsa/.chainsaw-test/policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: policies.kyverno.io/v1
+kind: ImageValidatingPolicy
+metadata:
+  name: verify-slsa-provenance-keyless
+status:
+  conditionStatus:
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-ivpol/verify-image-slsa/artifacthub-pkg.yml
+++ b/other-ivpol/verify-image-slsa/artifacthub-pkg.yml
@@ -22,4 +22,4 @@ annotations:
   kyverno/kubernetesVersion: "1.35"
   kyverno/subject: "Pod"
 createdAt: "2026-05-13T13:35:28Z"
-digest: 92dc46e16b5428066c54bd409bf5a06081c80b7d034df57625442824d0d701b6
+digest: b61d92f4158cff06539c2cf6718382ea70844021dc5a636fbf08e31a570372f4

--- a/other-ivpol/verify-image-slsa/artifacthub-pkg.yml
+++ b/other-ivpol/verify-image-slsa/artifacthub-pkg.yml
@@ -1,0 +1,25 @@
+name: verify-image-slsa
+version: 1.0.0
+displayName: Verify Image SLSA Provenance
+description: >-
+  Your policy description here explaining what the policy does.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other-ivpol/verify-image-slsa/verify-image-slsa.yaml
+  ```
+
+keywords:
+  - kyverno
+  - Software Supply Chain Security
+
+readme: |
+  Provenance is used to identify how an artifact was produced and from where it originated. SLSA provenance is an industry-standard method of representing that provenance. This policy verifies that an image has SLSA provenance and was signed by the expected subject and issuer when produced through GitHub Actions. It requires configuration based upon your own values.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+
+annotations:
+  kyverno/category: "Software Supply Chain Security"
+  kyverno/kubernetesVersion: "1.35"
+  kyverno/subject: "Pod"
+createdAt: "2026-05-13T13:35:28Z"
+digest: 92dc46e16b5428066c54bd409bf5a06081c80b7d034df57625442824d0d701b6

--- a/other-ivpol/verify-image-slsa/verify-image-slsa.yaml
+++ b/other-ivpol/verify-image-slsa/verify-image-slsa.yaml
@@ -1,0 +1,55 @@
+apiVersion: policies.kyverno.io/v1
+kind: ImageValidatingPolicy
+metadata:
+  name: verify-slsa-provenance-keyless
+  annotations:
+    policies.kyverno.io/title: Verify SLSA Provenance (Keyless)
+    policies.kyverno.io/category: Software Supply Chain Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.18.0
+    policies.kyverno.io/description: >-
+      Provenance is used to identify how an artifact was produced
+      and from where it originated. SLSA provenance is an industry-standard
+      method of representing that provenance. This policy verifies that an
+      image has SLSA provenance and was signed by the expected subject and issuer
+      when produced through GitHub Actions. It requires configuration based upon
+      your own values.
+spec:
+  validationActions: [Audit]
+  webhookConfiguration:
+    timeoutSeconds: 30
+
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+
+  matchImageReferences:
+    - glob: "myreg.org/path/repo:*"
+
+  attestors:
+    - name: cosign
+      cosign:
+        keyless:
+          identities:
+            - subject: "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v*"
+              issuer: "https://token.actions.githubusercontent.com"
+        ctlog:
+          url: https://rekor.sigstore.dev
+
+  attestations:
+    - name: slsaProvenance
+      intoto:
+        type: https://slsa.dev/provenance/v0.2
+
+  validations:
+    - message: "Failed to verify SLSA provenance attestation signature with Cosign keyless"
+      expression: >-
+        images.containers.map(image, verifyAttestationSignatures(image, attestations.slsaProvenance, [attestors.cosign])).all(e, e > 0)
+
+    - message: "builder.id in the attestation is not equal to the official SLSA provenance generator workflow"
+      expression: >-
+        images.containers.map(image, extractPayload(image, attestations.slsaProvenance).builder.id.matches('^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9].[0-9].[0-9]$')).all(e, e)

--- a/other-ivpol/verify-image-slsa/verify-image-slsa.yaml
+++ b/other-ivpol/verify-image-slsa/verify-image-slsa.yaml
@@ -16,7 +16,7 @@ metadata:
       when produced through GitHub Actions. It requires configuration based upon
       your own values.
 spec:
-  validationActions: [Audit]
+  validationActions: [Deny]
   webhookConfiguration:
     timeoutSeconds: 30
 


### PR DESCRIPTION
## Related Issue(s)

Part of #1488

Old ClusterPolicy: https://github.com/kyverno/policies/tree/main/other/verify-image-slsa

## Description

Convert old SLSA Provenance policy into the new ImageValidating policy

## Checklist



- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
