### PR TITLE
fix: allow pod-level seccomp inheritance in restrict-seccomp-strict vpol

### DIFF
--- a/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
+++ b/pod-security-vpol/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
@@ -31,13 +31,23 @@ spec:
   variables:
   - name: allContainers
     expression: >-
-      object.spec.containers + 
-      object.spec.?initContainers.orValue([]) + 
-      object.spec.?ephemeralContainers.orValue([])
+      object.spec.containers
+      + object.spec.?initContainers.orValue([])
+      + object.spec.?ephemeralContainers.orValue([])
   validations:
-  - expression: >- 
-      object.spec.?securityContext.?seccompProfile.?type.orValue('RuntimeDefault') in ['RuntimeDefault', 'Localhost']
-      && variables.allContainers.all(container, 
-      container.?securityContext.?seccompProfile.?type.orValue('RuntimeDefault') in ['RuntimeDefault', 'Localhost'])
+  - expression: >-
+      !object.spec.?securityContext.?seccompProfile.?type.hasValue() ||
+      object.spec.securityContext.seccompProfile.type in ['RuntimeDefault', 'Localhost']
     message: >-
-      seccompProfile.type must be either 'RuntimeDefault' or 'Localhost'.
+      The field spec.securityContext.seccompProfile.type must be unset or
+      set to `RuntimeDefault` or `Localhost`.
+
+  - expression: >-
+      variables.allContainers.all(c,
+        c.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost'] ||
+        (!c.?securityContext.?seccompProfile.?type.hasValue() &&
+         object.spec.?securityContext.?seccompProfile.?type.orValue('') in ['RuntimeDefault', 'Localhost']))
+    message: >-
+      Containers must set securityContext.seccompProfile.type to `RuntimeDefault`
+      or `Localhost`, or inherit a valid pod-level
+      spec.securityContext.seccompProfile.type.


### PR DESCRIPTION
## Related Issue(s)
Related: kyverno/kyverno#16224
Follow-up to kyverno/kyverno#16249 to keep the `restrict-seccomp-strict` ValidatingPolicy aligned across repositories.

## Description

This PR aligns the `restrict-seccomp-strict` ValidatingPolicy in `kyverno/policies` with the fix merged in `kyverno/kyverno`.

## Changes

- Allow containers to inherit a valid pod-level `spec.securityContext.seccompProfile.type`.
- Continue to reject invalid container-level overrides (for example, `Unconfined`).
- Align the validation logic with the canonical implementation using the shared `allContainers` variable and separate pod-level/container-level validations.

### Validation

```text
$ kyverno test pod-security-vpol/restricted/restrict-seccomp-strict

Test Summary: 52 tests passed and 0 tests failed
```

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
