### PR TITLE
feat: add AI workload governance policies (require-ai-workload-controls, restrict-ai-network-egress)

### DIFF
--- a/other/require-ai-workload-controls/.chainsaw-test/bad-pod-no-annotation.yaml
+++ b/other/require-ai-workload-controls/.chainsaw-test/bad-pod-no-annotation.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-ai-workload-no-annotation
+  labels:
+    ai.workload/type: model-serving
+  # Missing: ai.workload/audit-logging annotation
+spec:
+  containers:
+  - name: inference-server
+    image: pytorch/pytorch:2.1.0-cuda11.8-cudnn8-runtime

--- a/other/require-ai-workload-controls/.chainsaw-test/bad-pod-plain-credential.yaml
+++ b/other/require-ai-workload-controls/.chainsaw-test/bad-pod-plain-credential.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-ai-workload-plain-credential
+  labels:
+    ai.workload/type: model-serving
+  annotations:
+    ai.workload/audit-logging: enabled
+spec:
+  containers:
+  - name: inference-server
+    image: pytorch/pytorch:2.1.0-cuda11.8-cudnn8-runtime
+    env:
+    - name: OPENAI_API_KEY
+      value: sk-proj-thisisaplaintextcredential  # violation: must use secretKeyRef
+    - name: MODEL_NAME
+      value: gpt-4o

--- a/other/require-ai-workload-controls/.chainsaw-test/chainsaw-test.yaml
+++ b/other/require-ai-workload-controls/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: require-ai-workload-controls
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../require-ai-workload-controls.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: good-pod.yaml
+  - name: step-03
+    try:
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+          file: bad-pod-no-annotation.yaml
+  - name: step-04
+    try:
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+          file: bad-pod-plain-credential.yaml

--- a/other/require-ai-workload-controls/.chainsaw-test/good-pod.yaml
+++ b/other/require-ai-workload-controls/.chainsaw-test/good-pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-ai-workload
+  labels:
+    ai.workload/type: model-serving
+  annotations:
+    ai.workload/audit-logging: enabled
+spec:
+  containers:
+  - name: inference-server
+    image: pytorch/pytorch:2.1.0-cuda11.8-cudnn8-runtime
+    env:
+    - name: OPENAI_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: ai-credentials
+          key: openai-api-key
+    - name: MODEL_NAME
+      value: gpt-4o
+    - name: MAX_TOKENS
+      value: "2048"

--- a/other/require-ai-workload-controls/.chainsaw-test/policy-ready.yaml
+++ b/other/require-ai-workload-controls/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-ai-workload-controls
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/other/require-ai-workload-controls/artifacthub-pkg.yml
+++ b/other/require-ai-workload-controls/artifacthub-pkg.yml
@@ -1,0 +1,40 @@
+name: require-ai-workload-controls
+version: 1.0.0
+displayName: Require AI Workload Controls
+createdAt: "2026-06-30T00:00:00.000Z"
+description: >-
+  Enforces security controls on AI model workload pods identified by the label
+  ai.workload/type. Requires an audit-logging annotation and blocks plain-text
+  AI API credentials in environment variables — API keys, tokens, and secrets
+  must be sourced from a Kubernetes Secret via secretKeyRef.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/require-ai-workload-controls/require-ai-workload-controls.yaml
+  ```
+keywords:
+  - kyverno
+  - ai
+  - security
+  - credentials
+  - audit
+  - machine-learning
+readme: |
+  Enforces two security controls on pods labelled as AI workloads
+  (ai.workload/type label present):
+
+  1. Requires the annotation `ai.workload/audit-logging: enabled` to confirm
+     that audit logging is configured for the workload.
+
+  2. Blocks plain-text AI API credentials in environment variables. Environment
+     variable names matching common AI service credential patterns
+     (OPENAI_API_KEY, ANTHROPIC_API_KEY, HUGGINGFACE_TOKEN, etc.) must use
+     secretKeyRef — plain-text values risk credential exposure in pod specs,
+     logs, and Kubernetes audit records.
+
+  Refer to the documentation for more details on Kyverno annotations:
+  https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.24+"
+  kyverno/subject: "Pod"
+digest: a3306c64b8dbbbb5035cef440ecfa44a100b61a46e0be8f0aab97d4daa442deb

--- a/other/require-ai-workload-controls/require-ai-workload-controls.yaml
+++ b/other/require-ai-workload-controls/require-ai-workload-controls.yaml
@@ -1,0 +1,68 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-ai-workload-controls
+  annotations:
+    policies.kyverno.io/title: Require AI Workload Controls
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.24+"
+    policies.kyverno.io/description: >-
+      Enforces security controls on AI model workload pods identified by the
+      label `ai.workload/type`. Requires an `ai.workload/audit-logging: enabled`
+      annotation to confirm audit logging is configured, and blocks plain-text
+      AI API credentials in environment variables — names matching common AI
+      service credential patterns (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY,
+      HUGGINGFACE_TOKEN) must be sourced from a Secret via secretKeyRef, not
+      set as plain-text values. These controls reduce the risk of credential
+      exposure in logs and audit trails for AI inference workloads.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+  - name: require-audit-logging-annotation
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchExpressions:
+            - key: ai.workload/type
+              operator: Exists
+    validate:
+      message: >-
+        Pods labelled as AI workloads must carry the annotation
+        'ai.workload/audit-logging: enabled' to confirm audit logging
+        is configured for this workload.
+      pattern:
+        metadata:
+          annotations:
+            ai.workload/audit-logging: enabled
+
+  - name: no-plain-text-ai-credentials
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchExpressions:
+            - key: ai.workload/type
+              operator: Exists
+    foreach:
+    - list: "request.object.spec.containers"
+      deny:
+        conditions:
+          any:
+          - key: "{{ element.env[?value != null] | [?regex_match('(OPENAI|ANTHROPIC|HUGGINGFACE|COHERE|REPLICATE|MISTRAL|GEMINI|GROQ|TOGETHER|BEDROCK).*(KEY|TOKEN|SECRET)|.*_(API_KEY|API_TOKEN|MODEL_KEY|MODEL_SECRET)$', name)] | length(@) }}"
+            operator: GreaterThan
+            value: "0"
+    validate:
+      message: >-
+        AI API credentials (API keys, tokens, secrets) must be sourced from
+        a Kubernetes Secret via secretKeyRef — plain-text values in env vars
+        risk credential exposure in pod specs, logs, and audit records.

--- a/other/restrict-ai-network-egress/.chainsaw-test/bad-pod-host-network.yaml
+++ b/other/restrict-ai-network-egress/.chainsaw-test/bad-pod-host-network.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-ai-workload-host-network
+  labels:
+    ai.workload/type: model-serving
+    networkpolicy.networking.k8s.io/policy-group: ai-inference
+spec:
+  hostNetwork: true  # violation: bypasses all NetworkPolicy egress rules
+  containers:
+  - name: inference-server
+    image: pytorch/pytorch:2.1.0-cuda11.8-cudnn8-runtime

--- a/other/restrict-ai-network-egress/.chainsaw-test/bad-pod-no-network-label.yaml
+++ b/other/restrict-ai-network-egress/.chainsaw-test/bad-pod-no-network-label.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-ai-workload-no-network-label
+  labels:
+    ai.workload/type: model-serving
+    # Missing: networkpolicy.networking.k8s.io/policy-group label
+spec:
+  containers:
+  - name: inference-server
+    image: pytorch/pytorch:2.1.0-cuda11.8-cudnn8-runtime

--- a/other/restrict-ai-network-egress/.chainsaw-test/chainsaw-test.yaml
+++ b/other/restrict-ai-network-egress/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: restrict-ai-network-egress
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../restrict-ai-network-egress.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: good-pod.yaml
+  - name: step-03
+    try:
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+          file: bad-pod-host-network.yaml
+  - name: step-04
+    try:
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+          file: bad-pod-no-network-label.yaml

--- a/other/restrict-ai-network-egress/.chainsaw-test/good-pod.yaml
+++ b/other/restrict-ai-network-egress/.chainsaw-test/good-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-ai-workload
+  labels:
+    ai.workload/type: model-serving
+    networkpolicy.networking.k8s.io/policy-group: ai-inference
+spec:
+  hostNetwork: false
+  containers:
+  - name: inference-server
+    image: pytorch/pytorch:2.1.0-cuda11.8-cudnn8-runtime

--- a/other/restrict-ai-network-egress/.chainsaw-test/policy-ready.yaml
+++ b/other/restrict-ai-network-egress/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-ai-network-egress
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/other/restrict-ai-network-egress/artifacthub-pkg.yml
+++ b/other/restrict-ai-network-egress/artifacthub-pkg.yml
@@ -1,0 +1,39 @@
+name: restrict-ai-network-egress
+version: 1.0.0
+displayName: Restrict AI Workload Network Egress
+createdAt: "2026-06-30T00:00:00.000Z"
+description: >-
+  Enforces network egress controls on AI model workload pods identified by the
+  label ai.workload/type. Blocks hostNetwork=true (which bypasses NetworkPolicy)
+  and requires a NetworkPolicy binding label to ensure egress restrictions are
+  enforced on outbound model API calls.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/restrict-ai-network-egress/restrict-ai-network-egress.yaml
+  ```
+keywords:
+  - kyverno
+  - ai
+  - network
+  - egress
+  - networkpolicy
+  - machine-learning
+readme: |
+  Enforces two network egress controls on pods labelled as AI workloads
+  (ai.workload/type label present):
+
+  1. Blocks `spec.hostNetwork: true`, which gives a pod direct access to the
+     node network and bypasses all NetworkPolicy egress rules.
+
+  2. Requires the label `networkpolicy.networking.k8s.io/policy-group` so that
+     a matching NetworkPolicy can enforce egress restrictions on outbound model
+     API calls. AI inference pods regularly reach external model APIs; without
+     this label, no NetworkPolicy selector can target the pod.
+
+  Refer to the documentation for more details on Kyverno annotations:
+  https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.24+"
+  kyverno/subject: "Pod, NetworkPolicy"
+digest: 8e8f1984a815ea381d66cc4fb7ee661ce7a78a044bb0a8f4adeb331d99847a2f

--- a/other/restrict-ai-network-egress/restrict-ai-network-egress.yaml
+++ b/other/restrict-ai-network-egress/restrict-ai-network-egress.yaml
@@ -1,0 +1,64 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-ai-network-egress
+  annotations:
+    policies.kyverno.io/title: Restrict AI Workload Network Egress
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod, NetworkPolicy
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.24+"
+    policies.kyverno.io/description: >-
+      Enforces network egress controls on AI model workload pods identified by
+      the label `ai.workload/type`. Blocks `spec.hostNetwork: true`, which
+      gives a pod direct access to the node network and bypasses all
+      NetworkPolicy egress rules, and requires every AI workload pod to carry
+      a `networkpolicy.networking.k8s.io/policy-group` label so that a
+      matching NetworkPolicy selector can enforce egress restrictions. AI
+      inference pods regularly reach external model APIs; without these
+      controls, a compromised pod can exfiltrate data or make arbitrary
+      outbound calls.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+  - name: block-host-network
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchExpressions:
+            - key: ai.workload/type
+              operator: Exists
+    validate:
+      message: >-
+        AI workload pods must not use hostNetwork. Setting hostNetwork=true
+        gives the pod direct node network access and bypasses all
+        NetworkPolicy egress controls.
+      pattern:
+        spec:
+          =(hostNetwork): "false"
+
+  - name: require-network-policy-label
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchExpressions:
+            - key: ai.workload/type
+              operator: Exists
+    validate:
+      message: >-
+        AI workload pods must carry the label
+        'networkpolicy.networking.k8s.io/policy-group' so that a matching
+        NetworkPolicy can enforce egress restrictions on outbound model API calls.
+      pattern:
+        metadata:
+          labels:
+            networkpolicy.networking.k8s.io/policy-group: "?*"


### PR DESCRIPTION
## Description

Adds two new `ClusterPolicy` resources under `other/` to govern Kubernetes pods running AI model workloads. Pods are identified by the presence of the `ai.workload/type` label.

This fills a gap in the existing policy library: as AI inference workloads (LLM APIs, embedding services, model servers) become common in production clusters, they introduce credential-handling and network-egress risks that general-purpose policies do not address.

---

### `other/require-ai-workload-controls`

**Rule 1 — `require-audit-logging-annotation`**
Pods labelled as AI workloads must carry the annotation `ai.workload/audit-logging: enabled`. This acts as a declaration that audit logging is configured for the workload — a prerequisite for detecting prompt-injection attacks, data-exfiltration attempts, and unexpected model calls.

**Rule 2 — `no-plain-text-ai-credentials`**
Blocks plain-text AI service API credentials (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `HUGGINGFACE_TOKEN`, `COHERE_API_KEY`, etc.) from being set directly in `env[].value`. All such credentials must be sourced via `secretKeyRef`. Plain-text credentials are visible in pod specs, `kubectl describe` output, and Kubernetes audit logs.

---

### `other/restrict-ai-network-egress`

**Rule 1 — `block-host-network`**
Blocks `spec.hostNetwork: true` on AI workload pods. Host networking gives a pod access to the node's full network stack and bypasses all `NetworkPolicy` egress rules — defeating any attempt to restrict where model API calls can be sent.

**Rule 2 — `require-network-policy-label`**
Requires the label `networkpolicy.networking.k8s.io/policy-group` on all AI workload pods. Without this label, no `NetworkPolicy` selector can target the pod, leaving its egress unrestricted. The label enables egress-restricting NetworkPolicies to bind to the pod.

---

## Checklist

- [x] ClusterPolicy YAML with full Kyverno annotation set (`title`, `category`, `severity`, `subject`, `minversion`, `description`)
- [x] `artifacthub-pkg.yml` with SHA256 digest for each policy
- [x] Chainsaw test suite per policy:
  - `policy-ready.yaml` — waits for the ClusterPolicy to become `Ready`
  - `good-pod.yaml` — compliant pod, expect no violation
  - `bad-pod-*.yaml` — one fixture per rule, expect violation (`$error != null`)
- [x] DCO sign-off (`Signed-off-by` in commit)
- [x] `validationFailureAction: Audit` (non-breaking default)
- [x] `background: true`

## Test fixtures summary

| Policy | Good pod | Bad pods |
|---|---|---|
| require-ai-workload-controls | all labels + annotation + secretKeyRef | missing annotation; plain-text `OPENAI_API_KEY` |
| restrict-ai-network-egress | `ai.workload/type` + network-policy label, no hostNetwork | `hostNetwork: true`; missing network-policy label |