### PR TITLE
feat: Add `other/add-daemonset-tolerations` — new DaemonSet toleration-defaulting policy

### DIFF
--- a/other/add-daemonset-tolerations/.chainsaw-test/chainsaw-test.yaml
+++ b/other/add-daemonset-tolerations/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: add-daemonset-tolerations
+spec:
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../add-daemonset-tolerations.yaml
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: resource.yaml
+  - name: step-03
+    try:
+    - assert:
+        file: patched-resource.yaml

--- a/other/add-daemonset-tolerations/.chainsaw-test/patched-resource.yaml
+++ b/other/add-daemonset-tolerations/.chainsaw-test/patched-resource.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-vgpu-device-manager
+  namespace: default
+spec:
+  template:
+    spec:
+      tolerations:
+      - operator: Exists

--- a/other/add-daemonset-tolerations/.chainsaw-test/policy-ready.yaml
+++ b/other/add-daemonset-tolerations/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-daemonset-tolerations
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/other/add-daemonset-tolerations/.chainsaw-test/resource.yaml
+++ b/other/add-daemonset-tolerations/.chainsaw-test/resource.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: nvidia-vgpu-device-manager
+  namespace: default
+  name: nvidia-vgpu-device-manager
+  annotations:
+    openshift.io/scc: nvidia-vgpu-device-manager
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-vgpu-device-manager
+  template:
+    metadata:
+      labels:
+        app: nvidia-vgpu-device-manager
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.deploy.vgpu-device-manager: "true"
+      serviceAccountName: nvidia-vgpu-device-manager
+      initContainers:
+        - name: vgpu-manager-validation
+          image: "registry.k8s.io/pause:3.10"
+          command: ['sh', '-c']
+          # TODO: Account for pre-installed vGPU Manager. Currently validator
+          # creates a different status file when driver is pre-installed.
+          args: ["until [ -f /run/nvidia/validations/vgpu-manager-ready ]; do echo waiting for NVIDIA vGPU Manager to be setup; sleep 5; done"]
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: run-nvidia-validations
+              mountPath: /run/nvidia/validations
+              mountPropagation: Bidirectional
+      containers:
+      - name: nvidia-vgpu-device-manager
+        image: "registry.k8s.io/pause:3.10"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CONFIG_FILE
+          value: "/vgpu-config/config.yaml"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /vgpu-config
+          name: vgpu-config
+        - mountPath: /sys
+          name: host-sys
+        - mountPath: /host
+          name: host-root
+          mountPropagation: HostToContainer
+        - name: driver-install-dir
+          mountPath: /driver-root
+          mountPropagation: HostToContainer
+      volumes:
+      - name: vgpu-config
+        configMap:
+          name: default
+      - name: host-sys
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: host-root
+        hostPath:
+          path: "/"
+      - name: driver-install-dir
+        hostPath:
+          path: "/run/nvidia/driver"
+          type: DirectoryOrCreate
+      - name: run-nvidia-validations
+        hostPath:
+          path: /run/nvidia/validations
+          type: DirectoryOrCreate

--- a/other/add-daemonset-tolerations/.kyverno-test/kyverno-test.yaml
+++ b/other/add-daemonset-tolerations/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,35 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: add-daemonset-tolerations-test
+policies:
+  - ../add-daemonset-tolerations.yaml
+resources:
+  - resources.yaml
+results:
+  # Real filed bugs: manifest had NO tolerations at all -> must be mutated
+  - kind: DaemonSet
+    policy: add-daemonset-tolerations
+    rule: add-daemonset-tolerations
+    resources:
+      - nvidia-vgpu-device-manager
+    patchedResources: patched-vgpu-device-manager.yaml
+    result: pass
+  - kind: DaemonSet
+    policy: add-daemonset-tolerations
+    rule: add-daemonset-tolerations
+    resources:
+      - sriov-network-metrics-exporter
+    patchedResources: patched-sriov-metrics-exporter.yaml
+    result: pass
+  # Already had tolerations set -> must NOT be touched
+  - kind: DaemonSet
+    policy: add-daemonset-tolerations
+    rule: add-daemonset-tolerations
+    resources:
+      - nvidia-device-plugin-daemonset
+      - sriov-network-config-daemon
+      - kube-multus-ds
+      - cni-plugins-ds
+      - rdma-shared-dp-ds
+    result: skip

--- a/other/add-daemonset-tolerations/.kyverno-test/patched-sriov-metrics-exporter.yaml
+++ b/other/add-daemonset-tolerations/.kyverno-test/patched-sriov-metrics-exporter.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: sriov-network-metrics-exporter
+  name: sriov-network-metrics-exporter
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: sriov-network-metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: sriov-network-metrics-exporter
+    spec:
+      containers:
+      - image: metrics-exporter:latest
+        name: metrics-exporter
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/worker: ""
+      serviceAccountName: metrics-exporter-sa
+      tolerations:
+      - operator: Exists
+
+---
+

--- a/other/add-daemonset-tolerations/.kyverno-test/patched-vgpu-device-manager.yaml
+++ b/other/add-daemonset-tolerations/.kyverno-test/patched-vgpu-device-manager.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    openshift.io/scc: nvidia-vgpu-device-manager
+  labels:
+    app: nvidia-vgpu-device-manager
+  name: nvidia-vgpu-device-manager
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-vgpu-device-manager
+  template:
+    metadata:
+      labels:
+        app: nvidia-vgpu-device-manager
+    spec:
+      containers:
+      - env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CONFIG_FILE
+          value: /vgpu-config/config.yaml
+        image: registry.k8s.io/pause:3.10
+        imagePullPolicy: IfNotPresent
+        name: nvidia-vgpu-device-manager
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /vgpu-config
+          name: vgpu-config
+        - mountPath: /sys
+          name: host-sys
+        - mountPath: /host
+          mountPropagation: HostToContainer
+          name: host-root
+        - mountPath: /driver-root
+          mountPropagation: HostToContainer
+          name: driver-install-dir
+      initContainers:
+      - args:
+        - until [ -f /run/nvidia/validations/vgpu-manager-ready ]; do echo waiting
+          for NVIDIA vGPU Manager to be setup; sleep 5; done
+        command:
+        - sh
+        - -c
+        image: registry.k8s.io/pause:3.10
+        name: vgpu-manager-validation
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /run/nvidia/validations
+          mountPropagation: Bidirectional
+          name: run-nvidia-validations
+      nodeSelector:
+        nvidia.com/gpu.deploy.vgpu-device-manager: "true"
+      serviceAccountName: nvidia-vgpu-device-manager
+      tolerations:
+      - operator: Exists
+      volumes:
+      - configMap:
+          name: default
+        name: vgpu-config
+      - hostPath:
+          path: /sys
+          type: Directory
+        name: host-sys
+      - hostPath:
+          path: /
+        name: host-root
+      - hostPath:
+          path: /run/nvidia/driver
+          type: DirectoryOrCreate
+        name: driver-install-dir
+      - hostPath:
+          path: /run/nvidia/validations
+          type: DirectoryOrCreate
+        name: run-nvidia-validations
+
+---
+

--- a/other/add-daemonset-tolerations/.kyverno-test/resources.yaml
+++ b/other/add-daemonset-tolerations/.kyverno-test/resources.yaml
@@ -1,0 +1,497 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: nvidia-vgpu-device-manager
+  namespace: default
+  name: nvidia-vgpu-device-manager
+  annotations:
+    openshift.io/scc: nvidia-vgpu-device-manager
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-vgpu-device-manager
+  template:
+    metadata:
+      labels:
+        app: nvidia-vgpu-device-manager
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.deploy.vgpu-device-manager: "true"
+      serviceAccountName: nvidia-vgpu-device-manager
+      initContainers:
+        - name: vgpu-manager-validation
+          image: "registry.k8s.io/pause:3.10"
+          command: ['sh', '-c']
+          # TODO: Account for pre-installed vGPU Manager. Currently validator
+          # creates a different status file when driver is pre-installed.
+          args: ["until [ -f /run/nvidia/validations/vgpu-manager-ready ]; do echo waiting for NVIDIA vGPU Manager to be setup; sleep 5; done"]
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: run-nvidia-validations
+              mountPath: /run/nvidia/validations
+              mountPropagation: Bidirectional
+      containers:
+      - name: nvidia-vgpu-device-manager
+        image: "registry.k8s.io/pause:3.10"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CONFIG_FILE
+          value: "/vgpu-config/config.yaml"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /vgpu-config
+          name: vgpu-config
+        - mountPath: /sys
+          name: host-sys
+        - mountPath: /host
+          name: host-root
+          mountPropagation: HostToContainer
+        - name: driver-install-dir
+          mountPath: /driver-root
+          mountPropagation: HostToContainer
+      volumes:
+      - name: vgpu-config
+        configMap:
+          name: default
+      - name: host-sys
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: host-root
+        hostPath:
+          path: "/"
+      - name: driver-install-dir
+        hostPath:
+          path: "/run/nvidia/driver"
+          type: DirectoryOrCreate
+      - name: run-nvidia-validations
+        hostPath:
+          path: /run/nvidia/validations
+          type: DirectoryOrCreate
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: nvidia-device-plugin-daemonset
+  name: nvidia-device-plugin-daemonset
+  namespace: default
+  annotations:
+    openshift.io/scc: hostmount-anyuid
+spec:
+  selector:
+    matchLabels:
+      app: nvidia-device-plugin-daemonset
+  template:
+    metadata:
+      labels:
+        app: nvidia-device-plugin-daemonset
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.deploy.device-plugin: "true"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      priorityClassName: system-node-critical
+      serviceAccountName: nvidia-device-plugin
+      initContainers:
+      - image: "registry.k8s.io/pause:3.10"
+        name: toolkit-validation
+        command: ['sh', '-c']
+        args: ["until [ -f /run/nvidia/validations/toolkit-ready ]; do echo waiting for nvidia container stack to be setup; sleep 5; done"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: run-nvidia-validations
+            mountPath: /run/nvidia/validations
+            mountPropagation: HostToContainer
+      - image: "registry.k8s.io/pause:3.10"
+        name: config-manager-init
+        command: ["config-manager"]
+        env:
+        - name: ONESHOT
+          value: "true"
+        - name: KUBECONFIG
+          value: ""
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: "spec.nodeName"
+        - name: NODE_LABEL
+          value: "nvidia.com/device-plugin.config"
+        - name: CONFIG_FILE_SRCDIR
+          value: "/available-configs"
+        - name: CONFIG_FILE_DST
+          value: "/config/config.yaml"
+        - name: DEFAULT_CONFIG
+          value: ""
+        - name: SEND_SIGNAL
+          value: "false"
+        - name: SIGNAL
+          value: ""
+        - name: PROCESS_TO_SIGNAL
+          value: ""
+      containers:
+      - image: "registry.k8s.io/pause:3.10"
+        name: nvidia-device-plugin
+        command: ["/bin/sh", "-c"]
+        args:
+          - /bin/entrypoint.sh
+        securityContext:
+          privileged: true
+        env:
+          - name: PASS_DEVICE_SPECS
+            value: "true"
+          - name: FAIL_ON_INIT_ERROR
+            value: "true"
+          - name: DEVICE_LIST_STRATEGY
+            value: envvar
+          - name: DEVICE_ID_STRATEGY
+            value: uuid
+          - name: NVIDIA_VISIBLE_DEVICES
+            value: all
+          - name: NVIDIA_DRIVER_CAPABILITIES
+            value: all
+          - name: MPS_ROOT
+            value: /run/nvidia/mps
+        volumeMounts:
+          - name: nvidia-device-plugin-entrypoint
+            readOnly: true
+            mountPath: /bin/entrypoint.sh
+            subPath: entrypoint.sh
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+          - name: run-nvidia-validations
+            mountPath: /run/nvidia/validations
+          - name: driver-install-dir
+            mountPath: /driver-root
+            mountPropagation: HostToContainer
+          - name: host-root
+            mountPath: /host
+            readOnly: true
+            mountPropagation: HostToContainer
+          - name: cdi-root
+            mountPath: /var/run/cdi
+          # The MPS /dev/shm is needed to allow for MPS daemon health-checking.
+          - name: mps-shm
+            mountPath: /dev/shm
+          - name: mps-root
+            mountPath: /mps
+      - image: "registry.k8s.io/pause:3.10"
+        name: config-manager
+        command: ["config-manager"]
+        securityContext:
+          privileged: true
+        env:
+        - name: ONESHOT
+          value: "false"
+        - name: KUBECONFIG
+          value: ""
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: "spec.nodeName"
+        - name: NODE_LABEL
+          value: "nvidia.com/device-plugin.config"
+        - name: CONFIG_FILE_SRCDIR
+          value: "/available-configs"
+        - name: CONFIG_FILE_DST
+          value: "/config/config.yaml"
+        - name: DEFAULT_CONFIG
+          value: ""
+        - name: SEND_SIGNAL
+          value: "true"
+        - name: SIGNAL
+          value: "1" # SIGHUP
+        - name: PROCESS_TO_SIGNAL
+          value: "nvidia-device-plugin"
+      volumes:
+        - name: nvidia-device-plugin-entrypoint
+          configMap:
+            name: nvidia-device-plugin-entrypoint
+            defaultMode: 448
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: run-nvidia-validations
+          hostPath:
+            path: "/run/nvidia/validations"
+            type: DirectoryOrCreate
+        - name: driver-install-dir
+          hostPath:
+            path: "/run/nvidia/driver"
+            type: DirectoryOrCreate
+        - name: host-root
+          hostPath:
+            path: /
+        - name: cdi-root
+          hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate
+        - name: mps-root
+          hostPath:
+            path: /run/nvidia/mps
+            type: DirectoryOrCreate
+        - name: mps-shm
+          hostPath:
+            path: /run/nvidia/mps/shm
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: sriov-network-metrics-exporter
+  name: sriov-network-metrics-exporter
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: sriov-network-metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: sriov-network-metrics-exporter
+    spec:
+      hostNetwork: true
+      serviceAccountName: metrics-exporter-sa
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/worker: ""
+      containers:
+      - name: metrics-exporter
+        image: metrics-exporter:latest
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 100m
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sriov-network-config-daemon
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: sriov-network-config-daemon
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 33%
+  template:
+    metadata:
+      labels:
+        app: sriov-network-config-daemon
+    spec:
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/worker: ""
+      tolerations:
+      - operator: Exists
+      serviceAccountName: sriov-network-config-daemon
+      priorityClassName: "system-node-critical"
+      containers:
+      - name: sriov-network-config-daemon
+        image: sriov-network-config-daemon:latest
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-multus-ds
+  namespace: kube-system
+  labels:
+    tier: node
+    app: multus
+    name: multus
+spec:
+  selector:
+    matchLabels:
+      name: multus
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: multus
+        name: multus
+    spec:
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+      serviceAccountName: multus
+      containers:
+      - name: kube-multus
+        image: registry.k8s.io/pause:3.10
+        command:
+        - /thin_entrypoint
+        args:
+        - --multus-conf-file=auto
+        - --multus-autoconfig-dir=/host/etc/cni/net.d
+        - --cni-conf-dir=/host/etc/cni/net.d
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 50Mi
+        securityContext:
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: cni
+          mountPath: /host/etc/cni/net.d
+        - name: cnibin
+          mountPath: /host/opt/cni/bin
+        - name: multus-cfg
+          mountPath: /tmp/multus-conf
+      initContainers:
+      - name: install-multus-binary
+        image: registry.k8s.io/pause:3.10
+        command:
+        - /install_multus
+        args:
+        - --type
+        - thin
+        resources:
+          requests:
+            cpu: 10m
+            memory: 15Mi
+        securityContext:
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: cnibin
+          mountPath: /host/opt/cni/bin
+          mountPropagation: Bidirectional
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cni
+        hostPath:
+          path: /etc/cni/net.d
+      - name: cnibin
+        hostPath:
+          path: /opt/cni/bin
+      - name: multus-cfg
+        configMap:
+          name: multus-cni-config
+          items:
+          - key: cni-conf.json
+            path: 70-multus.conf
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cni-plugins-ds
+  namespace: default
+  labels:
+    tier: node
+    app: cni-plugins
+spec:
+  selector:
+    matchLabels:
+      name: cni-plugins
+  template:
+    metadata:
+      labels:
+        name: cni-plugins
+        tier: node
+        app: cni-plugins
+    spec:
+      hostNetwork: true
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: cni-plugins
+          image: "registry.k8s.io/pause:3.10"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "50Mi"
+            limits:
+              cpu: "100m"
+              memory: "50Mi"
+          volumeMounts:
+            - name: cnibin
+              mountPath: /host/opt/cni/bin
+      volumes:
+        - name: cnibin
+          hostPath:
+            path: /opt/cni/bin
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: rdma-shared-dp-ds
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: rdma-shared-dp
+  template:
+    metadata:
+      labels:
+        app: rdma-shared-dp
+    spec:
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+      - image: "registry.k8s.io/pause:3.10"
+        name: rdma-shared-dp
+        command: [ "/bin/k8s-rdma-shared-dp" ]
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+            readOnly: false
+          - name: plugins-registry
+            mountPath: /var/lib/kubelet/plugins_registry
+            readOnly: false
+          - name: devs
+            mountPath: /dev/
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+        - name: devs
+          hostPath:
+            path: /dev/
+      nodeSelector:
+        feature.node.kubernetes.io/pci-15b3.present: "true"
+        network.nvidia.com/operator.mofed.wait: "false"

--- a/other/add-daemonset-tolerations/add-daemonset-tolerations.yaml
+++ b/other/add-daemonset-tolerations/add-daemonset-tolerations.yaml
@@ -1,0 +1,43 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-daemonset-tolerations
+  annotations:
+    policies.kyverno.io/title: Add DaemonSet Tolerations
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: DaemonSet
+    kyverno.io/kyverno-version: 1.11.0
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.26"
+    policies.kyverno.io/description: >-
+      DaemonSet Pods are meant to run on every eligible node, but if a DaemonSet's
+      Pod template sets no tolerations at all, it silently fails to schedule on any
+      tainted node — with no error pointing at the missing toleration as the cause.
+      This has been found as a real, recurring gap across multiple widely-used
+      operators (each one hardcodes tolerations on most of their DaemonSets but
+      missed it on one), so this policy adds a broad `operator: Exists` toleration
+      as a safety net to any DaemonSet whose Pod template declares no tolerations
+      at all. It only fills a true gap — a DaemonSet with any tolerations already
+      set, even a narrow one, is left untouched.
+spec:
+  background: false
+  rules:
+    - name: add-daemonset-tolerations
+      match:
+        any:
+          - resources:
+              kinds:
+                - DaemonSet
+      preconditions:
+        any:
+          - key: "{{ length(request.object.spec.template.spec.tolerations || `[]`) }}"
+            operator: Equals
+            value: 0
+      mutate:
+        patchStrategicMerge:
+          spec:
+            template:
+              spec:
+                tolerations:
+                  - operator: Exists

--- a/other/add-daemonset-tolerations/artifacthub-pkg.yml
+++ b/other/add-daemonset-tolerations/artifacthub-pkg.yml
@@ -1,0 +1,22 @@
+name: add-daemonset-tolerations
+version: 1.0.0
+displayName: Add DaemonSet Tolerations
+description: >-
+  DaemonSet Pods are meant to run on every eligible node, but if a DaemonSet's Pod template sets no tolerations at all, it silently fails to schedule on any tainted node — with no error pointing at the missing toleration as the cause. This policy adds a broad `operator: Exists` toleration as a safety net to any DaemonSet whose Pod template declares no tolerations at all. It only fills a true gap — a DaemonSet with any tolerations already set, even a narrow one, is left untouched.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/add-daemonset-tolerations/add-daemonset-tolerations.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+readme: |
+  DaemonSet Pods are meant to run on every eligible node, but if a DaemonSet's Pod template sets no tolerations at all, it silently fails to schedule on any tainted node — with no error pointing at the missing toleration as the cause.
+
+  This gap has been found as a real, recurring issue across multiple widely-used Kubernetes operators — each one hardcodes tolerations on most of its DaemonSets but missed it on one, causing that specific DaemonSet to silently fail to schedule on exactly the tainted nodes it needed to run on. This policy adds a broad `operator: Exists` toleration as a safety net to any DaemonSet with no tolerations at all, without touching DaemonSets that already have any tolerations configured (even a narrow one).
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.26"
+  kyverno/subject: "DaemonSet"


### PR DESCRIPTION
## Related Issue(s)

Not a `kyverno/policies` issue — motivated by a pattern found while auditing several unrelated
Kubernetes operators for DaemonSet configuration gaps:

- [NVIDIA/gpu-operator#2717](https://github.com/NVIDIA/gpu-operator/issues/2717)
- [k8snetworkplumbingwg/sriov-network-operator#1132](https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/1132)

Both are the same shape: a DaemonSet manifest with zero `tolerations` set, silently failing to
schedule on tainted nodes, while every sibling DaemonSet in the same operator hardcodes a
toleration. Filed upstream against each operator individually, but the pattern recurring across
unrelated projects suggested a cluster-level safety net was worth contributing here too.

## Description

Adds `other/add-daemonset-tolerations`: a `mutate` policy that adds a broad `operator: Exists`
toleration to any `DaemonSet` whose Pod template has **no tolerations at all**. Gated by a
JMESPath precondition checking that `length()` of the existing tolerations list (defaulting to an
empty list if the field is absent) equals `0`, so it only fills a true gap — any DaemonSet with
even one toleration already configured is left untouched.

Checked the existing library first: `other/add-tolerations` exists but is `Pod`-scoped with one
hardcoded, organization-specific example toleration (`org.com/role=service:NoSchedule`) — a
customize-me template, not a DaemonSet-aware safety net for the "zero tolerations" case. No
existing policy covers this specific gap.

**Validation**, using the real (sanitized) manifests from the two linked issues plus five
already-correct sibling DaemonSets as negative controls:

```
$ kyverno test other/add-daemonset-tolerations/.kyverno-test
Test Summary: 7 tests passed and 0 tests failed

$ chainsaw test other/add-daemonset-tolerations/.chainsaw-test
--- PASS: chainsaw/add-daemonset-tolerations (5.79s)
```

The `chainsaw` e2e test applies the policy and a real fixture through an actual Kyverno
installation on a `kind` cluster and asserts the live-mutated result, not just the static CLI
evaluation.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
