### PR TITLE
Add label-node-selector policy

### DIFF
--- a/other/label-node-selector/.chainsaw-test/chainsaw-test.yaml
+++ b/other/label-node-selector/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: label-node-selector
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: permissions.yaml
+    - script:
+        content: |
+          kubectl get configmap -n kyverno kyverno -o yaml | sed 's/\[Node\/\*,\*,\*\]//g' | sed 's/\[Node,\*,\*\]//g' | kubectl apply -f -
+    - script:
+        content: |
+          node=$(kubectl get nodes --no-headers | awk '{print $1}' | head -n 1)
+          kubectl label node "$node" NodeType=test --overwrite
+    - sleep:
+        duration: 5s
+  - name: step-02
+    try:
+    - apply:
+        file: ../label-node-selector.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-03
+    try:
+    - sleep:
+        duration: 5s
+    - script:
+        content: ./label-check.sh

--- a/other/label-node-selector/.chainsaw-test/label-check.sh
+++ b/other/label-node-selector/.chainsaw-test/label-check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+node=$(kubectl get nodes --no-headers | awk '{print $1}' | head -n 1)
+if kubectl get node "$node" -o json | grep -q '"node-role.kubernetes.io/test": ""'; then
+    echo "Success: node $node labelled node-role.kubernetes.io/test"
+    exit 0
+fi
+echo "Failed to label node $node node-role.kubernetes.io/test"
+exit 1

--- a/other/label-node-selector/.chainsaw-test/permissions.yaml
+++ b/other/label-node-selector/.chainsaw-test/permissions.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:background-controller:label-node-selector
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/other/label-node-selector/.chainsaw-test/policy-ready.yaml
+++ b/other/label-node-selector/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: label-node-selector
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/other/label-node-selector/artifacthub-pkg.yml
+++ b/other/label-node-selector/artifacthub-pkg.yml
@@ -1,0 +1,28 @@
+name: label-node-selector
+version: 1.0.0
+displayName: Label Nodes with Node Selector
+createdAt: "2026-05-15T00:00:00Z"
+description: >-
+  Label Nodes with Node Selector so only well-known labels can be applied during node bootstrapping.
+  This policy reads the `NodeType` label on a Node and writes a corresponding
+  `node-role.kubernetes.io/<NodeType>` label to that Node. The Node resource filter should
+  be removed and users may need to grant the Kyverno ServiceAccount permission to update Nodes.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/label-node-selector/label-node-selector.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+readme: |
+  Label Nodes with Node Selector so only well-known labels can be applied during node bootstrapping.
+  This policy reads the `NodeType` label on a Node and writes a corresponding
+  `node-role.kubernetes.io/<NodeType>` label to that Node. The Node resource filter should
+  be removed and users may need to grant the Kyverno ServiceAccount permission to update Nodes.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.23"
+  kyverno/subject: "Node, Label"
+digest: ed3161cabec4528727c8e466b94c7242651923c9106d5cba9967eb28e8186617

--- a/other/label-node-selector/label-node-selector.yaml
+++ b/other/label-node-selector/label-node-selector.yaml
@@ -1,0 +1,40 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: label-node-selector
+  annotations:
+    policies.kyverno.io/title: Label Nodes with Node Selector
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Node, Label
+    kyverno.io/kyverno-version: 1.7.2
+    policies.kyverno.io/minversion: 1.7.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/description: >-
+      Label Nodes with Node Selector so only well-known labels can be applied during node bootstrapping.
+      This policy reads the `NodeType` label on a Node and writes a corresponding
+      `node-role.kubernetes.io/<NodeType>` label to that Node. The Node resource filter should
+      be removed and users may need to grant the Kyverno ServiceAccount permission to update Nodes.
+spec:
+  mutateExistingOnPolicyUpdate: true
+  rules:
+    - name: label-node-selector
+      match:
+        any:
+          - resources:
+              kinds:
+                - Node
+      preconditions:
+        all:
+          - key: "{{ request.object.metadata.labels.NodeType || '' }}"
+            operator: NotEquals
+            value: ""
+      mutate:
+        targets:
+          - apiVersion: v1
+            kind: Node
+            name: "{{ request.object.metadata.name }}"
+        patchesJson6902: |-
+          - op: add
+            path: /metadata/labels/node-role.kubernetes.io~1{{ request.object.metadata.labels.NodeType }}
+            value: ""


### PR DESCRIPTION
Actually the idea is to use field "role" in K8s UI-s for marking (the cattle) nodes.

This policy adds "well known" label node-role.kubernetes.io/ROLE= to each node. It is impossible to do on a bootstrap phase so the idea is to do it later with Kyverno. 

It looks like(FreeLens):
<img width="1736" height="638" alt="image" src="https://github.com/user-attachments/assets/8ec3ef21-1f94-49a8-aa14-9bcbeeb92a51" />

K9s:
<img width="2302" height="380" alt="image" src="https://github.com/user-attachments/assets/c7a43100-7de9-45ac-a552-41b61f96825c" />

So in general it is easier to observe and operate those marked nodes.

P.S. Includes Artifact Hub metadata, a Chainsaw test, and RBAC notes for the Kyverno background controller and Node resource filter.