### PR TITLE
fix(vpol): add null-safety checks on mutliple policies

### DIFF
--- a/best-practices-vpol/require-probes/.kyverno-test/kyverno-test.yaml
+++ b/best-practices-vpol/require-probes/.kyverno-test/kyverno-test.yaml
@@ -21,3 +21,13 @@ results:
   - goodpod03
   - goodpod04
   result: pass
+- kind: CronJob
+  policy: require-pod-probes
+  resources:
+  - badcronjob01
+  result: fail
+- kind: CronJob
+  policy: require-pod-probes
+  resources:
+  - goodcronjob01
+  result: pass

--- a/best-practices-vpol/require-probes/.kyverno-test/resource.yaml
+++ b/best-practices-vpol/require-probes/.kyverno-test/resource.yaml
@@ -108,3 +108,35 @@ spec:
       periodSeconds: 10
   - name: nginx
     image: nginx:latest
+---
+# CronJob: containers live under spec.jobTemplate.spec.template.spec.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob01
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: c
+              image: busybox
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob01
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: c
+              image: busybox
+              livenessProbe:
+                exec:
+                  command: ["true"]

--- a/best-practices-vpol/require-probes/artifacthub-pkg.yml
+++ b/best-practices-vpol/require-probes/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: require-probes
-version: 1.0.0
+version: 1.0.1
 displayName: Require Pod Probes
 createdAt: "2023-04-10T19:47:15.000Z"
 description: >-
@@ -14,9 +14,9 @@ keywords:
   - EKS Best Practices
 readme: |
   Liveness and readiness probes need to be configured to correctly manage a Pod's lifecycle during deployments, restarts, and upgrades. For each Pod, a periodic `livenessProbe` is performed by the kubelet to determine if the Pod's containers are running or need to be restarted. A `readinessProbe` is used by Services and Deployments to determine if the Pod is ready to receive network traffic. This policy validates that all containers have one of livenessProbe, readinessProbe, or startupProbe defined.
-  
+
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Best Practices, EKS Best Practices"
   kyverno/subject: "Pod"
-digest: bb39d13e91397d65e435f9d89e3515b5d1544911afc493b47aea82b9424e134f
+digest: ffc26904334a92b3ab9a25ed78776379caa79a697899158d5b03e46ca1102c8d

--- a/best-practices-vpol/require-probes/require-probes.yaml
+++ b/best-practices-vpol/require-probes/require-probes.yaml
@@ -35,11 +35,16 @@ spec:
       resources: ["jobs", "cronjobs"]
       operations: ["CREATE", "UPDATE"]
   variables:
+  # Resolve the pod spec across the three matched shapes: bare Pod (spec),
+  # CronJob (spec.jobTemplate.spec.template.spec) and other controllers (spec.template.spec).
+  - name: podSpec
+    expression: >-
+      has(object.spec.containers) ? object.spec :
+        has(object.spec.jobTemplate) ? object.spec.jobTemplate.spec.template.spec :
+          object.spec.template.spec
   - name: allContainers
     expression: >-
-      has(object.spec.containers) ? 
-        object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([]) : 
-        object.spec.template.spec.containers + object.spec.template.spec.?initContainers.orValue([]) + object.spec.template.spec.?ephemeralContainers.orValue([])      
+      variables.podSpec.containers + variables.podSpec.?initContainers.orValue([]) + variables.podSpec.?ephemeralContainers.orValue([])
   validations:
   - expression: >-
       variables.allContainers.all(container, 
@@ -49,4 +54,4 @@ spec:
       'All containers must have at least one probe (livenessProbe, readinessProbe, or startupProbe) defined. Missing probes in containers: ' + 
       variables.allContainers.filter(container, 
         !(has(container.livenessProbe) || has(container.readinessProbe) || has(container.startupProbe))
-      ).map(container, container.name).join(', ')  
+      ).map(container, container.name).join(', ')

--- a/other-vpol/ensure-probes-different/artifacthub-pkg.yml
+++ b/other-vpol/ensure-probes-different/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: ensure-probes-different-vpol
-version: 1.0.0
+version: 1.0.1
 displayName: Validate Probes in ValidatingPolicy
 description: >-
   Liveness and readiness probes accomplish different goals, and setting both to the same is an anti-pattern and often results in app problems in the future. This policy checks that liveness and readiness probes are not equal.
@@ -13,13 +13,11 @@ keywords:
   - ValidatingPolicy
 readme: |
   Liveness and readiness probes accomplish different goals, and setting both to the same is an anti-pattern and often results in app problems in the future. This policy checks that liveness and readiness probes are not equal.
-  
+
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Pod"
-digest: ebc10399c0cbbaa689f326a5a60177304fa09068f31ee82460d97d4727ed3314
-
-
+digest: b56acdf6389a2d18bb2a735b1eac84480e1b74528da45d959b30e882ce4d00c7
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/ensure-probes-different/ensure-probes-different.yaml
+++ b/other-vpol/ensure-probes-different/ensure-probes-different.yaml
@@ -31,7 +31,7 @@ spec:
         operations: ["CREATE", "UPDATE"]
   validations:
     - expression: >-
-        !object.spec.template.spec.containers.exists(container, 
+        !object.spec.template.spec.?containers.orValue([]).exists(container,
         has(container.readinessProbe) && has(container.livenessProbe) &&
         container.readinessProbe == container.livenessProbe)
       message: "Liveness and readiness probes cannot be the same."

--- a/other-vpol/restrict-binding-system-groups/.chainsaw-test/crb-no-subjects.yaml
+++ b/other-vpol/restrict-binding-system-groups/.chainsaw-test/crb-no-subjects.yaml
@@ -1,0 +1,9 @@
+# ClusterRoleBinding without a subjects field (e.g. the built-in system:node binding).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-no-subjects
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view

--- a/other-vpol/restrict-binding-system-groups/.kyverno-test/kyverno-test.yaml
+++ b/other-vpol/restrict-binding-system-groups/.kyverno-test/kyverno-test.yaml
@@ -9,6 +9,7 @@ resources:
 - ../.chainsaw-test/crb-good.yaml
 - ../.chainsaw-test/rb-bad.yaml
 - ../.chainsaw-test/rb-good.yaml
+- ../.chainsaw-test/crb-no-subjects.yaml
 results:
 - policy: restrict-binding-system-groups
   isValidatingPolicy: true
@@ -42,4 +43,9 @@ results:
   - goodrb02
   - goodrb03
   result: pass
-
+- policy: restrict-binding-system-groups
+  isValidatingPolicy: true
+  kind: ClusterRoleBinding
+  resources:
+  - crb-no-subjects
+  result: pass

--- a/other-vpol/restrict-binding-system-groups/artifacthub-pkg.yml
+++ b/other-vpol/restrict-binding-system-groups/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: restrict-binding-system-groups-vpol
-version: 1.0.0
+version: 1.0.1
 displayName: Restrict Binding System Groups in ValidatingPolicy
 description: >-
   Certain system groups exist in Kubernetes which grant permissions that are used for certain system-level functions yet typically never appropriate for other users. This policy prevents creating bindings to some of these groups including system:anonymous, system:unauthenticated, and system:masters.
@@ -14,13 +14,11 @@ keywords:
   - ValidatingPolicy
 readme: |
   Certain system groups exist in Kubernetes which grant permissions that are used for certain system-level functions yet typically never appropriate for other users. This policy prevents creating bindings to some of these groups including system:anonymous, system:unauthenticated, and system:masters.
-  
+
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Security, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "RoleBinding, ClusterRoleBinding, RBAC"
-digest: 9696b546b9c1be6ce7b87ea664d07a74d730a8267af028a1187b98814806ba3b
-
-
+digest: 7a40b8cd6a54df47578e3f091a535d0949ee7e6b67c2bb113f71ff16a7403f81
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.yaml
+++ b/other-vpol/restrict-binding-system-groups/restrict-binding-system-groups.yaml
@@ -28,10 +28,10 @@ spec:
         operations: ["CREATE", "UPDATE"]
         resources: ["rolebindings", "clusterrolebindings"]
   validations:
-    - expression: "object.subjects.all(subject, subject.name != 'system:anonymous')"
+    - expression: "object.?subjects.orValue([]).all(subject, subject.name != 'system:anonymous')"
       message: "Binding to system:anonymous is not allowed."
-    - expression: "object.subjects.all(subject, subject.name != 'system:unauthenticated')"
+    - expression: "object.?subjects.orValue([]).all(subject, subject.name != 'system:unauthenticated')"
       message: "Binding to system:unauthenticated is not allowed."
-    - expression: "object.subjects.all(subject, subject.name != 'system:masters')"
+    - expression: "object.?subjects.orValue([]).all(subject, subject.name != 'system:masters')"
       message: "Binding to system:masters is not allowed."
             

--- a/other-vpol/restrict-clusterrole-nodesproxy/.kyverno-test/kyverno-test.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/.kyverno-test/kyverno-test.yaml
@@ -21,5 +21,6 @@ results:
   - goodcr01
   - goodcr02
   - default-rules
+  - nonresource-rule
   result: pass
 

--- a/other-vpol/restrict-clusterrole-nodesproxy/.kyverno-test/resource.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/.kyverno-test/resource.yaml
@@ -48,3 +48,12 @@ metadata:
   name: default-rules
 rules: null
 ---
+---
+# ClusterRole rule with only nonResourceURLs (no resources field).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nonresource-rule
+rules:
+- nonResourceURLs: ["/healthz", "/livez"]
+  verbs: ["get"]

--- a/other-vpol/restrict-clusterrole-nodesproxy/artifacthub-pkg.yml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/artifacthub-pkg.yml
@@ -1,8 +1,7 @@
 name: restrict-clusterrole-nodesproxy-vpol
-version: 1.0.0
+version: 1.0.1
 displayName: Restrict ClusterRole with Nodes Proxy in ValidatingPolicy
-description: >-
-  A ClusterRole with nodes/proxy resource access allows a user to perform anything the kubelet API allows. It also allows users to bypass the API server and talk directly to the kubelet potentially circumventing audits and admission controllers. See https://blog.aquasec.com/privilege-escalation-kubernetes-rbac for more info. This policy prevents the creation of a ClusterRole if it contains the nodes/proxy resource. 
+description: "A ClusterRole with nodes/proxy resource access allows a user to perform anything the kubelet API allows. It also allows users to bypass the API server and talk directly to the kubelet potentially circumventing audits and admission controllers. See https://blog.aquasec.com/privilege-escalation-kubernetes-rbac for more info. This policy prevents the creation of a ClusterRole if it contains the nodes/proxy resource. "
 install: |-
   ```shell
   kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -11,15 +10,10 @@ keywords:
   - kyverno
   - Sample
   - ValidatingPolicy
-readme: |
-  A ClusterRole with nodes/proxy resource access allows a user to perform anything the kubelet API allows. It also allows users to bypass the API server and talk directly to the kubelet potentially circumventing audits and admission controllers. See https://blog.aquasec.com/privilege-escalation-kubernetes-rbac for more info. This policy prevents the creation of a ClusterRole if it contains the nodes/proxy resource. 
-  
-  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+readme: "A ClusterRole with nodes/proxy resource access allows a user to perform anything the kubelet API allows. It also allows users to bypass the API server and talk directly to the kubelet potentially circumventing audits and admission controllers. See https://blog.aquasec.com/privilege-escalation-kubernetes-rbac for more info. This policy prevents the creation of a ClusterRole if it contains the nodes/proxy resource. \n\nRefer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/\n"
 annotations:
   kyverno/category: "Sample in Vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "ClusterRole, RBAC"
-digest: b686a5c559918a918a61a7c744e29e09e8e4b363c32e0430d7faf1c51007ee1b
-
-
+digest: 41942f85c112b1c00f96cbd6860b6edd3588c74fb7d3e0a3fcfae8caafdf1fc0
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -31,9 +31,9 @@ spec:
         resources: ["clusterroles"]
   validations:
     - expression: >-
-        object.rules == null || 
-        !object.rules.exists(rule, 
-        rule.resources.exists(resource, resource == 'nodes/proxy') && 
-        rule.apiGroups.exists(apiGroup, apiGroup == ''))
+        object.?rules.orValue([]) == null ||
+        !object.?rules.orValue([]).exists(rule,
+        rule.?resources.orValue([]).exists(resource, resource == 'nodes/proxy') &&
+        rule.?apiGroups.orValue([]).exists(apiGroup, apiGroup == ''))
       message: "A ClusterRole containing the nodes/proxy resource is not allowed."
 

--- a/other-vpol/restrict-edit-for-endpoints/.kyverno-test/kyverno-test.yaml
+++ b/other-vpol/restrict-edit-for-endpoints/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-edit-for-endpoints
+policies:
+- ../restrict-edit-for-endpoints.yaml
+resources:
+- resource.yaml
+results:
+- policy: restrict-edit-for-endpoints
+  isValidatingPolicy: true
+  kind: ClusterRole
+  resources:
+  - system:aggregate-to-edit
+  result: fail

--- a/other-vpol/restrict-edit-for-endpoints/.kyverno-test/resource.yaml
+++ b/other-vpol/restrict-edit-for-endpoints/.kyverno-test/resource.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregate-to-edit
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["edit"]

--- a/other-vpol/restrict-edit-for-endpoints/artifacthub-pkg.yml
+++ b/other-vpol/restrict-edit-for-endpoints/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: restrict-edit-for-endpoints-vpol
-version: 1.0.0
+version: 1.0.1
 displayName: Restrict Edit for Endpoints CVE-2021-25740 in ValidatingPolicy
 description: >-
   Clusters not initially installed with Kubernetes 1.22 may be vulnerable to an issue defined in CVE-2021-25740 which could enable users to send network traffic to locations they would otherwise not have access to via a confused deputy attack. This was due to the system:aggregate-to-edit ClusterRole having edit permission of Endpoints. This policy, intended to run in background mode, checks if your cluster is vulnerable to CVE-2021-25740 by ensuring the system:aggregate-to-edit ClusterRole does not have the edit permission of Endpoints.
@@ -13,12 +13,11 @@ keywords:
   - ValidatingPolicy
 readme: |
   Clusters not initially installed with Kubernetes 1.22 may be vulnerable to an issue defined in CVE-2021-25740 which could enable users to send network traffic to locations they would otherwise not have access to via a confused deputy attack. This was due to the system:aggregate-to-edit ClusterRole having edit permission of Endpoints. This policy, intended to run in background mode, checks if your cluster is vulnerable to CVE-2021-25740 by ensuring the system:aggregate-to-edit ClusterRole does not have the edit permission of Endpoints.
-  
+
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Security in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "ClusterRole"
-digest: 4501fc696db216e18a0aee77db2172794958cc485c46073b5fc3b3e5b9fe29db
-
+digest: 6b871afcf775ffa5333617055c8a93c324a53ed57e56e8959c939358e9bd7bfb
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml
+++ b/other-vpol/restrict-edit-for-endpoints/restrict-edit-for-endpoints.yaml
@@ -31,7 +31,7 @@ spec:
         resources: ["clusterroles"]
         resourceNames: ["system:aggregate-to-edit"]
   validations:
-    - expression: "!object.rules.exists(rule, 'endpoints' in rule.resources && 'edit' in rule.verbs)"
+    - expression: "object.?rules.orValue([]) == null || !object.?rules.orValue([]).exists(rule, 'endpoints' in rule.?resources.orValue([]) && 'edit' in rule.?verbs.orValue([]))"
       message: >-
         This cluster may still be vulnerable to CVE-2021-25740. The system:aggregate-to-edit ClusterRole
         should not have edit permission over Endpoints.

--- a/other-vpol/restrict-escalation-verbs-roles/.kyverno-test/kyverno-test.yaml
+++ b/other-vpol/restrict-escalation-verbs-roles/.kyverno-test/kyverno-test.yaml
@@ -27,6 +27,7 @@ results:
   - goodclusterrole01
   - goodclusterrole02
   - default-rules
+  - nonresource-rule
   result: pass
 - isValidatingPolicy: true
   kind: Role

--- a/other-vpol/restrict-escalation-verbs-roles/.kyverno-test/resource.yaml
+++ b/other-vpol/restrict-escalation-verbs-roles/.kyverno-test/resource.yaml
@@ -143,3 +143,12 @@ metadata:
   name: default-rules
 rules: null
 ---
+---
+# ClusterRole rule with only nonResourceURLs (no resources field).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nonresource-rule
+rules:
+- nonResourceURLs: ["/healthz", "/livez"]
+  verbs: ["get"]

--- a/other-vpol/restrict-escalation-verbs-roles/artifacthub-pkg.yml
+++ b/other-vpol/restrict-escalation-verbs-roles/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: restrict-escalation-verbs-roles-vpol
-version: 1.0.0
+version: 1.0.1
 displayName: Restrict Escalation Verbs in Roles in ValidatingPolicy
 description: >-
   The verbs `impersonate`, `bind`, and `escalate` may all potentially lead to privilege escalation and should be tightly controlled. This policy prevents use of these verbs in Role or ClusterRole resources.
@@ -13,13 +13,11 @@ keywords:
   - ValidatingPolicy
 readme: |
   The verbs `impersonate`, `bind`, and `escalate` may all potentially lead to privilege escalation and should be tightly controlled. This policy prevents use of these verbs in Role or ClusterRole resources.
-  
+
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Security in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Role, ClusterRole, RBAC"
-digest: a26cb647dab19f806b82f72d9fae59217f2a88d53a8f637fc723aa9551628733
-
-
+digest: ee4e329bd64ab2276413720bd87dbec77c7b3739c20a0150842ca7a463289aca
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
+++ b/other-vpol/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
@@ -35,10 +35,10 @@ spec:
       expression: "['*', 'bind', 'escalate', 'impersonate']"
   validations:
     - expression: >-
-        object.rules == null || 
-        !object.rules.exists(rule,
-        rule.apiGroups.exists(apiGroup, apiGroup in variables.apiGroups) &&
-        rule.resources.exists(resource, resource in variables.resources) &&
-        rule.verbs.exists(verb, verb in variables.verbs))
+        object.?rules.orValue([]) == null ||
+        !object.?rules.orValue([]).exists(rule,
+        rule.?apiGroups.orValue([]).exists(apiGroup, apiGroup in variables.apiGroups) &&
+        rule.?resources.orValue([]).exists(resource, resource in variables.resources) &&
+        rule.?verbs.orValue([]).exists(verb, verb in variables.verbs))
       message: "Use of verbs `escalate`, `bind`, and `impersonate` are forbidden."
 

--- a/other-vpol/restrict-secret-role-verbs/.kyverno-test/kyverno-test.yaml
+++ b/other-vpol/restrict-secret-role-verbs/.kyverno-test/kyverno-test.yaml
@@ -23,6 +23,7 @@ results:
   - goodcr02
   - goodcr03
   - default-rules
+  - nonresource-rule
   result: pass
 - isValidatingPolicy: true
   kind: Role

--- a/other-vpol/restrict-secret-role-verbs/.kyverno-test/resource.yaml
+++ b/other-vpol/restrict-secret-role-verbs/.kyverno-test/resource.yaml
@@ -141,3 +141,12 @@ metadata:
 rules: null
 ---
 
+---
+# ClusterRole rule with only nonResourceURLs (no resources field).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nonresource-rule
+rules:
+- nonResourceURLs: ["/healthz", "/livez"]
+  verbs: ["get"]

--- a/other-vpol/restrict-secret-role-verbs/artifacthub-pkg.yml
+++ b/other-vpol/restrict-secret-role-verbs/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: restrict-secret-role-verbs-vpol
-version: 1.0.0
+version: 1.0.1
 displayName: Restrict Secret Verbs in Roles in ValidatingPolicy
 description: >-
   The verbs `get`, `list`, and `watch` in a Role or ClusterRole, when paired with the Secrets resource, effectively allows Secrets to be read which may expose sensitive information. This policy prevents a Role or ClusterRole from using these verbs in tandem with Secret resources. In order to fully implement this control, it is recommended to pair this policy with another which also prevents use of the wildcard ('*') in the verbs list either when explicitly naming Secrets or when also using a wildcard in the base API group.
@@ -13,13 +13,11 @@ keywords:
   - ValidatingPolicy
 readme: |
   The verbs `get`, `list`, and `watch` in a Role or ClusterRole, when paired with the Secrets resource, effectively allows Secrets to be read which may expose sensitive information. This policy prevents a Role or ClusterRole from using these verbs in tandem with Secret resources. In order to fully implement this control, it is recommended to pair this policy with another which also prevents use of the wildcard ('*') in the verbs list either when explicitly naming Secrets or when also using a wildcard in the base API group.
-  
+
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Security in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Role, ClusterRole, RBAC"
-digest: 4cc686aa39e12082c230f81eeb1d8971fa814a3c3a4d1a8a5d9c16fe72ee2dbe
-
-
+digest: 6f8badd52eb3ef7380a75c43bbaec2655aa164a57b9df920efab869e505f1e93
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
+++ b/other-vpol/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
@@ -34,8 +34,8 @@ spec:
       expression: "['get','list','watch']"
   validations:
     - expression: >-
-        object.rules == null || 
-        !object.rules.exists(rule, 
-        'secrets' in rule.resources && rule.verbs.exists(verb, verb in variables.forbiddenVerbs))
+        object.?rules.orValue([]) == null ||
+        !object.?rules.orValue([]).exists(rule,
+        'secrets' in rule.?resources.orValue([]) && rule.?verbs.orValue([]).exists(verb, verb in variables.forbiddenVerbs))
       message: "Requesting verbs `get`, `list`, or `watch` on Secrets is forbidden."
 

--- a/other-vpol/restrict-wildcard-resources/.kyverno-test/kyverno-test.yaml
+++ b/other-vpol/restrict-wildcard-resources/.kyverno-test/kyverno-test.yaml
@@ -45,4 +45,9 @@ results:
   - goodrole05
   - default-rules
   result: pass
-
+- policy: restrict-wildcard-resources
+  isValidatingPolicy: true
+  kind: ClusterRole
+  resources:
+  - cr-nonresource-only
+  result: pass

--- a/other-vpol/restrict-wildcard-resources/.kyverno-test/resource.yaml
+++ b/other-vpol/restrict-wildcard-resources/.kyverno-test/resource.yaml
@@ -177,3 +177,12 @@ metadata:
 rules: null
 ---
 
+---
+# ClusterRole rule with only nonResourceURLs (no resources field).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cr-nonresource-only
+rules:
+  - nonResourceURLs: ["/healthz", "/livez"]
+    verbs: ["get"]

--- a/other-vpol/restrict-wildcard-resources/artifacthub-pkg.yml
+++ b/other-vpol/restrict-wildcard-resources/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: restrict-wildcard-resources-vpol
-version: 1.0.0
+version: 1.0.1
 displayName: Restrict Wildcards in Resources in ValidatingPolicy
 description: >-
   Wildcards ('*') in resources grants access to all of the resources referenced by the given API group and does not follow the principal of least privilege. As much as possible, avoid such open resources unless scoped to perhaps a custom API group. This policy blocks any Role or ClusterRole that contains a wildcard entry in the resources list found in any rule.
@@ -14,13 +14,11 @@ keywords:
   - ValidatingPolicy
 readme: |
   Wildcards ('*') in resources grants access to all of the resources referenced by the given API group and does not follow the principal of least privilege. As much as possible, avoid such open resources unless scoped to perhaps a custom API group. This policy blocks any Role or ClusterRole that contains a wildcard entry in the resources list found in any rule.
-  
+
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Security, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "ClusterRole, Role, RBAC"
-digest: 2e3606f23a81d1d7150909a038976c777b4e56e2e74c66010c3d51040175f75f
-
-
+digest: d09d68dd06320088335465559ed8aafecb447ac459189f35338e49b01b71f5e5
 createdAt: "2025-05-11T17:46:12Z"

--- a/other-vpol/restrict-wildcard-resources/restrict-wildcard-resources.yaml
+++ b/other-vpol/restrict-wildcard-resources/restrict-wildcard-resources.yaml
@@ -29,6 +29,6 @@ spec:
         operations: ["CREATE", "UPDATE"]
         resources: ["roles", "clusterroles"]
   validations:
-    - expression: "object.rules == null || !object.rules.exists(rule, '*' in rule.resources)"
+    - expression: "object.?rules.orValue([]) == null || object.?rules.orValue([]).all(rule, !('*' in rule.?resources.orValue([])))"
       message: "Use of a wildcard ('*') in any resources is forbidden."
 

--- a/other-vpol/restrict-wildcard-verbs/.kyverno-test/kyverno-test.yaml
+++ b/other-vpol/restrict-wildcard-verbs/.kyverno-test/kyverno-test.yaml
@@ -24,6 +24,7 @@ results:
   - goodcr03
   - goodcr04
   - default-rules
+  - nonresource-rule
   result: pass
 - policy: restrict-wildcard-verbs
   isValidatingPolicy: true

--- a/other-vpol/restrict-wildcard-verbs/.kyverno-test/resource.yaml
+++ b/other-vpol/restrict-wildcard-verbs/.kyverno-test/resource.yaml
@@ -158,3 +158,12 @@ metadata:
   name: default-rules
 rules: null
 ---
+---
+# ClusterRole rule with only nonResourceURLs (no resources field).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nonresource-rule
+rules:
+- nonResourceURLs: ["/healthz", "/livez"]
+  verbs: ["get"]

--- a/other-vpol/restrict-wildcard-verbs/artifacthub-pkg.yml
+++ b/other-vpol/restrict-wildcard-verbs/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: restrict-wildcard-verbs-vpol
-version: 1.0.0
+version: 1.0.1
 displayName: Restrict Wildcard in Verbs in ValidatingPolicy
 description: >-
   Wildcards ('*') in verbs grants all access to the resources referenced by it and does not follow the principal of least privilege. As much as possible, avoid such open verbs unless scoped to perhaps a custom API group. This policy blocks any Role or ClusterRole that contains a wildcard entry in the verbs list found in any rule.
@@ -14,13 +14,11 @@ keywords:
   - ValidatingPolicy
 readme: |
   Wildcards ('*') in verbs grants all access to the resources referenced by it and does not follow the principal of least privilege. As much as possible, avoid such open verbs unless scoped to perhaps a custom API group. This policy blocks any Role or ClusterRole that contains a wildcard entry in the verbs list found in any rule.
-  
+
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Security, EKS Best Practices in vpol"
   kyverno/kubernetesVersion: "1.30"
   kyverno/subject: "Role, ClusterRole, RBAC"
-digest: 11c353aa1dff4cab3268c727ac1fa86724b92731204bb01dc6a09d3d010439fb
-
-
+digest: 1d79c87b48051f1796e93b2d99388e6b536adf9bcbee89b635796565f1280e85
 createdAt: "2025-05-11T17:46:11Z"

--- a/other-vpol/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
+++ b/other-vpol/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
@@ -29,6 +29,6 @@ spec:
         operations: ["CREATE", "UPDATE"]
         resources: ["roles", "clusterroles"]
   validations:
-    - expression: "object.rules == null || !object.rules.exists(rule, '*' in rule.verbs)"
+    - expression: "object.?rules.orValue([]) == null || !object.?rules.orValue([]).exists(rule, '*' in rule.?verbs.orValue([]))"
       message: "Use of a wildcard ('*') in any verbs is forbidden."
 


### PR DESCRIPTION
## Related Issue(s)

N/A

## Description

Several `ValidatingPolicy` (CEL) objects throw runtime errors during Kyverno background scans when they hit valid resources whose optional fields are absent. CEL raises `no such key: <field>` on a missing map key, which surfaces as `result: error` in the policy reports instead of a clean `pass`/`fail`.

Affected policies and the field they accessed unguarded:

| Policy | Unsafe access |
|---|---|
| `restrict-binding-system-groups` | `object.subjects` |
| `restrict-wildcard-resources` | `object.rules`, `rule.resources` |
| `restrict-clusterrole-nodesproxy` | `object.rules`, `rule.resources`, `rule.apiGroups` |
| `restrict-escalation-verbs-roles` | `rule.apiGroups`, `rule.resources`, `rule.verbs` |
| `restrict-secret-role-verbs` | `rule.resources`, `rule.verbs` |
| `restrict-edit-for-endpoints` | `object.rules`, `rule.resources`, `rule.verbs` |
| `restrict-wildcard-verbs` | `rule.verbs` |
| `require-pod-probes` | `object.spec.template.spec` (breaks on CronJobs) |
| `ensure-probes-different` | `spec.template.spec.containers` |

### Example

Take `restrict-binding-system-groups`, which walks `object.subjects` to reject
bindings to `system:masters`, `system:anonymous`, etc.

A `ClusterRoleBinding` may legitimately have **no `subjects` field at all** —
the cluster ships with such objects, e.g. `system:node`:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: system:node
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system:node
# no subjects: kubelets are authorized via the Node authorizer, not a subject list
```

The old expression `object.subjects.all(...)` throws `no such key: subjects`
on this object. Two consequences:

1. **Report noise / broken signal.** Every such binding shows up as `error`
   rather than `pass`, so the report can no longer be trusted to answer
   "is anything bound to `system:masters`?".
2. **Evaluation stops at the error.** The policy never gets to assert its
   actual rule for that object, so a genuinely bad binding sitting next to a
   subject-less one could be masked by the error state.

An absent list should be treated as "no subjects to check" (→ `pass`), not as
a crash.

### Fix

Guard every optional accessor with the `.?field.orValue(default)` idiom,
preserving each policy's original structure and pass/fail semantics:

- `object.?subjects.orValue([]).all(...)`
- `object.?rules.orValue([]) == null || object.?rules.orValue([]).all(rule, ... rule.?resources.orValue([]) ...)`
  (the explicit `rules: null` case still passes)
- a `podSpec` variable that resolves the Pod / CronJob / controller shapes so
  probe-less CronJobs are correctly **failed** rather than skipped.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
