### PR TITLE
feat: add replace-configmap-region-string sample policy

### DIFF
--- a/other/replace-configmap-region-string/.kyverno-test/kyverno-test.yaml
+++ b/other/replace-configmap-region-string/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,16 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: replace-configmap-region-string
+policies:
+- ../replace-configmap-region-string.yaml
+resources:
+- resource.yaml
+results:
+- kind: ConfigMap
+  patchedResources: patchedResource.yaml
+  policy: replace-configmap-region-string
+  resources:
+  - default/region-config
+  result: pass
+  rule: replace-region-in-configmap-data

--- a/other/replace-configmap-region-string/.kyverno-test/patchedResource.yaml
+++ b/other/replace-configmap-region-string/.kyverno-test/patchedResource.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: region-config
+  namespace: default
+data:
+  endpoint: https://s3.ap-south-2.amazonaws.com
+  note: keep-me
+  multi: region=ap-south-2;backup=ap-south-2

--- a/other/replace-configmap-region-string/.kyverno-test/resource.yaml
+++ b/other/replace-configmap-region-string/.kyverno-test/resource.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: region-config
+  namespace: default
+data:
+  endpoint: https://s3.ap-south-1.amazonaws.com
+  note: keep-me
+  multi: region=ap-south-1;backup=ap-south-1

--- a/other/replace-configmap-region-string/artifacthub-pkg.yml
+++ b/other/replace-configmap-region-string/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: replace-configmap-region-string
+version: 1.0.0
+displayName: Replace ConfigMap Region String
+createdAt: "2026-07-17T07:56:46.000Z"
+description: >-
+  ConfigMap values sometimes embed cloud region identifiers that need to be rewritten during a migration, for example from `ap-south-1` to `ap-south-2`. This sample policy mutates every data entry in a ConfigMap and replaces the old region substring with the new one using `replace_all`. Customize the from/to strings to match your migration.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/replace-configmap-region-string/replace-configmap-region-string.yaml
+  ```
+keywords:
+  - kyverno
+  - Sample
+readme: |
+  ConfigMap values sometimes embed cloud region identifiers that need to be rewritten during a migration, for example from `ap-south-1` to `ap-south-2`. This sample policy mutates every data entry in a ConfigMap and replaces the old region substring with the new one using `replace_all`. Customize the from/to strings to match your migration.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Sample"
+  kyverno/kubernetesVersion: "1.24"
+  kyverno/subject: "ConfigMap"
+digest: 9481435a825fb1874ee169b959e03294febdbf90b60e1b7075760284600d4148

--- a/other/replace-configmap-region-string/replace-configmap-region-string.yaml
+++ b/other/replace-configmap-region-string/replace-configmap-region-string.yaml
@@ -1,0 +1,45 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: replace-configmap-region-string
+  annotations:
+    policies.kyverno.io/title: Replace ConfigMap Region String
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: ConfigMap
+    policies.kyverno.io/minversion: 1.9.0
+    kyverno.io/kyverno-version: 1.9.0
+    kyverno.io/kubernetes-version: "1.24"
+    policies.kyverno.io/description: >-
+      ConfigMap values sometimes embed cloud region identifiers that need to be
+      rewritten during a migration, for example from `ap-south-1` to `ap-south-2`.
+      This sample policy mutates every data entry in a ConfigMap and replaces the
+      old region substring with the new one using `replace_all`. Customize the
+      from/to strings to match your migration.
+spec:
+  background: false
+  rules:
+  - name: replace-region-in-configmap-data
+    match:
+      any:
+      - resources:
+          kinds:
+          - ConfigMap
+    preconditions:
+      all:
+      - key: "{{ request.operation || 'BACKGROUND' }}"
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+    mutate:
+      foreach:
+      - list: request.object.data | keys(@)
+        context:
+        - name: oldvalue
+          variable:
+            jmesPath: "request.object.data.\"{{element}}\""
+        patchesJson6902: |-
+          - path: /data/{{element}}
+            op: replace
+            value: "{{ replace_all('{{oldvalue}}', 'ap-south-1', 'ap-south-2') }}"


### PR DESCRIPTION
## Related Issue(s)
Closes #1230

## Description
Adds a sample ClusterPolicy that mutates ConfigMap `data` values and replaces an embedded region substring (`ap-south-1` → `ap-south-2`) using `foreach` over data keys plus `replace_all`.

The original request used `patchStrategicMerge` with `request.object.data | keys(@)` in a way that does not resolve the map entry value correctly. This policy loads each value into a foreach `context` variable (`oldvalue`) and applies a JSON6902 replace, which the Kyverno CLI mutates successfully.

The from/to region strings are intentionally simple so the sample is easy to customize for other migrations.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/policies#contribution).
- [x] I have added Kyverno annotations.
- [x] I have added an `artifacthub-pkg.yml` with a Linux-generated digest.
- [x] I have tested this policy with the Kyverno CLI.

## Test Plan
- [x] `kyverno test other/replace-configmap-region-string/.kyverno-test` → 1 pass
- [x] `kyverno apply` rewrites multi-occurrence values (`region=ap-south-1;backup=ap-south-1`)

Signed-off-by: Alex Chen <l46983284@gmail.com>
