### PR TITLE
fix: avoid variables in MutatingPolicy match conditions

### DIFF
--- a/other-mpol/remove-hostpath-volumes/remove-hostpath-volumes.yaml
+++ b/other-mpol/remove-hostpath-volumes/remove-hostpath-volumes.yaml
@@ -29,12 +29,9 @@ spec:
         has(object.spec.volumes) ? 
           object.spec.volumes.filter(v, has(v.hostPath)).map(v, v.name) : 
           []
-    - name: hasHostPath
-      expression: |
-        variables.hostpathVolumes.size() > 0
   matchConditions:
     - name: has-hostpath-volumes
-      expression: variables.hasHostPath
+      expression: has(object.spec.volumes) && object.spec.volumes.exists(v, has(v.hostPath))
   mutations:
     - patchType: JSONPatch
       jsonPatch:


### PR DESCRIPTION
## Summary

Update the `remove-hostpath-volumes` MutatingPolicy so its trigger `matchConditions` expression reads the trigger object directly instead of referencing a policy variable.

Kyverno PR kyverno/kyverno#16614 corrects MutatingPolicy evaluation ordering so trigger match conditions run before variables are installed. Under that contract, `variables.hasHostPath` is intentionally unavailable in `matchConditions` and causes the CLI policies suite to fail compilation.

The replacement expression is behaviorally equivalent:

```cel
has(object.spec.volumes) && object.spec.volumes.exists(v, has(v.hostPath))
```

The existing `hostpathVolumes` variable remains available to the mutation expression.

## Related

- kyverno/kyverno#16614
- kyverno/kyverno#16612

## Validation

Ran the Kyverno CLI built from kyverno/kyverno#16614 against this complete policies checkout:

```text
Test Summary: 4945 tests passed and 0 tests failed
```