### PR TITLE
add disallow-static-aws-credentials policy

### DIFF
--- a/aws/disallow-static-aws-credentials/.chainsaw-test/secret-fail-data.yaml
+++ b/aws/disallow-static-aws-credentials/.chainsaw-test/secret-fail-data.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-creds-data
+  namespace: default
+type: Opaque
+data:
+  AWS_ACCESS_KEY_ID: QUTJQUVYT1NGT0RORjdFWEFNUExF
+  AWS_SECRET_ACCESS_KEY: d0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQ==

--- a/aws/disallow-static-aws-credentials/.chainsaw-test/secret-fail-stringdata.yaml
+++ b/aws/disallow-static-aws-credentials/.chainsaw-test/secret-fail-stringdata.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-creds-stringdata
+  namespace: default
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: AKIAIOSFODNN7EXAMPLE
+  AWS_SECRET_ACCESS_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/aws/disallow-static-aws-credentials/.chainsaw-test/secret-pass.yaml
+++ b/aws/disallow-static-aws-credentials/.chainsaw-test/secret-pass.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-config
+  namespace: default
+type: Opaque
+data:
+  DATABASE_URL: cG9zdGdyZXM6Ly91c2VyOnBhc3NAZGI6NTQzMi9teWRi
+  API_TOKEN: c29tZS1hcGktdG9rZW4=

--- a/aws/disallow-static-aws-credentials/.kyverno-test/kyverno-test.yaml
+++ b/aws/disallow-static-aws-credentials/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: disallow-static-aws-credentials
+policies:
+  - ../disallow-static-aws-credentials.yaml
+resources:
+  - ../.chainsaw-test/secret-fail-data.yaml
+  - ../.chainsaw-test/secret-fail-stringdata.yaml
+  - ../.chainsaw-test/secret-pass.yaml
+results:
+  - policy: disallow-static-aws-credentials
+    rule: deny-static-aws-credentials
+    kind: Secret
+    resources:
+      - aws-creds-data
+    result: fail
+  - policy: disallow-static-aws-credentials
+    rule: deny-static-aws-credentials
+    kind: Secret
+    resources:
+      - aws-creds-stringdata
+    result: fail
+  - policy: disallow-static-aws-credentials
+    rule: deny-static-aws-credentials
+    kind: Secret
+    resources:
+      - app-config
+    result: pass

--- a/aws/disallow-static-aws-credentials/artifacthub-pkg.yml
+++ b/aws/disallow-static-aws-credentials/artifacthub-pkg.yml
@@ -1,0 +1,30 @@
+name: disallow-static-aws-credentials
+version: 1.0.0
+displayName: Disallow Static AWS Credentials
+createdAt: "2026-06-12T00:00:00.000Z"
+description: >-
+  Static AWS credentials stored in Kubernetes Secrets are not automatically rotated,
+  may be exposed through etcd backups or audit logs, and bypass IAM access controls.
+  IAM Roles for Service Accounts (IRSA) is the recommended approach for granting AWS
+  API access to Pods on EKS. This policy audits Secrets whose data or stringData fields
+  contain the keys AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/aws/disallow-static-aws-credentials/disallow-static-aws-credentials.yaml
+  ```
+keywords:
+  - kyverno
+  - AWS, EKS Best Practices
+readme: |
+  Static AWS credentials stored in Kubernetes Secrets are not automatically rotated,
+  may be exposed through etcd backups or audit logs, and bypass IAM access controls.
+  IAM Roles for Service Accounts (IRSA) is the recommended approach for granting AWS
+  API access to Pods on EKS. This policy audits Secrets whose data or stringData fields
+  contain the keys AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "AWS, EKS Best Practices"
+  kyverno/kubernetesVersion: "1.26-1.30"
+  kyverno/subject: "Secret"
+digest: 34ed77a393a0f009182e4f66ee6f085509f42ea5e8bfd51e5ac4415b50e13d2a

--- a/aws/disallow-static-aws-credentials/disallow-static-aws-credentials.yaml
+++ b/aws/disallow-static-aws-credentials/disallow-static-aws-credentials.yaml
@@ -1,0 +1,51 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-static-aws-credentials
+  annotations:
+    policies.kyverno.io/title: Disallow Static AWS Credentials
+    policies.kyverno.io/category: AWS, EKS Best Practices
+    policies.kyverno.io/severity: high
+    kyverno.io/kyverno-version: 1.11.0
+    policies.kyverno.io/minversion: 1.11.0
+    kyverno.io/kubernetes-version: "1.26-1.30"
+    policies.kyverno.io/subject: Secret
+    policies.kyverno.io/description: >-
+      Static AWS credentials stored in Kubernetes Secrets are not automatically rotated,
+      may be exposed through etcd backups or audit logs, and bypass IAM access controls.
+      IAM Roles for Service Accounts (IRSA) is the recommended approach for granting AWS
+      API access to Pods on EKS. This policy audits Secrets whose data or stringData fields
+      contain the keys AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: deny-static-aws-credentials
+      match:
+        any:
+          - resources:
+              kinds:
+                - Secret
+      preconditions:
+        all:
+          - key: "{{ request.operation || 'BACKGROUND' }}"
+            operator: NotEquals
+            value: DELETE
+      validate:
+        message: >-
+          Secrets must not contain static AWS credentials (AWS_ACCESS_KEY_ID,
+          AWS_SECRET_ACCESS_KEY). Use IAM Roles for Service Accounts (IRSA) instead.
+          See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+        deny:
+          conditions:
+            any:
+              - key: "{{ keys(request.object.data || `{}`) }}"
+                operator: AnyIn
+                value:
+                  - AWS_ACCESS_KEY_ID
+                  - AWS_SECRET_ACCESS_KEY
+              - key: "{{ keys(request.object.stringData || `{}`) }}"
+                operator: AnyIn
+                value:
+                  - AWS_ACCESS_KEY_ID
+                  - AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
## What this does

Adds a new policy to the `aws/` category that audits Kubernetes Secrets containing static AWS credentials as key names (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) in their `data` or `stringData` fields.

## Why it's needed

Static AWS credentials stored in Kubernetes Secrets:
- Are not automatically rotated
- Can be exposed via etcd backups, audit logs, or accidental `kubectl get secret -o yaml`
- Bypass IAM-level audit trails and controls

IAM Roles for Service Accounts (IRSA) is the correct pattern for EKS workloads needing AWS API access. This policy gives platform teams an audit signal when static credentials appear in the cluster, with a message pointing to the IRSA docs.

## What's checked

The policy checks both `data` (base64-encoded at admission) and `stringData` (plaintext, visible at admission time before API server encoding) so it catches credentials regardless of how the Secret was created.

## Test results

```
Test Summary: 3 tests passed and 0 tests failed
```

- `aws-creds-data` — Secret with creds in `data` → fail ✓
- `aws-creds-stringdata` — Secret with creds in `stringData` → fail ✓  
- `app-config` — Secret with unrelated keys → pass ✓

## Checklist

- [x] Policy annotations complete
- [x] `validationFailureAction: Audit`
- [x] `background: true`
- [x] `kyverno-test.yaml` with passing and failing resources
- [x] `artifacthub-pkg.yml` with SHA256 digest (verified on Linux)
- [x] DCO sign-off on commit