### PR TITLE
feat: add DRA adminAccess mitigation policies

### DIFF
--- a/other/report-dra-adminaccess-namespaces/.kyverno-test/kyverno-test.yaml
+++ b/other/report-dra-adminaccess-namespaces/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,15 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: report-dra-adminaccess-namespaces
+policies:
+- ../report-dra-adminaccess-namespaces.yaml
+resources:
+- resources.yaml
+results:
+- policy: report-dra-adminaccess-namespaces
+  rule: flag-adminaccess-namespace
+  kind: Namespace
+  resources:
+  - dra-labeled-ns
+  result: fail

--- a/other/report-dra-adminaccess-namespaces/.kyverno-test/resources.yaml
+++ b/other/report-dra-adminaccess-namespaces/.kyverno-test/resources.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dra-labeled-ns
+  labels:
+    resource.kubernetes.io/admin-access: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dra-unlabeled-ns

--- a/other/report-dra-adminaccess-namespaces/artifacthub-pkg.yml
+++ b/other/report-dra-adminaccess-namespaces/artifacthub-pkg.yml
@@ -1,0 +1,23 @@
+name: report-dra-adminaccess-namespaces
+version: 1.0.0
+displayName: Report Namespaces With DRA AdminAccess Enabled
+description: >-
+  RBAC changes and the `resource.kubernetes.io/admin-access` namespace label drift independently — an admin who revokes a user's namespace-edit permission has no built-in signal that the label itself was left behind, still granting every claim-creator in that namespace DRA adminAccess. This policy runs in background mode and continuously reports every namespace currently carrying the label, so it shows up as a standing entry in routine PolicyReport-based access reviews.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/report-dra-adminaccess-namespaces/report-dra-adminaccess-namespaces.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+  - Dynamic Resource Allocation
+readme: |
+  RBAC changes and the `resource.kubernetes.io/admin-access` namespace label drift independently — an admin who revokes a user's namespace-edit permission has no built-in signal that the label itself was left behind, still granting every claim-creator in that namespace DRA adminAccess (see [kubernetes/kubernetes#141293](https://github.com/kubernetes/kubernetes/issues/141293)).
+
+  This policy runs in background mode and continuously reports every namespace currently carrying the label, so it shows up as a standing entry in routine PolicyReport-based access reviews — the same pattern commonly used to track Pod Security Admission privileged-profile namespaces. It intentionally always reports (never passes) for any matching namespace; the point is visibility, not blocking.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.36"
+  kyverno/subject: "Namespace"

--- a/other/report-dra-adminaccess-namespaces/report-dra-adminaccess-namespaces.yaml
+++ b/other/report-dra-adminaccess-namespaces/report-dra-adminaccess-namespaces.yaml
@@ -1,0 +1,43 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: report-dra-adminaccess-namespaces
+  annotations:
+    policies.kyverno.io/title: Report Namespaces With DRA AdminAccess Enabled
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.18.2
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.36"
+    policies.kyverno.io/subject: Namespace
+    policies.kyverno.io/description: >-
+      RBAC changes and the resource.kubernetes.io/admin-access namespace label
+      drift independently -- an admin who revokes a user's namespace-edit
+      permission has no built-in signal that the label itself was left behind,
+      still granting every claim-creator in that namespace DRA adminAccess (see
+      kubernetes/kubernetes#141293). This policy runs in background mode and
+      continuously reports every namespace currently carrying the label, so it
+      shows up as a standing entry in routine PolicyReport-based access reviews --
+      the same pattern commonly used to track Pod Security Admission
+      privileged-profile namespaces. It intentionally always reports (never
+      passes) for any matching namespace; the point is visibility, not blocking.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+  - name: flag-adminaccess-namespace
+    match:
+      any:
+      - resources:
+          kinds:
+            - Namespace
+          selector:
+            matchLabels:
+              resource.kubernetes.io/admin-access: "true"
+    validate:
+      message: >-
+        This namespace has DRA adminAccess enabled (resource.kubernetes.io/admin-access=true).
+        Every principal authorized to create ResourceClaim/ResourceClaimTemplate objects here
+        can bypass ordinary device access-mode restrictions, cluster-wide in effect. Review
+        periodically as part of routine access reviews -- see kubernetes/kubernetes#141293.
+      deny: {}

--- a/other/restrict-dra-adminaccess-claims/artifacthub-pkg.yml
+++ b/other/restrict-dra-adminaccess-claims/artifacthub-pkg.yml
@@ -1,0 +1,25 @@
+name: restrict-dra-adminaccess-claims
+version: 1.0.0
+displayName: Restrict DRA AdminAccess Claims via SubjectAccessReview
+description: >-
+  Kubernetes' DRA adminAccess authorization only checks whether the claim's namespace carries the `resource.kubernetes.io/admin-access` label — it never checks the identity of the principal creating the claim, so every authorized claim-creator in a labeled namespace gets this capability, not just a specifically-trusted one. This policy closes that gap by performing a SubjectAccessReview for a dedicated, synthetic permission (`resourceclaims/adminaccess`, verb create) before allowing any ResourceClaim or ResourceClaimTemplate that requests `adminAccess: true` — re-implementing, via policy, the same kind of RBAC-backed check Kubernetes already uses natively for the resourceclaims/binding and resourceclaims/driver subresources.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/restrict-dra-adminaccess-claims/restrict-dra-adminaccess-claims.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+  - Dynamic Resource Allocation
+readme: |
+  Kubernetes' DRA adminAccess authorization (`AuthorizedForAdmin` in `pkg/registry/resource/utils.go`) only checks whether the claim's namespace carries the `resource.kubernetes.io/admin-access` label — it never checks the identity of the principal creating the claim, so *every* authorized claim-creator in a labeled namespace gets this capability, not just a specifically-trusted one. See [kubernetes/kubernetes#141293](https://github.com/kubernetes/kubernetes/issues/141293), including the live-verified finding that a completely uninvolved bystander in the same namespace inherits it automatically.
+
+  This policy closes that gap by performing a SubjectAccessReview for a dedicated, synthetic permission (`resourceclaims/adminaccess` / `resourceclaimtemplates/adminaccess`, verb `create`) before allowing any ResourceClaim or ResourceClaimTemplate that requests `adminAccess: true` — re-implementing, via policy, the same kind of RBAC-backed check Kubernetes already uses natively for the `resourceclaims/binding` and `resourceclaims/driver` subresources.
+
+  Grant `resourceclaims/adminaccess` to specific trusted ServiceAccounts (e.g. a monitoring/management workload) via a dedicated ClusterRole and RoleBinding — see `grant-dra-adminaccess-role.yaml` in this folder for an example.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.36"
+  kyverno/subject: "ResourceClaim, ResourceClaimTemplate"

--- a/other/restrict-dra-adminaccess-claims/grant-dra-adminaccess-role.yaml
+++ b/other/restrict-dra-adminaccess-claims/grant-dra-adminaccess-role.yaml
@@ -1,0 +1,28 @@
+# Example: grant the synthetic resourceclaims/adminaccess permission this policy
+# checks for to a specific, trusted monitoring/management ServiceAccount. This
+# subresource does not exist in the real Kubernetes API -- it is a convention this
+# policy's SubjectAccessReview checks for, purely as an RBAC-expressible permission
+# string, mirroring how kubernetes/kubernetes already gates resourceclaims/binding
+# and resourceclaims/driver.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dra-adminaccess-grantee
+rules:
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/adminaccess", "resourceclaimtemplates/adminaccess"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gpu-monitoring-adminaccess
+  namespace: gpu-monitoring   # the namespace your trusted monitoring/management workload runs in
+subjects:
+- kind: ServiceAccount
+  name: gpu-monitoring        # replace with your actual trusted ServiceAccount
+  namespace: gpu-monitoring
+roleRef:
+  kind: ClusterRole
+  name: dra-adminaccess-grantee
+  apiGroup: rbac.authorization.k8s.io

--- a/other/restrict-dra-adminaccess-claims/restrict-dra-adminaccess-claims.yaml
+++ b/other/restrict-dra-adminaccess-claims/restrict-dra-adminaccess-claims.yaml
@@ -1,0 +1,120 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-dra-adminaccess-claims
+  annotations:
+    policies.kyverno.io/title: Restrict DRA AdminAccess Claims via SubjectAccessReview
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: high
+    kyverno.io/kyverno-version: 1.18.2
+    policies.kyverno.io/minversion: 1.10.0
+    kyverno.io/kubernetes-version: "1.36"
+    policies.kyverno.io/subject: ResourceClaim, ResourceClaimTemplate
+    policies.kyverno.io/description: >-
+      Kubernetes' DRA adminAccess authorization (AuthorizedForAdmin in
+      pkg/registry/resource/utils.go) only checks whether the claim's namespace
+      carries the resource.kubernetes.io/admin-access label -- it never checks the
+      identity of the principal creating the claim, so *every* authorized
+      claim-creator in a labeled namespace gets this capability, not just a
+      specifically-trusted one (see kubernetes/kubernetes#141293, including the
+      live-verified finding that a completely uninvolved bystander in the same
+      namespace inherits it automatically). This policy closes that gap by
+      performing a SubjectAccessReview for a dedicated, synthetic permission
+      (resourceclaims/adminaccess, verb create) before allowing any ResourceClaim
+      or ResourceClaimTemplate that requests adminAccess: true -- re-implementing,
+      via policy, the same kind of RBAC-backed check Kubernetes already uses
+      natively for the resourceclaims/binding and resourceclaims/driver
+      subresources. Grant resourceclaims/adminaccess to specific trusted
+      ServiceAccounts (e.g. a monitoring/management workload) via a dedicated
+      ClusterRole and RoleBinding -- see grant-dra-adminaccess-role.yaml in this
+      folder for an example.
+spec:
+  validationFailureAction: Audit
+  background: false
+  rules:
+  - name: check-adminaccess-sar-resourceclaim
+    match:
+      any:
+      - resources:
+          kinds:
+            - ResourceClaim
+    preconditions:
+      all:
+      - key: "{{ request.object.spec.devices.requests[?exactly.adminAccess] || `[]` | length(@) }}"
+        operator: GreaterThanOrEquals
+        value: 1
+    context:
+      - name: sar
+        apiCall:
+          urlPath: /apis/authorization.k8s.io/v1/subjectaccessreviews
+          method: POST
+          data:
+          - key: kind
+            value: SubjectAccessReview
+          - key: apiVersion
+            value: authorization.k8s.io/v1
+          - key: spec
+            value:
+              resourceAttributes:
+                group: resource.k8s.io
+                resource: resourceclaims
+                subresource: adminaccess
+                namespace: "{{ request.namespace }}"
+                verb: create
+              user: "{{ request.userInfo.username }}"
+              groups: "{{ request.userInfo.groups }}"
+    validate:
+      message: >-
+        Requesting adminAccess on a DRA ResourceClaim requires the
+        resourceclaims/adminaccess:create permission -- ask a cluster admin to
+        grant it if this is a legitimate monitoring/management workload. See
+        kubernetes/kubernetes#141293.
+      deny:
+        conditions:
+          any:
+          - key: "{{ sar.status.allowed }}"
+            operator: NotEquals
+            value: true
+  - name: check-adminaccess-sar-resourceclaimtemplate
+    match:
+      any:
+      - resources:
+          kinds:
+            - ResourceClaimTemplate
+    preconditions:
+      all:
+      - key: "{{ request.object.spec.spec.devices.requests[?exactly.adminAccess] || `[]` | length(@) }}"
+        operator: GreaterThanOrEquals
+        value: 1
+    context:
+      - name: sar
+        apiCall:
+          urlPath: /apis/authorization.k8s.io/v1/subjectaccessreviews
+          method: POST
+          data:
+          - key: kind
+            value: SubjectAccessReview
+          - key: apiVersion
+            value: authorization.k8s.io/v1
+          - key: spec
+            value:
+              resourceAttributes:
+                group: resource.k8s.io
+                resource: resourceclaimtemplates
+                subresource: adminaccess
+                namespace: "{{ request.namespace }}"
+                verb: create
+              user: "{{ request.userInfo.username }}"
+              groups: "{{ request.userInfo.groups }}"
+    validate:
+      message: >-
+        Requesting adminAccess on a DRA ResourceClaimTemplate requires the
+        resourceclaimtemplates/adminaccess:create permission -- ask a cluster
+        admin to grant it if this is a legitimate monitoring/management workload.
+        See kubernetes/kubernetes#141293.
+      deny:
+        conditions:
+          any:
+          - key: "{{ sar.status.allowed }}"
+            operator: NotEquals
+            value: true

--- a/other/restrict-dra-adminaccess-label/.kyverno-test/kyverno-test.yaml
+++ b/other/restrict-dra-adminaccess-label/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,16 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-dra-adminaccess-label
+userinfo: ./userinfo.yaml
+policies:
+- ../restrict-dra-adminaccess-label.yaml
+resources:
+- resources.yaml
+results:
+- policy: restrict-dra-adminaccess-label
+  rule: check-admin-access-label
+  kind: Namespace
+  resources:
+  - dra-self-escalated-ns
+  result: fail

--- a/other/restrict-dra-adminaccess-label/.kyverno-test/resources.yaml
+++ b/other/restrict-dra-adminaccess-label/.kyverno-test/resources.yaml
@@ -1,0 +1,8 @@
+# Real fixture, adapted from the live self-escalation repro behind
+# kubernetes/kubernetes#141293 (C:\YSB\bugs\DRA\2-adminaccess-namespace-label\repro\manifests\1-namespaces.yaml)
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dra-self-escalated-ns
+  labels:
+    resource.kubernetes.io/admin-access: "true"

--- a/other/restrict-dra-adminaccess-label/.kyverno-test/userinfo.yaml
+++ b/other/restrict-dra-adminaccess-label/.kyverno-test/userinfo.yaml
@@ -1,0 +1,4 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: UserInfo
+userInfo:
+  username: system:serviceaccount:admin-unlabeled:limited-user

--- a/other/restrict-dra-adminaccess-label/artifacthub-pkg.yml
+++ b/other/restrict-dra-adminaccess-label/artifacthub-pkg.yml
@@ -1,0 +1,25 @@
+name: restrict-dra-adminaccess-label
+version: 1.0.0
+displayName: Restrict DRA AdminAccess Namespace Label
+description: >-
+  Kubernetes' Dynamic Resource Allocation (DRA) grants a device access-mode bypass ("adminAccess") to any ResourceClaim or ResourceClaimTemplate created in a namespace labeled `resource.kubernetes.io/admin-access=true`. That authorization check only inspects the namespace label — it never checks the RBAC permissions of whoever sets the label, so an ordinary, common self-service permission (edit rights scoped to just one's own Namespace object) is sufficient for a non-admin user to grant this capability to themselves and to every other claim-creator who shares that namespace. This policy ensures that only trusted principals (cluster-admin by default) may add or change this label on a Namespace.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/restrict-dra-adminaccess-label/restrict-dra-adminaccess-label.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+  - Dynamic Resource Allocation
+readme: |
+  Kubernetes' Dynamic Resource Allocation (DRA) grants a device access-mode bypass ("adminAccess") to any ResourceClaim or ResourceClaimTemplate created in a namespace labeled `resource.kubernetes.io/admin-access=true`.
+
+  That authorization check (`AuthorizedForAdmin` in `pkg/registry/resource/utils.go`) only inspects the namespace label — it never checks the RBAC permissions of whoever sets the label. An ordinary, common self-service permission (edit rights scoped to just one's own Namespace object) is sufficient for a non-admin user to grant this capability to themselves, and to every other claim-creator who shares that namespace — see [kubernetes/kubernetes#141293](https://github.com/kubernetes/kubernetes/issues/141293) for the live-verified finding this policy mitigates.
+
+  This policy ensures that only trusted principals (cluster-admin by default; adjust the excluded clusterRoles/subjects to match your own environment) may add or change this label on a Namespace.
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.36"
+  kyverno/subject: "Namespace"

--- a/other/restrict-dra-adminaccess-label/restrict-dra-adminaccess-label.yaml
+++ b/other/restrict-dra-adminaccess-label/restrict-dra-adminaccess-label.yaml
@@ -1,0 +1,50 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-dra-adminaccess-label
+  annotations:
+    policies.kyverno.io/title: Restrict DRA AdminAccess Namespace Label
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: high
+    kyverno.io/kyverno-version: 1.18.2
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.36"
+    policies.kyverno.io/subject: Namespace
+    policies.kyverno.io/description: >-
+      Kubernetes' Dynamic Resource Allocation (DRA) grants a device access-mode
+      bypass ("adminAccess") to any ResourceClaim or ResourceClaimTemplate created
+      in a namespace labeled resource.kubernetes.io/admin-access=true. That
+      authorization check (AuthorizedForAdmin in pkg/registry/resource/utils.go)
+      only inspects the namespace label -- it never checks the RBAC permissions of
+      whoever sets the label. An ordinary, common self-service permission (edit
+      rights scoped to just one's own Namespace object) is sufficient for a
+      non-admin user to grant this capability to themselves, and to every other
+      claim-creator who shares that namespace -- see
+      kubernetes/kubernetes#141293 for the live-verified finding this policy
+      mitigates. This policy ensures that only trusted principals (cluster-admin by
+      default; adjust the excluded clusterRoles/subjects to match your own
+      environment) may add or change this label on a Namespace.
+spec:
+  validationFailureAction: Audit
+  background: false
+  rules:
+  - name: check-admin-access-label
+    match:
+      any:
+      - resources:
+          kinds:
+            - Namespace
+          selector:
+            matchLabels:
+              resource.kubernetes.io/admin-access: "true"
+    exclude:
+      any:
+      - clusterRoles:
+        - cluster-admin
+    validate:
+      message: >-
+        Only cluster-admins may label a Namespace
+        resource.kubernetes.io/admin-access=true. This label grants every DRA
+        claim-creator in the namespace an "adminAccess" device access-mode bypass,
+        cluster-wide in effect -- see kubernetes/kubernetes#141293.
+      deny: {}


### PR DESCRIPTION
## Related Issue(s)

Related to [kubernetes/kubernetes#141293](https://github.com/kubernetes/kubernetes/issues/141293) (closed
by the Kubernetes project as working-as-designed at the code level — RBAC intentionally gates verbs on
resource types, not field values) and
[kubernetes/website#56957](https://github.com/kubernetes/website/issues/56957) (a documentation
correction currently in review). This PR does not resolve either of those directly; it gives cluster
operators a way to get real protection today, independent of how/when those are resolved upstream.

## Description

Kubernetes' Dynamic Resource Allocation (DRA) has an `adminAccess` capability that lets a
`ResourceClaim`/`ResourceClaimTemplate` bypass ordinary device access-mode restrictions. It's gated
entirely by a single namespace label (`resource.kubernetes.io/admin-access: "true"`) with **no RBAC check
on who sets that label or who uses the capability once it's set**. Live-verified finding (full detail in
kubernetes/kubernetes#141293): a non-admin user holding only a narrow, common self-service permission
(edit rights scoped to their own Namespace object) can label their own namespace and immediately use
`adminAccess` — and *every other* claim-creator who happens to share that namespace inherits the same
capability automatically, including a completely uninvolved bystander with zero namespace access of any
kind.

Critically, this isn't confined to the escalating user's own resources. Devices (`ResourceSlice` objects)
are cluster-scoped, not namespaced — an `adminAccess` claim can bypass exclusivity on any device reachable
by its selector, including one a *different* namespace's claim currently holds. The blast radius is
cluster-wide, not limited to the labeled namespace's own workloads.

This PR adds three independent policies:

1. **`restrict-dra-adminaccess-label`** — only cluster-admins (configurable) may add or change the
   `resource.kubernetes.io/admin-access` label on a Namespace. Modeled directly on the existing
   `psa/deny-privileged-profile` policy (same `exclude.clusterRoles` pattern, applied to this label
   instead of the PSA one).
2. **`restrict-dra-adminaccess-claims`** — the more important of the two enforcement policies. Performs a
   live `SubjectAccessReview` against a dedicated, synthetic permission (`resourceclaims/adminaccess` /
   `resourceclaimtemplates/adminaccess`, verb `create`) before allowing any claim that requests
   `adminAccess: true`, independent of the namespace label entirely. This directly closes the "any
   bystander inherits it" gap — re-implementing, via policy, the same kind of RBAC-backed identity check
   Kubernetes already uses natively for the `resourceclaims/binding` and `resourceclaims/driver`
   subresources. See `grant-dra-adminaccess-role.yaml` in that folder for an example of granting this to a
   real trusted workload.
3. **`report-dra-adminaccess-namespaces`** — background-mode standing visibility report of every namespace
   currently carrying the label. Addresses a separate, longer-tail concern: RBAC grants and the namespace
   label drift independently, so an admin revoking a user's namespace-edit permission has no built-in
   signal that the label itself was left behind. Live-verified to catch pre-existing/drifted state (a
   namespace labeled before this policy even existed), not just new events.

All three were live-tested end to end on a real cluster (Kyverno v1.18.2 via Helm), not just statically —
including both `Audit` (shipped default) and `Enforce` modes for the first two, and the background-scan
drift-detection behavior for the third. Static `kyverno test` is included for the two policies where that's
meaningful (`restrict-dra-adminaccess-label`, `report-dra-adminaccess-namespaces`); `restrict-dra-adminaccess-claims`
has none, since its `SubjectAccessReview` context needs a live API server to resolve and can't be
meaningfully mocked offline — the same reason the existing `other/check-subjectaccessreview` example policy
in this repo also ships with no static test.

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
