### PR TITLE
fix: correct CEL evaluation for strict seccomp inheritance

### DIFF
--- a/pod-security-cel/restricted/restrict-seccomp-strict/.kyverno-test/kyverno-test.yaml
+++ b/pod-security-cel/restricted/restrict-seccomp-strict/.kyverno-test/kyverno-test.yaml
@@ -41,6 +41,7 @@ results:
   - badpod05
   - badpod06
   - badpod07
+  - badpod08
   result: fail
   rule: check-seccomp-strict
 - kind: CronJob
@@ -86,5 +87,6 @@ results:
   - goodpod08
   - goodpod09
   - goodpod10
+  - goodpod11
   result: pass
   rule: check-seccomp-strict

--- a/pod-security-cel/restricted/restrict-seccomp-strict/.kyverno-test/resource.yaml
+++ b/pod-security-cel/restricted/restrict-seccomp-strict/.kyverno-test/resource.yaml
@@ -107,6 +107,15 @@ spec:
   - name: container01
     image: dummyimagename
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod08
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+---
 ###### Pods - Good
 apiVersion: v1
 kind: Pod
@@ -274,6 +283,18 @@ spec:
   securityContext:
     seccompProfile:
       type: RuntimeDefault
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod11
+spec:
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: container01
+    image: dummyimagename
 ---
 ###### Deployments - Bad
 apiVersion: apps/v1

--- a/pod-security-cel/restricted/restrict-seccomp-strict/artifacthub-pkg.yml
+++ b/pod-security-cel/restricted/restrict-seccomp-strict/artifacthub-pkg.yml
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "Pod"
-digest: 66cf094f57c592abe9378262ca46d3860bf5cbdb67cc9d53654eaf784549b916
+digest: 48f7fa6426ef41733bbb9a9292c199a3b5abcf664cc3e2b0eb32c030188e1f3a
 createdAt: "2023-12-04T09:04:49Z"

--- a/pod-security-cel/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
+++ b/pod-security-cel/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
@@ -33,6 +33,14 @@ spec:
         cel:
           expressions:
             - expression: >-
+                !object.spec.?securityContext.?seccompProfile.?type.hasValue() ||
+                object.spec.securityContext.seccompProfile.type == 'RuntimeDefault' ||
+                object.spec.securityContext.seccompProfile.type == 'Localhost'
+              message: >-
+                Use of custom Seccomp profiles is disallowed. The field
+                spec.securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`.
+
+            - expression: >-
                 object.spec.containers.all(container,
                   (container.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost']) ||
                   (!container.?securityContext.?seccompProfile.?type.hasValue() && object.spec.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost'])
@@ -41,7 +49,7 @@ spec:
                 Use of custom Seccomp profiles is disallowed. The field
                 spec.containers[*].securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`,
                 or inherited from spec.securityContext.seccompProfile.type.
-              
+
             - expression: >-
                 object.spec.?initContainers.orValue([]).all(container,
                   (container.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost']) ||

--- a/pod-security-cel/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
+++ b/pod-security-cel/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
@@ -32,40 +32,32 @@ spec:
       validate:
         cel:
           expressions:
-            - expression: >- 
-                !object.spec.?securityContext.?seccompProfile.?type.hasValue() ||
-                object.spec.securityContext.seccompProfile.type == 'RuntimeDefault' ||
-                object.spec.securityContext.seccompProfile.type == 'Localhost'
-              message: >-
-                Use of custom Seccomp profiles is disallowed. The field
-                spec.securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`.
-      
-            - expression: >- 
+            - expression: >-
                 object.spec.containers.all(container,
-                  !container.?securityContext.?seccompProfile.?type.hasValue() ||
-                  container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
-                  container.securityContext.seccompProfile.type == 'Localhost'
+                  (container.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost']) ||
+                  (!container.?securityContext.?seccompProfile.?type.hasValue() && object.spec.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost'])
                 )
               message: >-
                 Use of custom Seccomp profiles is disallowed. The field
-                spec.containers[*].securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`.
+                spec.containers[*].securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`,
+                or inherited from spec.securityContext.seccompProfile.type.
               
-            - expression: >- 
+            - expression: >-
                 object.spec.?initContainers.orValue([]).all(container,
-                  !container.?securityContext.?seccompProfile.?type.hasValue() ||
-                  container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
-                  container.securityContext.seccompProfile.type == 'Localhost'
+                  (container.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost']) ||
+                  (!container.?securityContext.?seccompProfile.?type.hasValue() && object.spec.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost'])
                 )
               message: >-
                 Use of custom Seccomp profiles is disallowed. The field
-                spec.initContainers[*].securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`.
+                spec.initContainers[*].securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`,
+                or inherited from spec.securityContext.seccompProfile.type.
 
-            - expression: >- 
+            - expression: >-
                 object.spec.?ephemeralContainers.orValue([]).all(container,
-                  !container.?securityContext.?seccompProfile.?type.hasValue() ||
-                  container.securityContext.seccompProfile.type == 'RuntimeDefault' ||
-                  container.securityContext.seccompProfile.type == 'Localhost'
+                  (container.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost']) ||
+                  (!container.?securityContext.?seccompProfile.?type.hasValue() && object.spec.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost'])
                 )
               message: >-
                 Use of custom Seccomp profiles is disallowed. The field
-                spec.ephemeralContainers[*].securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`.
+                spec.ephemeralContainers[*].securityContext.seccompProfile.type must be set to `RuntimeDefault` or `Localhost`,
+                or inherited from spec.securityContext.seccompProfile.type.


### PR DESCRIPTION
## Related Issue(s)
Closes #1446

## Description
This PR fixes the CEL evaluation logic for strict seccomp inheritance. It addresses the behavior mismatch reported when transforming the `restrict-seccomp-strict` ClusterPolicy into CEL-Expressions.

## Checklist
* [x] I have read the policy contribution guidelines.
* [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
* [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.