### PR TITLE
restrict-clusterrole-nodesproxy: block apiGroups wildcard "*"

### DIFF
--- a/other-cel/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-bad.yaml
+++ b/other-cel/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-bad.yaml
@@ -19,3 +19,13 @@ rules:
   resources: ["pods", "nodes/proxy"]
   verbs: ["get", "watch", "list"]
 
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: badcr03
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]

--- a/other-cel/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-good.yaml
+++ b/other-cel/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-good.yaml
@@ -30,3 +30,13 @@ kind: ClusterRole
 metadata:
   name: omitted-rules
 ---
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: goodcr03
+rules:
+- apiGroups: ["networking.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]

--- a/other-cel/restrict-clusterrole-nodesproxy/.kyverno-test/kyverno-test.yaml
+++ b/other-cel/restrict-clusterrole-nodesproxy/.kyverno-test/kyverno-test.yaml
@@ -13,6 +13,7 @@ results:
   resources:
   - badcr01
   - badcr02
+  - badcr03
   result: fail
 - policy: restrict-clusterrole-nodesproxy
   rule: clusterrole-nodesproxy
@@ -21,5 +22,6 @@ results:
   - goodcr01
   - goodcr02
   - default-rules
+  - goodcr03
   result: pass
 

--- a/other-cel/restrict-clusterrole-nodesproxy/.kyverno-test/resource.yaml
+++ b/other-cel/restrict-clusterrole-nodesproxy/.kyverno-test/resource.yaml
@@ -56,3 +56,23 @@ metadata:
 rules:
 - nonResourceURLs: ["/test"]
   verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: badcr03
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: goodcr03
+rules:
+- apiGroups: ["networking.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]

--- a/other-cel/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other-cel/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -38,6 +38,6 @@ spec:
                 !object.rules.exists(rule,
                 has(rule.resources) &&
                 rule.resources.exists(resource, resource == 'nodes/proxy') && 
-                rule.apiGroups.exists(apiGroup, apiGroup == ''))
+                rule.apiGroups.exists(apiGroup, apiGroup == '' || apiGroup == '*'))
               message: "A ClusterRole containing the nodes/proxy resource is not allowed."
 

--- a/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-bad.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-bad.yaml
@@ -19,3 +19,13 @@ rules:
   resources: ["pods", "nodes/proxy"]
   verbs: ["get", "watch", "list"]
 
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: badcr03
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]

--- a/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-good.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-good.yaml
@@ -30,3 +30,13 @@ kind: ClusterRole
 metadata:
   name: omitted-rules
 ---
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: goodcr03
+rules:
+- apiGroups: ["networking.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]

--- a/other-vpol/restrict-clusterrole-nodesproxy/.kyverno-test/kyverno-test.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/.kyverno-test/kyverno-test.yaml
@@ -13,6 +13,7 @@ results:
   resources:
   - badcr01
   - badcr02
+  - badcr03
   result: fail
 - policy: restrict-clusterrole-nodesproxy
   isValidatingPolicy: true
@@ -21,5 +22,6 @@ results:
   - goodcr01
   - goodcr02
   - default-rules
+  - goodcr03
   result: pass
 

--- a/other-vpol/restrict-clusterrole-nodesproxy/.kyverno-test/resource.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/.kyverno-test/resource.yaml
@@ -48,3 +48,23 @@ metadata:
   name: default-rules
 rules: null
 ---
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: badcr03
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: goodcr03
+rules:
+- apiGroups: ["networking.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]

--- a/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/other-vpol/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -34,6 +34,6 @@ spec:
         object.rules == null || 
         !object.rules.exists(rule, 
         rule.resources.exists(resource, resource == 'nodes/proxy') && 
-        rule.apiGroups.exists(apiGroup, apiGroup == ''))
+        rule.apiGroups.exists(apiGroup, apiGroup == '' || apiGroup == '*'))
       message: "A ClusterRole containing the nodes/proxy resource is not allowed."
 

--- a/other/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-bad.yaml
+++ b/other/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-bad.yaml
@@ -18,3 +18,12 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "nodes/proxy"]
   verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: badcr03
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]

--- a/other/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-good.yaml
+++ b/other/restrict-clusterrole-nodesproxy/.chainsaw-test/cr-good.yaml
@@ -18,3 +18,12 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: goodcr03
+rules:
+- apiGroups: ["networking.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]

--- a/other/restrict-clusterrole-nodesproxy/.kyverno-test/kyverno-test.yaml
+++ b/other/restrict-clusterrole-nodesproxy/.kyverno-test/kyverno-test.yaml
@@ -14,6 +14,7 @@ results:
   resources:
   - badcr01
   - badcr02
+  - badcr03
   result: fail
 - policy: restrict-clusterrole-nodesproxy
   rule: clusterrole-nodesproxy
@@ -21,5 +22,6 @@ results:
   resources:
   - goodcr01
   - goodcr02
+  - goodcr03
   result: pass
 


### PR DESCRIPTION
## Related Issue(s)

Closes #1492 — reported by @zwindler, who did the analysis and proposed this fix. They offered to send a PR; as it had been open a couple of months I've drafted it, and I'd be glad for them to take it over if they prefer.

## Description

A `ClusterRole` that pairs an explicit `nodes/proxy` resource with `apiGroups: ["*"]` is not blocked. Kubernetes treats `"*"` as matching every API group, including the core group `""`, so such a ClusterRole grants exactly the permissions this policy exists to prevent — and `nodes/proxy` **GET** is enough for command execution against the kubelet over a WebSocket handshake, without a `pods/exec` audit trail.

### What I verified before changing anything

I reproduced each variant against the Kyverno CLI (v1.18.2) rather than assuming the report applied uniformly, and it does not:

| Variant | `apiGroups: ["*"]` + `nodes/proxy` | Affected? |
|---|---|---|
| `other-cel` | not blocked | **yes** |
| `other-vpol` | not blocked | **yes** |
| `other` (JMESPath) | blocked | **no** |

The JMESPath variant is fine as-is: its `AnyIn` operator already performs wildcard matching on the condition value, so `["*"]` matches the `""` key today. I confirmed this is genuine matching rather than an always-true condition by checking that `apiGroups: ["metrics.k8s.io"]` with `nodes/proxy` still passes. So the issue's "both CEL and JMESPath variants" is accurate for CEL but not for JMESPath — **no change is made to `other/`'s policy**, only a regression test so the behaviour stays locked in.

### The fix

One predicate, in the two CEL-based variants:

```diff
- rule.apiGroups.exists(apiGroup, apiGroup == ''))
+ rule.apiGroups.exists(apiGroup, apiGroup == '' || apiGroup == '*'))
```

This widens only the `apiGroups` check and leaves the `resources` check untouched, so the over-blocking fixed by #931 for #895 does **not** regress — Istio-style ClusterRoles with `resources: ["*"]` in a custom API group never reach the `apiGroups` predicate, because `"*"` is not `nodes/proxy`. `goodcr03` now covers that case explicitly so it can't silently regress later.

### Tests

Added to all three variants:

- **`badcr03`** — explicit `nodes/proxy` with `apiGroups: ["*"]`, must **fail**.
- **`goodcr03`** — Istio-style `resources: ["*"]` in `networking.istio.io`, must **pass** (the #895 guard).

Confirmed the new test actually catches the bug — reverting just the policy expressions while keeping the new fixtures gives:

```
other-cel  │ badcr03 │ Fail │ Want fail, got pass
other-vpol │ badcr03 │ Fail │ Want fail, got pass
```

With the fix applied, all variants are green:

```
other:      6 tests passed and 0 tests failed
other-cel:  7 tests passed and 0 tests failed
other-vpol: 7 tests passed and 0 tests failed
```

I have not touched `artifacthub-pkg.yml` versions or hashes, following the precedent in #1352 where the digests were refreshed separately by maintainers (#1359, #1362). Happy to bump them here instead if you'd prefer.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
