### PR TITLE
New Policy: timeoutSeconds is less than periodSeconds

### DIFF
--- a/best-practices/validate-probe-timeout-period/.chainsaw-test/bad-liveness-timeout.yaml
+++ b/best-practices/validate-probe-timeout-period/.chainsaw-test/bad-liveness-timeout.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-liveness-timeout
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      timeoutSeconds: 15
+      periodSeconds: 10

--- a/best-practices/validate-probe-timeout-period/.chainsaw-test/bad-readiness-timeout.yaml
+++ b/best-practices/validate-probe-timeout-period/.chainsaw-test/bad-readiness-timeout.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-readiness-timeout
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 8080
+      timeoutSeconds: 10
+      periodSeconds: 10

--- a/best-practices/validate-probe-timeout-period/.chainsaw-test/bad-startup-timeout.yaml
+++ b/best-practices/validate-probe-timeout-period/.chainsaw-test/bad-startup-timeout.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-startup-timeout
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    startupProbe:
+      httpGet:
+        path: /startup
+        port: 8080
+      timeoutSeconds: 30
+      periodSeconds: 10

--- a/best-practices/validate-probe-timeout-period/.chainsaw-test/chainsaw-test.yaml
+++ b/best-practices/validate-probe-timeout-period/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: validate-probe-timeout-period
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../validate-probe-timeout-period.yaml
+    - patch:
+        resource:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          metadata:
+            name: validate-probe-timeout-period
+          spec:
+            validationFailureAction: Enforce
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: good-pods.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: bad-liveness-timeout.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: bad-readiness-timeout.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: bad-startup-timeout.yaml

--- a/best-practices/validate-probe-timeout-period/.chainsaw-test/good-pods.yaml
+++ b/best-practices/validate-probe-timeout-period/.chainsaw-test/good-pods.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod-defaults
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      # Using defaults: timeoutSeconds=1, periodSeconds=10 (valid)
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod-explicit
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      timeoutSeconds: 5
+      periodSeconds: 10
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 8080
+      timeoutSeconds: 3
+      periodSeconds: 5
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod-startup
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    startupProbe:
+      httpGet:
+        path: /startup
+        port: 8080
+      timeoutSeconds: 2
+      periodSeconds: 5
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod-all-probes
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      timeoutSeconds: 1
+      periodSeconds: 5
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 8080
+      timeoutSeconds: 2
+      periodSeconds: 10
+    startupProbe:
+      httpGet:
+        path: /startup
+        port: 8080
+      timeoutSeconds: 5
+      periodSeconds: 10

--- a/best-practices/validate-probe-timeout-period/.chainsaw-test/policy-ready.yaml
+++ b/best-practices/validate-probe-timeout-period/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,8 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-probe-timeout-period
+status:
+  conditions:
+  - status: "True"
+    type: Ready

--- a/best-practices/validate-probe-timeout-period/.kyverno-test/kyverno-test.yaml
+++ b/best-practices/validate-probe-timeout-period/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,60 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: validate-probe-timeout-period
+policies:
+- ../validate-probe-timeout-period.yaml
+resources:
+- resource.yaml
+results:
+- kind: Pod
+  policy: validate-probe-timeout-period
+  resources:
+  - bad-liveness-timeout
+  result: fail
+  rule: validate-liveness-probe-timeout
+- kind: Pod
+  policy: validate-probe-timeout-period
+  resources:
+  - bad-readiness-timeout
+  result: fail
+  rule: validate-readiness-probe-timeout
+- kind: Pod
+  policy: validate-probe-timeout-period
+  resources:
+  - bad-startup-timeout
+  result: fail
+  rule: validate-startup-probe-timeout
+- kind: Pod
+  policy: validate-probe-timeout-period
+  resources:
+  - bad-liveness-equal
+  result: fail
+  rule: validate-liveness-probe-timeout
+- kind: Pod
+  policy: validate-probe-timeout-period
+  resources:
+  - good-pod-defaults
+  - good-pod-explicit
+  - good-pod-startup
+  - good-pod-all-probes
+  result: pass
+  rule: validate-liveness-probe-timeout
+- kind: Pod
+  policy: validate-probe-timeout-period
+  resources:
+  - good-pod-defaults
+  - good-pod-explicit
+  - good-pod-startup
+  - good-pod-all-probes
+  result: pass
+  rule: validate-readiness-probe-timeout
+- kind: Pod
+  policy: validate-probe-timeout-period
+  resources:
+  - good-pod-defaults
+  - good-pod-explicit
+  - good-pod-startup
+  - good-pod-all-probes
+  result: pass
+  rule: validate-startup-probe-timeout

--- a/best-practices/validate-probe-timeout-period/.kyverno-test/resource.yaml
+++ b/best-practices/validate-probe-timeout-period/.kyverno-test/resource.yaml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod-defaults
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      # Using defaults: timeoutSeconds=1, periodSeconds=10 (valid)
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod-explicit
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      timeoutSeconds: 5
+      periodSeconds: 10
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 8080
+      timeoutSeconds: 3
+      periodSeconds: 5
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod-startup
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    startupProbe:
+      httpGet:
+        path: /startup
+        port: 8080
+      timeoutSeconds: 2
+      periodSeconds: 5
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod-all-probes
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      timeoutSeconds: 1
+      periodSeconds: 5
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 8080
+      timeoutSeconds: 2
+      periodSeconds: 10
+    startupProbe:
+      httpGet:
+        path: /startup
+        port: 8080
+      timeoutSeconds: 5
+      periodSeconds: 10
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-liveness-timeout
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      timeoutSeconds: 15
+      periodSeconds: 10
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-readiness-timeout
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 8080
+      timeoutSeconds: 10
+      periodSeconds: 10
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-startup-timeout
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    startupProbe:
+      httpGet:
+        path: /startup
+        port: 8080
+      timeoutSeconds: 30
+      periodSeconds: 10
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-liveness-equal
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      timeoutSeconds: 5
+      periodSeconds: 5

--- a/best-practices/validate-probe-timeout-period/artifacthub-pkg.yml
+++ b/best-practices/validate-probe-timeout-period/artifacthub-pkg.yml
@@ -1,0 +1,21 @@
+name: validate-probe-timeout-period
+version: 1.0.0
+displayName: Validate Probe Timeout Period
+createdAt: "2026-06-26T00:00:00.000Z"
+description: >-
+  Probe timeoutSeconds should be less than periodSeconds to prevent overlapping probe executions. When timeoutSeconds is greater than or equal to periodSeconds, multiple concurrent probes can run simultaneously for the same container, leading to resource waste, unclear probe states, and unexpected behavior. This policy validates that for all probe types (liveness, readiness, startup), the timeout value is less than the period value, accounting for default values (timeoutSeconds defaults to 1, periodSeconds defaults to 10).
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/best-practices/validate-probe-timeout-period/validate-probe-timeout-period.yaml
+  ```
+keywords:
+  - kyverno
+  - Best Practices
+readme: |
+  Probe timeoutSeconds should be less than periodSeconds to prevent overlapping probe executions. When timeoutSeconds is greater than or equal to periodSeconds, multiple concurrent probes can run simultaneously for the same container, leading to resource waste, unclear probe states, and unexpected behavior. This policy validates that for all probe types (liveness, readiness, startup), the timeout value is less than the period value, accounting for default values (timeoutSeconds defaults to 1, periodSeconds defaults to 10).
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Best Practices"
+  kyverno/subject: "Pod"
+digest: 0cc735cd221582df3876377305905f9482eff5f68d1a3437b6c922dd135e2e0d

--- a/best-practices/validate-probe-timeout-period/validate-probe-timeout-period.yaml
+++ b/best-practices/validate-probe-timeout-period/validate-probe-timeout-period.yaml
@@ -1,0 +1,114 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-probe-timeout-period
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: DaemonSet,Deployment,StatefulSet
+    policies.kyverno.io/title: Validate Probe Timeout Period
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23+"
+    policies.kyverno.io/description: >-
+      Probe timeoutSeconds should be less than periodSeconds to prevent overlapping
+      probe executions. When timeoutSeconds is greater than or equal to periodSeconds,
+      multiple concurrent probes can run simultaneously for the same container, leading to
+      resource waste, unclear probe states, and unexpected behavior. This policy validates
+      that for all probe types (liveness, readiness, startup), the timeout value is less
+      than the period value, accounting for default values (timeoutSeconds defaults to 1,
+      periodSeconds defaults to 10).
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+  - name: validate-liveness-probe-timeout
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+    validate:
+      message: >-
+        Liveness probe timeoutSeconds ({{element.livenessProbe.timeoutSeconds || `1`}})
+        must be less than periodSeconds ({{element.livenessProbe.periodSeconds || `10`}}).
+      foreach:
+      - list: request.object.spec.containers[]
+        preconditions:
+          all:
+          - key: livenessProbe
+            operator: AnyIn
+            value: "{{ element.keys(@)[] }}"
+        deny:
+          conditions:
+            any:
+            - key: "{{ element.livenessProbe.timeoutSeconds || `1` }}"
+              operator: GreaterThanOrEquals
+              value: "{{ element.livenessProbe.periodSeconds || `10` }}"
+  - name: validate-readiness-probe-timeout
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+    validate:
+      message: >-
+        Readiness probe timeoutSeconds ({{element.readinessProbe.timeoutSeconds || `1`}})
+        must be less than periodSeconds ({{element.readinessProbe.periodSeconds || `10`}}).
+      foreach:
+      - list: request.object.spec.containers[]
+        preconditions:
+          all:
+          - key: readinessProbe
+            operator: AnyIn
+            value: "{{ element.keys(@)[] }}"
+        deny:
+          conditions:
+            any:
+            - key: "{{ element.readinessProbe.timeoutSeconds || `1` }}"
+              operator: GreaterThanOrEquals
+              value: "{{ element.readinessProbe.periodSeconds || `10` }}"
+  - name: validate-startup-probe-timeout
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    preconditions:
+      all:
+      - key: "{{request.operation || 'BACKGROUND'}}"
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+    validate:
+      message: >-
+        Startup probe timeoutSeconds ({{element.startupProbe.timeoutSeconds || `1`}})
+        must be less than periodSeconds ({{element.startupProbe.periodSeconds || `10`}}).
+      foreach:
+      - list: request.object.spec.containers[]
+        preconditions:
+          all:
+          - key: startupProbe
+            operator: AnyIn
+            value: "{{ element.keys(@)[] }}"
+        deny:
+          conditions:
+            any:
+            - key: "{{ element.startupProbe.timeoutSeconds || `1` }}"
+              operator: GreaterThanOrEquals
+              value: "{{ element.startupProbe.periodSeconds || `10` }}"


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

## Description

While debugging customer issue we observed that following config was used for the probes:
```
readinessProbe:
      failureThreshold: 60
      httpGet:
        path: /k8s/api/v0/ready
        port: http
        scheme: HTTP
      initialDelaySeconds: 1
      periodSeconds: 1
      successThreshold: 1
      timeoutSeconds: 15
```

Initially thought of fixing this on k8s. But there is some rare use cases where overlap can happen. So its better to flag this as bad practice rather blocking someone doing it. Hence contributing to kyverno.

**AI Usage:**
I have used AI for test cases. The main issue was manually identified in a real customer scenario.

<!--
What does this PR do?
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
