### PR TITLE
feat: add restrict-exec-verbs-roles policy

### DIFF
--- a/other/restrict-exec-verbs-roles/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other/restrict-exec-verbs-roles/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-exec-verbs-roles
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/other/restrict-exec-verbs-roles/.chainsaw-test/chainsaw-test.yaml
+++ b/other/restrict-exec-verbs-roles/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: restrict-exec-verbs-roles
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../restrict-exec-verbs-roles.yaml
+    - patch:
+        resource:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          metadata:
+            name: restrict-exec-verbs-roles
+          spec:
+            validationFailureAction: Enforce
+    - assert:
+        file: chainsaw-step-01-assert-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: role-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: role-bad.yaml

--- a/other/restrict-exec-verbs-roles/.chainsaw-test/role-bad.yaml
+++ b/other/restrict-exec-verbs-roles/.chainsaw-test/role-bad.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: bad-exec-role
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bad-attach-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["pods/attach"]
+    verbs: ["get", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bad-portforward-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["pods/portforward"]
+    verbs: ["create"]

--- a/other/restrict-exec-verbs-roles/.chainsaw-test/role-good.yaml
+++ b/other/restrict-exec-verbs-roles/.chainsaw-test/role-good.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: good-pod-reader
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: good-deployment-manager
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "update", "delete"]

--- a/other/restrict-exec-verbs-roles/.kyverno-test/kyverno-test.yaml
+++ b/other/restrict-exec-verbs-roles/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,34 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-exec-verbs-roles
+policies:
+- ../restrict-exec-verbs-roles.yaml
+resources:
+- resource.yaml
+results:
+- kind: ClusterRole
+  policy: restrict-exec-verbs-roles
+  resources:
+  - bad-attach-clusterrole
+  - bad-portforward-clusterrole
+  result: fail
+  rule: exec-verbs
+- kind: Role
+  policy: restrict-exec-verbs-roles
+  resources:
+  - bad-exec-role
+  result: fail
+  rule: exec-verbs
+- kind: ClusterRole
+  policy: restrict-exec-verbs-roles
+  resources:
+  - good-deployment-manager
+  result: pass
+  rule: exec-verbs
+- kind: Role
+  policy: restrict-exec-verbs-roles
+  resources:
+  - good-pod-reader
+  result: pass
+  rule: exec-verbs

--- a/other/restrict-exec-verbs-roles/.kyverno-test/resource.yaml
+++ b/other/restrict-exec-verbs-roles/.kyverno-test/resource.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: bad-exec-role
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bad-attach-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["pods/attach"]
+    verbs: ["get", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bad-portforward-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["pods/portforward"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: good-pod-reader
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: good-deployment-manager
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "update", "delete"]

--- a/other/restrict-exec-verbs-roles/artifacthub-pkg.yml
+++ b/other/restrict-exec-verbs-roles/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: restrict-exec-verbs-roles
+version: 1.0.0
+displayName: Restrict Exec Verbs in Roles
+createdAt: "2026-07-07T00:00:00.000Z"
+description: >-
+  A Role or ClusterRole granting create or get on pods/exec, pods/attach, or pods/portforward hands out standing interactive access to workloads, equivalent to code execution inside every reachable container. Existing policies block exec requests at admission time (PodExecOptions); this policy prevents the RBAC grant itself from being created, which is the durable control. This policy blocks any Role or ClusterRole that grants these verbs on those subresources.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/restrict-exec-verbs-roles/restrict-exec-verbs-roles.yaml
+  ```
+keywords:
+  - kyverno
+  - Security
+readme: |
+  A Role or ClusterRole granting create or get on pods/exec, pods/attach, or pods/portforward hands out standing interactive access to workloads, equivalent to code execution inside every reachable container. Existing policies block exec requests at admission time (PodExecOptions); this policy prevents the RBAC grant itself from being created, which is the durable control. This policy blocks any Role or ClusterRole that grants these verbs on those subresources.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Security"
+  kyverno/kubernetesVersion: "1.27"
+  kyverno/subject: "Role, ClusterRole, RBAC"
+digest: a2e060fe376b5013b641d8ba3e9881fc937b2e6a4935c0e9a7952401e1d7b2f2

--- a/other/restrict-exec-verbs-roles/restrict-exec-verbs-roles.yaml
+++ b/other/restrict-exec-verbs-roles/restrict-exec-verbs-roles.yaml
@@ -1,0 +1,47 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-exec-verbs-roles
+  annotations:
+    policies.kyverno.io/title: Restrict Exec Verbs in Roles
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Role, ClusterRole, RBAC
+    kyverno.io/kyverno-version: 1.11.0
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.27"
+    policies.kyverno.io/description: >-
+      A Role or ClusterRole granting create or get on pods/exec, pods/attach,
+      or pods/portforward hands out standing interactive access to workloads -
+      equivalent to code execution inside every reachable container. Existing
+      policies block exec requests at admission time (PodExecOptions); this
+      policy prevents the RBAC grant itself from being created, which is the
+      durable control. Interactive access should be granted through an audited
+      break-glass role instead of a standing permission.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: exec-verbs
+      match:
+        any:
+        - resources:
+            kinds:
+              - Role
+              - ClusterRole
+      validate:
+        message: >-
+          Granting create/get on pods/exec, pods/attach, or pods/portforward
+          in a Role or ClusterRole is not allowed.
+        deny:
+          conditions:
+            any:
+            - key: ["create", "get"]
+              operator: AnyIn
+              value: "{{ request.object.rules[?resources.contains(@,'pods/exec')].verbs[] }}"
+            - key: ["create", "get"]
+              operator: AnyIn
+              value: "{{ request.object.rules[?resources.contains(@,'pods/attach')].verbs[] }}"
+            - key: ["create", "get"]
+              operator: AnyIn
+              value: "{{ request.object.rules[?resources.contains(@,'pods/portforward')].verbs[] }}"


### PR DESCRIPTION
## What this does

Adds a new `other/restrict-exec-verbs-roles` policy that blocks any Role or ClusterRole granting `create`/`get` on `pods/exec`, `pods/attach`, or `pods/portforward`.

## Motivation

The existing `block-pod-exec-by-*` policies restrict exec **requests** at admission (`PodExecOptions`). They don't restrict the RBAC **grant** — a standing Role/ClusterRole permission that hands out interactive, code-execution-equivalent access to workloads. The grant is the durable control worth preventing, and the library already restricts analogous grants for other resources (`restrict-clusterrole-nodesproxy`, `restrict-escalation-verbs-roles`, `restrict-clusterrole-csr`).

- Category: Security
- Subject: Role, ClusterRole, RBAC
- `kyverno test` passes (see `.kyverno-test/`); a chainsaw e2e test is included following the pattern of `restrict-binding-system-groups`
- artifacthub-pkg.yml digest computed with `.hack/update-artifacthub-pkg.sh` (idempotent)

Refs: [Kubernetes RBAC Good Practices](https://kubernetes.io/docs/concepts/security/rbac-good-practices/); OWASP Kubernetes Top 10 K03.

Happy to add `other-cel/` and `other-vpol/` variants in this PR or a follow-up if you'd like them — the CEL form is a straightforward translation.