### PR TITLE
Fix RCE bypass in restrict-clusterrole-nodesproxy policies (Fixes #1492)

### DIFF
--- a/other-cel/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other-cel/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -38,6 +38,6 @@ spec:
                 !object.rules.exists(rule,
                 has(rule.resources) &&
                 rule.resources.exists(resource, resource == 'nodes/proxy') && 
-                rule.apiGroups.exists(apiGroup, apiGroup == ''))
+                rule.apiGroups.exists(apiGroup, apiGroup == '' || apiGroup == '*'))
               message: "A ClusterRole containing the nodes/proxy resource is not allowed."
 

--- a/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -34,6 +34,6 @@ spec:
         object.rules == null || 
         !object.rules.exists(rule, 
         rule.resources.exists(resource, resource == 'nodes/proxy') && 
-        rule.apiGroups.exists(apiGroup, apiGroup == ''))
+        rule.apiGroups.exists(apiGroup, apiGroup == '' || apiGroup == '*'))
       message: "A ClusterRole containing the nodes/proxy resource is not allowed."
 

--- a/other/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-bad.yaml
+++ b/other/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-bad.yaml
@@ -18,3 +18,15 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "nodes/proxy"]
   verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: badcr03
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes/proxy", "namespaces"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "watch", "list"]

--- a/other/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -35,6 +35,10 @@ spec:
             - key: nodes/proxy
               operator: AnyIn
               value: "{{ request.object.rules[].resources[] }}"
+            any:
             - key: ""
+              operator: AnyIn
+              value: "{{ request.object.rules[].apiGroups[] }}"
+            - key: "*"
               operator: AnyIn
               value: "{{ request.object.rules[].apiGroups[] }}"


### PR DESCRIPTION
## Related Issue(s)

Fixes #1492

## Description

This PR fixes a Remote Code Execution (RCE) bypass vulnerability in the `restrict-clusterrole-nodesproxy` policy, as detailed in #1492.

Previously, the policy successfully blocked ClusterRoles requesting access to the `nodes/proxy` resource on the core API group (`apiGroups: [""]`), but failed to block requests utilizing the wildcard API group (`apiGroups: ["*"]`). 

The logic has been updated to explicitly match and deny both `""` and `"*"` across all three variants of the policy:
- Legacy JMESPath (`other`)
- CEL ClusterPolicy (`other-cel`)
- CEL ValidatingPolicy (`other-vpol`)

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [ ] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [ ] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
