### PR TITLE
test(other): add chainsaw coverage for restrict-edit-for-endpoints

### DIFF
--- a/other-cel/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other-cel/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,0 +1,4 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-edit-for-endpoints

--- a/other-cel/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-test.yaml
+++ b/other-cel/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,30 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-edit-for-endpoints
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../restrict-edit-for-endpoints.yaml
+    - patch:
+        resource:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          metadata:
+            name: restrict-edit-for-endpoints
+          spec:
+            validationFailureAction: Enforce
+    - assert:
+        file: chainsaw-step-01-assert-1.yaml
+
+  - name: step-02
+    try:
+    - apply:
+        file: cr-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: cr-bad.yaml

--- a/other-cel/restrict-edit-for-endpoints/.chainsaw-test/cr-bad.yaml
+++ b/other-cel/restrict-edit-for-endpoints/.chainsaw-test/cr-bad.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregate-to-edit
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - edit

--- a/other-cel/restrict-edit-for-endpoints/.chainsaw-test/cr-good.yaml
+++ b/other-cel/restrict-edit-for-endpoints/.chainsaw-test/cr-good.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregate-to-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - edit

--- a/other-vpol/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other-vpol/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,0 +1,4 @@
+apiVersion: policies.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: restrict-edit-for-endpoints

--- a/other-vpol/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-test.yaml
+++ b/other-vpol/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-edit-for-endpoints
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../restrict-edit-for-endpoints.yaml
+    - assert:
+        file: chainsaw-step-01-assert-1.yaml
+
+  - name: step-02
+    try:
+    - apply:
+        file: cr-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: cr-bad.yaml

--- a/other-vpol/restrict-edit-for-endpoints/.chainsaw-test/cr-bad.yaml
+++ b/other-vpol/restrict-edit-for-endpoints/.chainsaw-test/cr-bad.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregate-to-edit
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - edit

--- a/other-vpol/restrict-edit-for-endpoints/.chainsaw-test/cr-good.yaml
+++ b/other-vpol/restrict-edit-for-endpoints/.chainsaw-test/cr-good.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregate-to-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - edit

--- a/other/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-step-01-assert-1.yaml
+++ b/other/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-step-01-assert-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-edit-for-endpoints
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready
+

--- a/other/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-test.yaml
+++ b/other/restrict-edit-for-endpoints/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: restrict-edit-for-endpoints
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../restrict-edit-for-endpoints.yaml
+    - patch:
+        resource:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          metadata:
+            name: restrict-edit-for-endpoints
+          spec:
+            validationFailureAction: Enforce
+    - assert:
+        file: chainsaw-step-01-assert-1.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: cr-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: cr-bad.yaml

--- a/other/restrict-edit-for-endpoints/.chainsaw-test/cr-bad.yaml
+++ b/other/restrict-edit-for-endpoints/.chainsaw-test/cr-bad.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregate-to-edit
+rules:
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs:
+  - edit

--- a/other/restrict-edit-for-endpoints/.chainsaw-test/cr-good.yaml
+++ b/other/restrict-edit-for-endpoints/.chainsaw-test/cr-good.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregate-to-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - edit


### PR DESCRIPTION
## Related Issue(s)

Closes #1512 

## Description
This PR adds Chainsaw coverage for the `restrict-edit-for-endpoints` policy.

During investigation, it was found that the existing negative test resources did not match the policy scope. The policy only evaluates `ClusterRole` resources named `system:aggregate-to-edit`, while the test resources used unrelated names (`badcr01`, `badcr02`).

Because the resources did not match the policy rule, Kyverno never evaluated the deny condition, meaning the test was not validating the actual policy behavior.

This change adds valid positive and negative test cases:
- A valid `ClusterRole` without Endpoint edit permissions is allowed.
- A vulnerable `ClusterRole` named `system:aggregate-to-edit` with Endpoint edit permissions is denied.

## Testing

Ran locally:

```bash
chainsaw test other/restrict-edit-for-endpoints/.chainsaw-test
```

Result:

```
PASS
Tests Summary...
- Passed tests 1
- Failed tests 0
```
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
