### PR TITLE
feat: block system:authenticated in restrict-binding-system-groups

### DIFF
--- a/other-cel/restrict-binding-system-groups/.chainsaw-test/crb-bad.yaml
+++ b/other-cel/restrict-binding-system-groups/.chainsaw-test/crb-bad.yaml
@@ -39,3 +39,16 @@ roleRef:
   name: manager
   apiGroup: rbac.authorization.k8s.io
 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: badcrb04
+subjects:
+- kind: Group
+  name: "system:authenticated"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: manager
+  apiGroup: rbac.authorization.k8s.io

--- a/other-cel/restrict-binding-system-groups/.chainsaw-test/rb-bad.yaml
+++ b/other-cel/restrict-binding-system-groups/.chainsaw-test/rb-bad.yaml
@@ -39,3 +39,16 @@ roleRef:
   name: foo
   apiGroup: rbac.authorization.k8s.io
 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: badrb04
+subjects:
+- kind: Group
+  name: "system:authenticated"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: foo
+  apiGroup: rbac.authorization.k8s.io

--- a/other-cel/restrict-binding-system-groups/.kyverno-test/kyverno-test.yaml
+++ b/other-cel/restrict-binding-system-groups/.kyverno-test/kyverno-test.yaml
@@ -10,36 +10,37 @@ resources:
 - ../.chainsaw-test/rb-bad.yaml
 - ../.chainsaw-test/rb-good.yaml
 results:
-- policy: restrict-binding-system-groups
-  rule: restrict-subject-groups
-  kind: ClusterRoleBinding
+- kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
   resources:
   - badcrb01
   - badcrb02
   - badcrb03
+  - badcrb04
   result: fail
-- policy: restrict-binding-system-groups
   rule: restrict-subject-groups
-  kind: ClusterRoleBinding
+- kind: RoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - badrb01
+  - badrb02
+  - badrb03
+  - badrb04
+  result: fail
+  rule: restrict-subject-groups
+- kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
   resources:
   - goodcrb01
   - goodcrb02
   - goodcrb03
   result: pass
-- policy: restrict-binding-system-groups
   rule: restrict-subject-groups
-  kind: RoleBinding
-  resources:
-  - badrb01
-  - badrb02
-  - badrb03
-  result: fail
-- policy: restrict-binding-system-groups
-  rule: restrict-subject-groups
-  kind: RoleBinding
+- kind: RoleBinding
+  policy: restrict-binding-system-groups
   resources:
   - goodrb01
   - goodrb02
   - goodrb03
   result: pass
-
+  rule: restrict-subject-groups

--- a/other-cel/restrict-binding-system-groups/artifacthub-pkg.yml
+++ b/other-cel/restrict-binding-system-groups/artifacthub-pkg.yml
@@ -20,6 +20,6 @@ annotations:
   kyverno/category: "Security, EKS Best Practices in CEL"
   kyverno/kubernetesVersion: "1.26-1.27"
   kyverno/subject: "RoleBinding, ClusterRoleBinding, RBAC"
-digest: 8a5fb4bfe55c063b3b14eaed7a81512548ce89cc7057aa5549723fefed670f1f
+digest: 9bb1740d3b4065bf33e3d443002e4df5e92651ff61715adb9bf6f0a4df1cdb63
 createdAt: "2024-04-12T16:28:28Z"
 

--- a/other-cel/restrict-binding-system-groups/restrict-binding-system-groups.yaml
+++ b/other-cel/restrict-binding-system-groups/restrict-binding-system-groups.yaml
@@ -14,7 +14,8 @@ metadata:
       Certain system groups exist in Kubernetes which grant permissions that
       are used for certain system-level functions yet typically never appropriate
       for other users. This policy prevents creating bindings to some of these
-      groups including system:anonymous, system:unauthenticated, and system:masters.
+      groups including system:anonymous, system:unauthenticated, system:authenticated,
+      and system:masters.
 spec:
   validationFailureAction: Audit
   background: true
@@ -38,4 +39,6 @@ spec:
               message: "Binding to system:unauthenticated is not allowed."
             - expression: "object.subjects.all(subject, subject.name != 'system:masters')"
               message: "Binding to system:masters is not allowed."
+            - expression: "object.subjects.all(subject, subject.name != 'system:authenticated')"
+              message: "Binding to system:authenticated is not allowed."
             

--- a/other-vpol/restrict-binding-system-groups/.chainsaw-test/crb-bad.yaml
+++ b/other-vpol/restrict-binding-system-groups/.chainsaw-test/crb-bad.yaml
@@ -39,3 +39,16 @@ roleRef:
   name: manager
   apiGroup: rbac.authorization.k8s.io
 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: badcrb04
+subjects:
+- kind: Group
+  name: "system:authenticated"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: manager
+  apiGroup: rbac.authorization.k8s.io

--- a/other-vpol/restrict-binding-system-groups/.chainsaw-test/rb-bad.yaml
+++ b/other-vpol/restrict-binding-system-groups/.chainsaw-test/rb-bad.yaml
@@ -39,3 +39,16 @@ roleRef:
   name: foo
   apiGroup: rbac.authorization.k8s.io
 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: badrb04
+subjects:
+- kind: Group
+  name: "system:authenticated"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: foo
+  apiGroup: rbac.authorization.k8s.io

--- a/other-vpol/restrict-binding-system-groups/.kyverno-test/kyverno-test.yaml
+++ b/other-vpol/restrict-binding-system-groups/.kyverno-test/kyverno-test.yaml
@@ -10,36 +10,37 @@ resources:
 - ../.chainsaw-test/rb-bad.yaml
 - ../.chainsaw-test/rb-good.yaml
 results:
-- policy: restrict-binding-system-groups
-  isValidatingPolicy: true
+- isValidatingPolicy: true
   kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
   resources:
   - badcrb01
   - badcrb02
   - badcrb03
+  - badcrb04
   result: fail
-- policy: restrict-binding-system-groups
-  isValidatingPolicy: true
+- isValidatingPolicy: true
+  kind: RoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - badrb01
+  - badrb02
+  - badrb03
+  - badrb04
+  result: fail
+- isValidatingPolicy: true
   kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
   resources:
   - goodcrb01
   - goodcrb02
   - goodcrb03
   result: pass
-- policy: restrict-binding-system-groups
-  isValidatingPolicy: true
+- isValidatingPolicy: true
   kind: RoleBinding
-  resources:
-  - badrb01
-  - badrb02
-  - badrb03
-  result: fail
-- policy: restrict-binding-system-groups
-  isValidatingPolicy: true
-  kind: RoleBinding
+  policy: restrict-binding-system-groups
   resources:
   - goodrb01
   - goodrb02
   - goodrb03
   result: pass
-

--- a/other-vpol/restrict-binding-system-groups/artifacthub-pkg.yml
+++ b/other-vpol/restrict-binding-system-groups/artifacthub-pkg.yml
@@ -20,7 +20,7 @@ annotations:
   kyverno/category: "Security, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "RoleBinding, ClusterRoleBinding, RBAC"
-digest: 9696b546b9c1be6ce7b87ea664d07a74d730a8267af028a1187b98814806ba3b
+digest: 2cf0ccadd6a1ce6aef1379d7fec00a4eddefc985936ff83c3d83abab693e7f39
 
 
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.yaml
+++ b/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.yaml
@@ -14,7 +14,8 @@ metadata:
       Certain system groups exist in Kubernetes which grant permissions that
       are used for certain system-level functions yet typically never appropriate
       for other users. This policy prevents creating bindings to some of these
-      groups including system:anonymous, system:unauthenticated, and system:masters.
+      groups including system:anonymous, system:unauthenticated, system:authenticated,
+      and system:masters.
 spec:
   validationActions: 
     - Audit
@@ -34,4 +35,6 @@ spec:
       message: "Binding to system:unauthenticated is not allowed."
     - expression: "object.subjects.all(subject, subject.name != 'system:masters')"
       message: "Binding to system:masters is not allowed."
+    - expression: "object.subjects.all(subject, subject.name != 'system:authenticated')"
+      message: "Binding to system:authenticated is not allowed."
             

--- a/other/restrict-binding-system-groups/.chainsaw-test/crb-bad.yaml
+++ b/other/restrict-binding-system-groups/.chainsaw-test/crb-bad.yaml
@@ -38,3 +38,16 @@ roleRef:
   kind: ClusterRole
   name: manager
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: badcrb04
+subjects:
+- kind: Group
+  name: "system:authenticated"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: manager
+  apiGroup: rbac.authorization.k8s.io

--- a/other/restrict-binding-system-groups/.chainsaw-test/rb-bad.yaml
+++ b/other/restrict-binding-system-groups/.chainsaw-test/rb-bad.yaml
@@ -38,3 +38,16 @@ roleRef:
   kind: Role
   name: foo
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: badrb04
+subjects:
+- kind: Group
+  name: "system:authenticated"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: foo
+  apiGroup: rbac.authorization.k8s.io

--- a/other/restrict-binding-system-groups/.kyverno-test/kyverno-test.yaml
+++ b/other/restrict-binding-system-groups/.kyverno-test/kyverno-test.yaml
@@ -10,87 +10,115 @@ resources:
 - ../.chainsaw-test/rb-bad.yaml
 - ../.chainsaw-test/rb-good.yaml
 results:
-- policy: restrict-binding-system-groups
-  rule: restrict-anonymous
-  kind: ClusterRoleBinding
+- kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
   resources:
   - badcrb01
   result: fail
-- policy: restrict-binding-system-groups
-  rule: restrict-unauthenticated
-  kind: ClusterRoleBinding
-  resources:
-  - badcrb02
-  result: fail
-- policy: restrict-binding-system-groups
-  rule: restrict-masters
-  kind: ClusterRoleBinding
-  resources:
-  - badcrb03
-  result: fail
-- policy: restrict-binding-system-groups
   rule: restrict-anonymous
-  kind: RoleBinding
+- kind: RoleBinding
+  policy: restrict-binding-system-groups
   resources:
   - badrb01
   result: fail
-- policy: restrict-binding-system-groups
-  rule: restrict-unauthenticated
-  kind: RoleBinding
+  rule: restrict-anonymous
+- kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
   resources:
-  - badrb02
+  - goodcrb01
+  - goodcrb02
+  - goodcrb03
+  result: pass
+  rule: restrict-anonymous
+- kind: RoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - goodrb01
+  - goodrb02
+  - goodrb03
+  result: pass
+  rule: restrict-anonymous
+- kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - badcrb04
   result: fail
-- policy: restrict-binding-system-groups
+  rule: restrict-authenticated
+- kind: RoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - badrb04
+  result: fail
+  rule: restrict-authenticated
+- kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - goodcrb01
+  - goodcrb02
+  - goodcrb03
+  result: pass
+  rule: restrict-authenticated
+- kind: RoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - goodrb01
+  - goodrb02
+  - goodrb03
+  result: pass
+  rule: restrict-authenticated
+- kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - badcrb03
+  result: fail
   rule: restrict-masters
-  kind: RoleBinding
+- kind: RoleBinding
+  policy: restrict-binding-system-groups
   resources:
   - badrb03
   result: fail
-- policy: restrict-binding-system-groups
-  rule: restrict-anonymous
-  kind: ClusterRoleBinding
-  resources:
-  - goodcrb01
-  - goodcrb02
-  - goodcrb03
-  result: pass
-- policy: restrict-binding-system-groups
-  rule: restrict-unauthenticated
-  kind: ClusterRoleBinding
-  resources:
-  - goodcrb01
-  - goodcrb02
-  - goodcrb03
-  result: pass
-- policy: restrict-binding-system-groups
   rule: restrict-masters
-  kind: ClusterRoleBinding
+- kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
   resources:
   - goodcrb01
   - goodcrb02
   - goodcrb03
   result: pass
-- policy: restrict-binding-system-groups
-  rule: restrict-anonymous
-  kind: RoleBinding
-  resources:
-  - goodrb01
-  - goodrb02
-  - goodrb03
-  result: pass
-- policy: restrict-binding-system-groups
-  rule: restrict-unauthenticated
-  kind: RoleBinding
-  resources:
-  - goodrb01
-  - goodrb02
-  - goodrb03
-  result: pass
-- policy: restrict-binding-system-groups
   rule: restrict-masters
-  kind: RoleBinding
+- kind: RoleBinding
+  policy: restrict-binding-system-groups
   resources:
   - goodrb01
   - goodrb02
   - goodrb03
   result: pass
+  rule: restrict-masters
+- kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - badcrb02
+  result: fail
+  rule: restrict-unauthenticated
+- kind: RoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - badrb02
+  result: fail
+  rule: restrict-unauthenticated
+- kind: ClusterRoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - goodcrb01
+  - goodcrb02
+  - goodcrb03
+  result: pass
+  rule: restrict-unauthenticated
+- kind: RoleBinding
+  policy: restrict-binding-system-groups
+  resources:
+  - goodrb01
+  - goodrb02
+  - goodrb03
+  result: pass
+  rule: restrict-unauthenticated

--- a/other/restrict-binding-system-groups/artifacthub-pkg.yml
+++ b/other/restrict-binding-system-groups/artifacthub-pkg.yml
@@ -20,4 +20,4 @@ annotations:
   kyverno/category: "Security, EKS Best Practices"
   kyverno/kubernetesVersion: "1.23"
   kyverno/subject: "RoleBinding, ClusterRoleBinding, RBAC"
-digest: 68386af8e018f4f0bd0fe986378651e3ea4c142b426b39c010e038df85fb7ef2
+digest: b7f09e3562ea1cf40b8b5c1e485cd746ca14225f5bf55b7fe1b562363805bd44

--- a/other/restrict-binding-system-groups/restrict-binding-system-groups.yaml
+++ b/other/restrict-binding-system-groups/restrict-binding-system-groups.yaml
@@ -14,7 +14,8 @@ metadata:
       Certain system groups exist in Kubernetes which grant permissions that
       are used for certain system-level functions yet typically never appropriate
       for other users. This policy prevents creating bindings to some of these
-      groups including system:anonymous, system:unauthenticated, and system:masters.
+      groups including system:anonymous, system:unauthenticated, system:authenticated,
+      and system:masters.
 spec:
   validationFailureAction: Audit
   background: true
@@ -55,4 +56,16 @@ spec:
         pattern:
           subjects:
             - name: "!system:masters"
+    - name: restrict-authenticated
+      match:
+        any:
+        - resources:
+            kinds:
+              - RoleBinding
+              - ClusterRoleBinding
+      validate:
+        message: "Binding to system:authenticated is not allowed."
+        pattern:
+          subjects:
+            - name: "!system:authenticated"
             


### PR DESCRIPTION
## What this does

`restrict-binding-system-groups` blocks bindings to `system:anonymous`, `system:unauthenticated`, and `system:masters` — but not **`system:authenticated`**, the group containing every principal with a valid token (all users and all ServiceAccounts). Binding a privileged role to it is a classic cluster-takeover misconfiguration (kubectl itself prints a warning when you create one) and is broader in blast radius than the groups the policy already covers.

## Changes

- adds a `restrict-authenticated` rule mirroring the existing three (classic `other/`)
- adds the equivalent CEL expression to the `other-cel/` and `other-vpol/` variants
- updates the policy descriptions to mention the fourth group
- extends the `.kyverno-test` and `.chainsaw-test` resources with failing `system:authenticated` bindings (`badcrb04`/`badrb04`) in all three variants

`kyverno test` passes on all three variants (32 / 14 / 14 results). Test files normalized with `kyverno fix test --save`; artifacthub digests refreshed via `.hack/update-artifacthub-pkg.sh` (idempotent).