### PR TITLE
fix(vpol): restrict-seccomp-strict must require an explicitly set sec…

### DIFF
--- a/pod-security-vpol/restricted/restrict-seccomp-strict/artifacthub-pkg.yml
+++ b/pod-security-vpol/restricted/restrict-seccomp-strict/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 name: restrict-seccomp-strict-vpol
-version: 1.0.0
+version: 1.1.0
 displayName: Restrict Seccomp (Strict) in ValidatingPolicy
 description: >-
   The seccomp profile in the Restricted group must not be explicitly set to Unconfined but additionally must also not allow an unset value. This policy,  requiring Kubernetes v1.30 or later, ensures that seccomp is  set to `RuntimeDefault` or `Localhost`. A known issue prevents a policy such as this using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
@@ -19,5 +19,5 @@ annotations:
   kyverno/category: "Pod Security Standards (Restricted)"
   kyverno/kubernetesVersion: "1.30+"
   kyverno/subject: "Pod"
-digest: 6dbd155991db3646193dd8e31f76a3e6a661afbf989def8a84a58390bb3aed6d
+digest: 71c6694c65dab5043c0905ae74ef4607013a2a6b6bed4002bf64a9a17b219345
 createdAt: "2025-03-13T23:26:58Z"

--- a/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
+++ b/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
@@ -35,9 +35,11 @@ spec:
       object.spec.?initContainers.orValue([]) + 
       object.spec.?ephemeralContainers.orValue([])
   validations:
-  - expression: >- 
-      object.spec.?securityContext.?seccompProfile.?type.orValue('RuntimeDefault') in ['RuntimeDefault', 'Localhost']
-      && variables.allContainers.all(container, 
-      container.?securityContext.?seccompProfile.?type.orValue('RuntimeDefault') in ['RuntimeDefault', 'Localhost'])
+  - expression: >-
+      variables.allContainers.all(container,
+      (has(container.securityContext) && has(container.securityContext.seccompProfile)
+      ? container.securityContext.seccompProfile.type
+      : object.spec.?securityContext.?seccompProfile.?type.orValue(''))
+      in ['RuntimeDefault', 'Localhost'])
     message: >-
-      seccompProfile.type must be either 'RuntimeDefault' or 'Localhost'.
+      seccompProfile.type must be explicitly set to either 'RuntimeDefault' or 'Localhost'.


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->
Did not create one, but https://github.com/kyverno/policies/issues/1472 (and possibly others) seems related

## Description

**Problem:**

The CEL `ValidatingPolicy` used `.orValue('RuntimeDefault')`, which substitutes `RuntimeDefault` whenever `seccompProfile.type` is **absent**. As a result a Pod that sets **no** `seccompProfile` at all is treated as compliant.

This diverges from the strict Pod Security Standard (and the equivalent `ClusterPolicy`), which require the profile to be **explicitly set** to `RuntimeDefault` or `Localhost`. On clusters where the kubelet `SeccompDefault` feature gate is **disabled**, an unset profile means the workload runs `Unconfined` — so silently passing it is a real security gap, not just a reporting mismatch.

A second, subtler bug: a container's own `seccompProfile` **overrides** the pod-level one, so an expression of the shape `pod-level-ok || all(container, container-ok)` wrongly passes a Pod whose pod-level profile is valid but which has a container explicitly set to `Unconfined`.

**Fix**

Evaluate each container against its **own** profile when set (container overrides pod), otherwise against the **pod-level** profile, and default an unset value to `''` (which is not in the allow-list, so it fails):

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
