### PR TITLE
feat: add require-minimum-tls-version policy for PQC compliance

### DIFF
--- a/other/require-minimum-tls-version/.kyverno-test/kyverno-test.yaml
+++ b/other/require-minimum-tls-version/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,27 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: require-minimum-tls-version
+policies:
+- ../require-minimum-tls-version.yaml
+resources:
+- resource.yaml
+results:
+- kind: Ingress
+  policy: require-minimum-tls-version
+  resources:
+  - good-ingress
+  result: pass
+  rule: require-tls-min-version
+- kind: Ingress
+  policy: require-minimum-tls-version
+  resources:
+  - bad-ingress-tls11
+  result: fail
+  rule: require-tls-min-version
+- kind: Ingress
+  policy: require-minimum-tls-version
+  resources:
+  - bad-ingress-tls10
+  result: fail
+  rule: require-tls-min-version

--- a/other/require-minimum-tls-version/.kyverno-test/resource.yaml
+++ b/other/require-minimum-tls-version/.kyverno-test/resource.yaml
@@ -1,0 +1,68 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: good-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-protocols: "TLSv1.2 TLSv1.3"
+spec:
+  tls:
+  - hosts:
+    - example.com
+    secretName: example-tls
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: example-svc
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bad-ingress-tls11
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-protocols: "TLSv1.1 TLSv1.2"
+spec:
+  tls:
+  - hosts:
+    - example.com
+    secretName: example-tls
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: example-svc
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bad-ingress-tls10
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-protocols: "TLSv1"
+spec:
+  tls:
+  - hosts:
+    - example.com
+    secretName: example-tls
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: example-svc
+            port:
+              number: 80

--- a/other/require-minimum-tls-version/artifacthub-pkg.yml
+++ b/other/require-minimum-tls-version/artifacthub-pkg.yml
@@ -1,0 +1,33 @@
+name: require-minimum-tls-version
+version: 1.0.0
+displayName: Require Minimum TLS Version
+createdAt: "2026-06-12T00:00:00.000Z"
+description: >-
+  TLS 1.0 and 1.1 are deprecated and contain known vulnerabilities. TLS 1.3
+  is required as a prerequisite for post-quantum cryptography (PQC) key exchange
+  as mandated by NIST IR 8547 and NSA CNSA 2.0. This policy ensures that Ingress
+  resources do not permit deprecated TLS protocol versions via the nginx ingress
+  annotation.
+install: |-
+```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/require-minimum-tls-version/require-minimum-tls-version.yaml
+```
+keywords:
+  - kyverno
+  - Security
+  - TLS
+  - PQC
+  - NIST
+readme: |
+  TLS 1.0 and 1.1 are deprecated and contain known vulnerabilities. TLS 1.3
+  is required as a prerequisite for post-quantum cryptography (PQC) key exchange
+  as mandated by NIST IR 8547 and NSA CNSA 2.0. This policy ensures that Ingress
+  resources do not permit deprecated TLS protocol versions via the nginx ingress
+  ssl-protocols annotation.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Security"
+  kyverno/kubernetesVersion: "1.26"
+  kyverno/subject: "Ingress"
+digest: ""

--- a/other/require-minimum-tls-version/require-minimum-tls-version.yaml
+++ b/other/require-minimum-tls-version/require-minimum-tls-version.yaml
@@ -1,0 +1,47 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-minimum-tls-version
+  annotations:
+    policies.kyverno.io/title: Require Minimum TLS Version
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Ingress
+    kyverno.io/kyverno-version: 1.11.0
+    kyverno.io/kubernetes-version: "1.26"
+    policies.kyverno.io/minversion: 1.6.0
+    policies.kyverno.io/description: >-
+      TLS 1.0 and 1.1 are deprecated and contain known vulnerabilities. TLS 1.3
+      is required as a prerequisite for post-quantum cryptography (PQC) key
+      exchange as mandated by NIST IR 8547 and NSA CNSA 2.0. This policy ensures
+      that Ingress resources do not permit deprecated TLS protocol versions via
+      the nginx ingress ssl-protocols annotation.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+  - name: require-tls-min-version
+    match:
+      any:
+      - resources:
+          kinds:
+          - Ingress
+    preconditions:
+      all:
+      - key: "{{ request.object.spec.tls[] | length(@) }}"
+        operator: GreaterThanOrEquals
+        value: 1
+    validate:
+      message: >-
+        Ingress resources must not permit TLS 1.0 or 1.1. Set the annotation
+        nginx.ingress.kubernetes.io/ssl-protocols to include only TLSv1.2 or
+        TLSv1.3 to comply with NIST IR 8547 and NSA CNSA 2.0.
+      deny:
+        conditions:
+          any:
+          - key: "{{ contains(request.object.metadata.annotations.\"nginx.ingress.kubernetes.io/ssl-protocols\" || '', 'TLSv1 ') || contains(request.object.metadata.annotations.\"nginx.ingress.kubernetes.io/ssl-protocols\" || '', ' TLSv1 ') || request.object.metadata.annotations.\"nginx.ingress.kubernetes.io/ssl-protocols\" == 'TLSv1' }}"
+            operator: Equals
+            value: true
+          - key: "{{ contains(request.object.metadata.annotations.\"nginx.ingress.kubernetes.io/ssl-protocols\" || '', 'TLSv1.1') }}"
+            operator: Equals
+            value: true


### PR DESCRIPTION
Adds a ClusterPolicy that enforces minimum TLS version requirements on Ingress resources by validating the nginx.ingress.kubernetes.io/ssl-protocols annotation. The policy flags any Ingress that permits TLSv1.0 or TLSv1.1, which are deprecated and incompatible with post-quantum cryptography (PQC) key exchange algorithms.

TLS 1.3 is a prerequisite for PQC key exchange as required by:
- NIST IR 8547 (deprecates classical asymmetric crypto by 2030)
- NSA CNSA 2.0 (mandates PQC for national security systems by 2027)
- France ANSSI (stops certifying non-PQC products from 2027)

Includes kyverno-test with pass and fail resource examples.

Closes #1498

## Related Issue(s)

Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

## Description

What does this PR do?

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.

- [] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
