### PR TITLE
fix: disallow-selinux false positive on null seLinuxOptions

### DIFF
--- a/pod-security/baseline/disallow-selinux/.chainsaw-test/pod-good.yaml
+++ b/pod-security/baseline/disallow-selinux/.chainsaw-test/pod-good.yaml
@@ -256,6 +256,28 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  name: null-goodpod01
+spec:
+  containers:
+  - name: container01
+    image: ghcr.io/kyverno/test-busybox:1.35
+  securityContext:
+    seLinuxOptions: null
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: null-goodpod02
+spec:
+  containers:
+  - name: container01
+    image: ghcr.io/kyverno/test-busybox:1.35
+    securityContext:
+      seLinuxOptions: null
+---
+apiVersion: v1
+kind: Pod
+metadata:
   name: selur-goodpod01
 spec:
   containers:

--- a/pod-security/baseline/disallow-selinux/.kyverno-test/kyverno-test.yaml
+++ b/pod-security/baseline/disallow-selinux/.kyverno-test/kyverno-test.yaml
@@ -98,8 +98,17 @@ results:
   - goodpod12
   - goodpod13
   - goodpod14
+  - null-goodpod01
+  - null-goodpod02
   result: pass
   rule: selinux-type
+- kind: Pod
+  policy: disallow-selinux
+  resources:
+  - null-goodpod01
+  - null-goodpod02
+  result: pass
+  rule: selinux-user-role
 - kind: CronJob
   policy: disallow-selinux
   resources:

--- a/pod-security/baseline/disallow-selinux/.kyverno-test/resource.yaml
+++ b/pod-security/baseline/disallow-selinux/.kyverno-test/resource.yaml
@@ -1226,6 +1226,29 @@ spec:
           - name: container01
             image: dummyimagename
 ---
+###### Pods - Good (null seLinuxOptions)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: null-goodpod01
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+  securityContext:
+    seLinuxOptions: null
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: null-goodpod02
+spec:
+  containers:
+  - name: container01
+    image: dummyimagename
+    securityContext:
+      seLinuxOptions: null
+---
 #############################
 ## Rule: selinux-user-role ##
 #############################

--- a/pod-security/baseline/disallow-selinux/artifacthub-pkg.yml
+++ b/pod-security/baseline/disallow-selinux/artifacthub-pkg.yml
@@ -3,7 +3,7 @@ version: 1.0.0
 displayName: Disallow SELinux
 createdAt: "2023-04-10T23:12:01.000Z"
 description: >-
-  SELinux options can be used to escalate privileges and should not be allowed. This policy ensures that the `seLinuxOptions` field is undefined.
+  SELinux options can be used to escalate privileges and should not be allowed. This policy ensures that the `seLinuxOptions` field is undefined or set to allowed values.
 install: |-
   ```shell
   kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
@@ -12,11 +12,11 @@ keywords:
   - kyverno
   - Pod Security Standards (Baseline)
 readme: |
-  SELinux options can be used to escalate privileges and should not be allowed. This policy ensures that the `seLinuxOptions` field is undefined.
+  SELinux options can be used to escalate privileges and should not be allowed. This policy ensures that the `seLinuxOptions` field is undefined or set to allowed values.
   
   Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
 annotations:
   kyverno/category: "Pod Security Standards (Baseline)"
   kyverno/kubernetesVersion: "1.22-1.23"
   kyverno/subject: "Pod"
-digest: 1e6920c08280c459e1c16fa0eb1d75304ffbda279b16798a8e68973d47e2cd5e
+digest: 789d55e5786f30daada2dc508295009d8013a83ce678800ca19a8da47b7f6fe8

--- a/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
@@ -11,7 +11,7 @@ metadata:
     kyverno.io/kubernetes-version: "1.22-1.23"
     policies.kyverno.io/description: >-
       SELinux options can be used to escalate privileges and should not be allowed. This policy
-      ensures that the `seLinuxOptions` field is undefined.
+      ensures that the `seLinuxOptions` field is undefined or set to allowed values.
 spec:
   validationFailureAction: Audit
   background: true
@@ -22,35 +22,44 @@ spec:
         - resources:
             kinds:
               - Pod
+      preconditions:
+        all:
+        - key: "{{ request.operation || 'BACKGROUND' }}"
+          operator: NotEquals
+          value: DELETE
       validate:
         message: >-
           Setting the SELinux type is restricted. The fields
           spec.securityContext.seLinuxOptions.type, spec.containers[*].securityContext.seLinuxOptions.type,
-          , spec.initContainers[*].securityContext.seLinuxOptions, and spec.ephemeralContainers[*].securityContext.seLinuxOptions.type
+          spec.initContainers[*].securityContext.seLinuxOptions.type, and spec.ephemeralContainers[*].securityContext.seLinuxOptions.type
           must either be unset or set to one of the allowed values (container_t, container_init_t, or container_kvm_t).
-        pattern:
-          spec:
-            =(securityContext):
-              =(seLinuxOptions):
-                =(type): "container_t | container_init_t | container_kvm_t"
-            =(ephemeralContainers):
-              - =(securityContext):
-                  =(seLinuxOptions):
-                    =(type): "container_t | container_init_t | container_kvm_t"
-            =(initContainers):
-              - =(securityContext):
-                  =(seLinuxOptions):
-                    =(type): "container_t | container_init_t | container_kvm_t"
-            containers:
-              - =(securityContext):
-                  =(seLinuxOptions):
-                    =(type): "container_t | container_init_t | container_kvm_t"
+        deny:
+          conditions:
+            any:
+            - key: "{{ request.object.spec.securityContext.seLinuxOptions.type || '' }}"
+              operator: AnyNotIn
+              value:
+              - ""
+              - container_t
+              - container_init_t
+              - container_kvm_t
+            - key: "{{ request.object.spec.[ephemeralContainers, initContainers, containers][].securityContext.seLinuxOptions.type[] }}"
+              operator: AnyNotIn
+              value:
+              - container_t
+              - container_init_t
+              - container_kvm_t
     - name: selinux-user-role
       match:
         any:
         - resources:
             kinds:
               - Pod
+      preconditions:
+        all:
+        - key: "{{ request.operation || 'BACKGROUND' }}"
+          operator: NotEquals
+          value: DELETE
       validate:
         message: >-
           Setting the SELinux user or role is forbidden. The fields
@@ -59,24 +68,18 @@ spec:
           spec.initContainers[*].securityContext.seLinuxOptions.user, spec.initContainers[*].securityContext.seLinuxOptions.role,
           spec.ephemeralContainers[*].securityContext.seLinuxOptions.user, and spec.ephemeralContainers[*].securityContext.seLinuxOptions.role
           must be unset.
-        pattern:
-          spec:
-            =(securityContext):
-              =(seLinuxOptions):
-                X(user): "null"
-                X(role): "null"
-            =(ephemeralContainers):
-              - =(securityContext):
-                  =(seLinuxOptions):
-                    X(user): "null"
-                    X(role): "null"
-            =(initContainers):
-              - =(securityContext):
-                  =(seLinuxOptions):
-                    X(user): "null"
-                    X(role): "null"
-            containers:
-              - =(securityContext):
-                  =(seLinuxOptions):
-                    X(user): "null"
-                    X(role): "null"
+        deny:
+          conditions:
+            any:
+            - key: "{{ request.object.spec.securityContext.seLinuxOptions.user || '' }}"
+              operator: NotEquals
+              value: ""
+            - key: "{{ request.object.spec.securityContext.seLinuxOptions.role || '' }}"
+              operator: NotEquals
+              value: ""
+            - key: "{{ request.object.spec.[ephemeralContainers, initContainers, containers][].securityContext.seLinuxOptions.user[] }}"
+              operator: AnyNotIn
+              value: [""]
+            - key: "{{ request.object.spec.[ephemeralContainers, initContainers, containers][].securityContext.seLinuxOptions.role[] }}"
+              operator: AnyNotIn
+              value: [""]


### PR DESCRIPTION
The `=(seLinuxOptions):` conditional anchor treats `seLinuxOptions: null` as "field exists" and enters validation, which fails because null has no children to match against. Kubernetes treats null identically to omitting the field, so this is a false positive.

## Related Issue(s)

None.

## Description

This PR converts both rules from the `=(seLinuxOptions):` pattern to deny+conditions using JMESPath, which handles null correctly via `|| ''`. This matches the approach already used by [disallow-capabilities](https://github.com/kyverno/policies/blob/main/pod-security/baseline/disallow-capabilities/disallow-capabilities.yaml#L19-L53).

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
