### PR TITLE
fix: include missing e2e jobs in required aggregate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1189,74 +1189,7 @@ jobs:
     needs:
     - argo
     - argo-cel
-    - aws
-    - aws-cel
-    - best-practices
-    - best-practices-vpol
-    - best-practices-cel
-    - best-practices-mpol
-    - best-practices-gpol
-    - castai
-    - castai-mpol
-    - cert-manager
-    - cleanup
-    - cleanup-dpol
-    - consul
-    - consul-cel
-    - external-secret-operator
-    - flux
-    - flux-cel
-    - istio
-    - istio-cel
-    - istio-mpol
-    - karpenter
-    - kasten
-    - kasten-cel
-    - kubecost
-    - kubecost-cel
-    - kubecost-mpol
-    - kubeops
-    - kubevirt
-    - kubevirt-gpol
-    - linkerd
-    - linkerd-cel
-    - linkerd-mpol
-    - nginx-ingress
-    - nginx-ingress-cel
-    - openshift
-    - openshift-cel
-    - other
-    - other-vpol
-    - other-mpol
-    - other-cel
-    - other-gpol
-    - pod-security
-    - pod-security-cel
-    - pod-security-vpol
-    - psa
-    - psa-cel
-    - psa-mpol
-    - psp-migration
-    - psp-migration-cel
-    - psp-migration-mpol
-    - tekton
-    - tekton-cel
-    - traefik
-    - traefik-cel
-    - velero
-    - velero-cel
-    - velero-mpol
-    - windows-security
-    runs-on: ubuntu-latest
-    if: ${{ success() }}
-    steps:
-    - run: ${{ true }}
-
-  e2e-required-failure:
-    name: e2e-required
-    needs:
-    - argo
-    - argo-cel
+    - argo-vpol
     - aws
     - aws-cel
     - best-practices
@@ -1299,6 +1232,78 @@ jobs:
     - other-mpol
     - other-cel
     - other-gpol
+    - other-ivpol
+    - pod-security
+    - pod-security-cel
+    - pod-security-vpol
+    - psa
+    - psa-cel
+    - psa-mpol
+    - psp-migration
+    - psp-migration-cel
+    - psp-migration-mpol
+    - tekton
+    - tekton-cel
+    - traefik
+    - traefik-cel
+    - velero
+    - velero-cel
+    - velero-mpol
+    - windows-security
+    runs-on: ubuntu-latest
+    if: ${{ success() }}
+    steps:
+    - run: ${{ true }}
+
+  e2e-required-failure:
+    name: e2e-required
+    needs:
+    - argo
+    - argo-cel
+    - argo-vpol
+    - aws
+    - aws-cel
+    - best-practices
+    - best-practices-vpol
+    - best-practices-cel
+    - best-practices-mpol
+    - best-practices-gpol
+    - castai
+    - castai-mpol
+    - cert-manager
+    - cleanup
+    - cleanup-dpol
+    - consul
+    - consul-cel
+    - external-secret-operator
+    - flux
+    - flux-cel
+    - istio
+    - istio-cel
+    - istio-mpol
+    - karpenter
+    - karpenter-mpol
+    - kasten
+    - kasten-cel
+    - kubecost
+    - kubecost-cel
+    - kubecost-mpol
+    - kubeops
+    - kubevirt
+    - kubevirt-gpol
+    - linkerd
+    - linkerd-cel
+    - linkerd-mpol
+    - nginx-ingress
+    - nginx-ingress-cel
+    - openshift
+    - openshift-cel
+    - other
+    - other-vpol
+    - other-mpol
+    - other-cel
+    - other-gpol
+    - other-ivpol
     - pod-security
     - pod-security-cel
     - pod-security-vpol


### PR DESCRIPTION
## Related Issue(s)
Closes #1505 

## Description

This PR updates the required E2E aggregate workflow to include missing jobs in the `needs` lists.

Specifically, it adds:
- `argo-vpol`
- `karpenter-mpol`
- `other-ivpol`

to the appropriate `e2e-required-success` and `e2e-required-failure` aggregate jobs so failures in these jobs are reflected by the required aggregate workflow status.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [X] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
