### PR TITLE
Convert old verify-image-with-multi-keys to ivpol

### DIFF
--- a/other-ivpol/verify-image-with-multi-keys/.chainsaw-test/bad.yaml
+++ b/other-ivpol/verify-image-with-multi-keys/.chainsaw-test/bad.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-pod
+  namespace: test-signing
+spec:
+  containers:
+    - name: test-container
+      image: 'ghcr.io/kyverno/test-verify-image:unsigned'
+      imagePullPolicy: Always

--- a/other-ivpol/verify-image-with-multi-keys/.chainsaw-test/chainsaw-test.yaml
+++ b/other-ivpol/verify-image-with-multi-keys/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: verify-image-with-multi-keys
+spec:
+  # disable templating because it can cause issues with CEL expressions
+  template: false
+
+  steps:
+  - name: step-01
+    try:
+    - script:
+        content: kubectl create namespace test-signing || true
+    - apply:
+        file: ../verify-image-with-multi-keys.yaml
+    - apply:
+        file: configmap.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - create:
+        file: good.yaml
+        timeout: 360s
+    - create:
+        timeout: 360s
+        expect:
+        - check:
+            ($error != null): true
+        file: bad.yaml

--- a/other-ivpol/verify-image-with-multi-keys/.chainsaw-test/configmap.yaml
+++ b/other-ivpol/verify-image-with-multi-keys/.chainsaw-test/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keys
+  namespace: default
+data:
+  production: |
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
+    5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
+    -----END PUBLIC KEY-----
+
+  test-signing: |
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
+    5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
+    -----END PUBLIC KEY-----

--- a/other-ivpol/verify-image-with-multi-keys/.chainsaw-test/good.yaml
+++ b/other-ivpol/verify-image-with-multi-keys/.chainsaw-test/good.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+  namespace: test-signing
+spec:
+  containers:
+    - name: test-container
+      image: 'ghcr.io/kyverno/test-verify-image@sha256:b588b277f929d067df06f8a88edfc4c5f9b0ec4349aa426e74e2923df46b3656'
+      imagePullPolicy: Always

--- a/other-ivpol/verify-image-with-multi-keys/.chainsaw-test/policy-ready.yaml
+++ b/other-ivpol/verify-image-with-multi-keys/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,15 @@
+apiVersion: policies.kyverno.io/v1
+kind: ImageValidatingPolicy
+metadata:
+  name: verify-image-with-multi-keys
+status:
+  conditionStatus:
+    (conditions[?type == 'RBACPermissionsGranted']):
+    - message: Policy is ready for reporting.
+      reason: Succeeded
+      status: "True"
+    (conditions[?type == 'WebhookConfigured']):
+    - message: Webhook configured.
+      reason: Succeeded
+      status: "True"
+      type: WebhookConfigured

--- a/other-ivpol/verify-image-with-multi-keys/artifacthub-pkg.yml
+++ b/other-ivpol/verify-image-with-multi-keys/artifacthub-pkg.yml
@@ -1,0 +1,23 @@
+name: verify-image-with-multi-keys-ivpol
+version: 1.0.0
+displayName: Verify Image with Multiple Keys (IVPOL)
+description: >-
+  There may be multiple keys used to sign images based on the parties involved in the creation process. This image verification policy requires the named image be signed by two separate keys.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other-ivpol/verify-image-with-multi-keys/verify-image-with-multi-keys.yaml
+  ```
+keywords:
+  - kyverno
+  - Software Supply Chain Security
+
+readme: |
+  There may be multiple keys used to sign images based on the parties involved in the creation process. This image verification policy requires the named image be signed by two separate keys.
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+
+annotations:
+  kyverno/category: "Software Supply Chain Security"
+  kyverno/kubernetesVersion: "1.35"
+  kyverno/subject: "Pod"
+createdAt: "2026-05-13T17:40:00Z"
+digest: 2c9890db2ef11f01fad508360402f7601a22c33f87801864b115e5b68ca26185

--- a/other-ivpol/verify-image-with-multi-keys/artifacthub-pkg.yml
+++ b/other-ivpol/verify-image-with-multi-keys/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ annotations:
   kyverno/kubernetesVersion: "1.35"
   kyverno/subject: "Pod"
 createdAt: "2026-05-13T17:40:00Z"
-digest: 2c9890db2ef11f01fad508360402f7601a22c33f87801864b115e5b68ca26185
+digest: 6fa49e150eb5fb9e69a9f13c161df2fdd261a0b42e4a349d2508c1d48da74c1d

--- a/other-ivpol/verify-image-with-multi-keys/verify-image-with-multi-keys.yaml
+++ b/other-ivpol/verify-image-with-multi-keys/verify-image-with-multi-keys.yaml
@@ -1,0 +1,57 @@
+apiVersion: policies.kyverno.io/v1
+kind: ImageValidatingPolicy
+metadata:
+  name: verify-image-with-multi-keys
+  annotations:
+    policies.kyverno.io/title: Verify Image with Multiple Keys
+    policies.kyverno.io/category: Software Supply Chain Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.14.0
+    policies.kyverno.io/description: >-
+      There may be multiple keys used to sign images based on
+      the parties involved in the creation process. This image
+      verification policy requires the named image be signed by
+      two separate keys.
+spec:
+  validationActions: [Deny]
+  webhookConfiguration:
+    timeoutSeconds: 30
+  evaluation:
+    background:
+      enabled: false
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+  variables:
+  - name: keys
+    expression: 'resource.Get("v1", "configmaps", "default", "keys")'
+  matchImageReferences:
+  - glob: "ghcr.io/kyverno/test-verify-image:*"
+  attestors:
+  - name: productionKey
+    cosign:
+      key:
+        expression: "variables.keys.data.production"
+      ctlog:
+        insecureIgnoreTlog: true
+  - name: namespaceKey
+    cosign:
+      key:
+        expression: "variables.keys.data[object.metadata.namespace]"
+      ctlog:
+        insecureIgnoreTlog: true
+  validations:
+  - message: "Image is missing a valid signature from the production key."
+    expression: >-
+      images.containers.all(image, 
+        verifyImageSignatures(image, [attestors.productionKey]) >= 1
+      )
+  - message: "Image is missing a valid signature from the namespace-specific key."
+    expression: >-
+      images.containers.all(image, 
+        verifyImageSignatures(image, [attestors.namespaceKey]) >= 1
+      )


### PR DESCRIPTION
## Related Issue(s)

Part of #1488 

Old ClusterPolicy: https://github.com/kyverno/policies/tree/main/other/verify-image-with-multi-keys

## Description

Convert `verify-image-with-multi-keys` to the new IVPOL

## Checklist


- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
