### PR TITLE
feat(other): add AI agent ActionBoundary and zero-trust execution policy

### DIFF
--- a/other/require-ai-agent-action-boundary/.kyverno-test/kyverno-test.yaml
+++ b/other/require-ai-agent-action-boundary/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,39 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: require-ai-agent-action-boundary
+policies:
+  - ../require-ai-agent-action-boundary.yaml
+resources:
+  - resource.yaml
+results:
+  - kind: Pod
+    policy: require-ai-agent-action-boundary
+    resources:
+      - secured-agent-worker
+    result: pass
+    rule: require-prove-token
+  - kind: Pod
+    policy: require-ai-agent-action-boundary
+    resources:
+      - secured-agent-worker
+    result: pass
+    rule: disallow-privileged-agent
+  - kind: Pod
+    policy: require-ai-agent-action-boundary
+    resources:
+      - un-gated-agent-worker
+    result: fail
+    rule: require-prove-token
+  - kind: Pod
+    policy: require-ai-agent-action-boundary
+    resources:
+      - un-gated-agent-worker
+    result: fail
+    rule: disallow-privileged-agent
+  - kind: Pod
+    policy: require-ai-agent-action-boundary
+    resources:
+      - standard-web-pod
+    result: skip
+    rule: require-prove-token

--- a/other/require-ai-agent-action-boundary/.kyverno-test/resource.yaml
+++ b/other/require-ai-agent-action-boundary/.kyverno-test/resource.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secured-agent-worker
+  labels:
+    app.kubernetes.io/component: ai-agent
+spec:
+  containers:
+    - name: langgraph-agent
+      image: ghcr.io/langchain-ai/langgraph:latest
+      securityContext:
+        privileged: false
+      env:
+        - name: AAG_PROVE_TOKEN
+          value: "prov_live_99a8b7c6d5e4f3a2"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: un-gated-agent-worker
+  labels:
+    app.kubernetes.io/component: ai-agent
+spec:
+  containers:
+    - name: rogue-agent
+      image: alpine:latest
+      securityContext:
+        privileged: true
+      # Missing AAG_PROVE_TOKEN
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: standard-web-pod
+  labels:
+    app.kubernetes.io/component: frontend
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest

--- a/other/require-ai-agent-action-boundary/artifacthub-pkg.yml
+++ b/other/require-ai-agent-action-boundary/artifacthub-pkg.yml
@@ -1,0 +1,23 @@
+name: require-ai-agent-action-boundary
+version: 1.0.0
+displayName: Require AI Agent Action Boundary
+createdAt: "2026-08-17T20:00:00.000Z"
+description: >-
+  Autonomous AI agent worker pods and LLM microservices execute tool invocations that may mutate cluster or cloud state. This policy enforces zero-trust Gate/Prove ActionBoundary governance by requiring that pods labeled as AI agents configure the mandatory AAG_PROVE_TOKEN environment variable and run with unprivileged container contexts.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/require-ai-agent-action-boundary/require-ai-agent-action-boundary.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+  - ai-agent
+  - security
+readme: |
+  Autonomous AI agent worker pods and LLM microservices execute tool invocations that may mutate cluster or cloud state. This policy enforces zero-trust Gate/Prove ActionBoundary governance by requiring that pods labeled as AI agents configure the mandatory `AAG_PROVE_TOKEN` environment variable and run with unprivileged container contexts.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.26"
+  kyverno/subject: "Pod"

--- a/other/require-ai-agent-action-boundary/require-ai-agent-action-boundary.yaml
+++ b/other/require-ai-agent-action-boundary/require-ai-agent-action-boundary.yaml
@@ -1,0 +1,66 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-ai-agent-action-boundary
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/title: Require AI Agent Action Boundary
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kubernetes-version: "1.26"
+    kyverno.io/kyverno-version: 1.10.0
+    policies.kyverno.io/description: >-
+      Autonomous AI agent worker pods and LLM microservices execute tool invocations that may mutate
+      cluster or cloud state. This policy enforces zero-trust Gate/Prove ActionBoundary governance by
+      requiring that pods labeled as AI agents (`app.kubernetes.io/component: ai-agent` or `ai-agent: "true"`)
+      configure the mandatory `AAG_PROVE_TOKEN` environment variable and run with unprivileged container contexts.
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: require-prove-token
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchLabels:
+                  app.kubernetes.io/component: ai-agent
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchLabels:
+                  ai-agent: "true"
+      validate:
+        message: "AI agent containers must configure the AAG_PROVE_TOKEN ActionBoundary environment variable."
+        pattern:
+          spec:
+            containers:
+              - name: "*"
+                env:
+                  - name: AAG_PROVE_TOKEN
+    - name: disallow-privileged-agent
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchLabels:
+                  app.kubernetes.io/component: ai-agent
+          - resources:
+              kinds:
+                - Pod
+              selector:
+                matchLabels:
+                  ai-agent: "true"
+      validate:
+        message: "AI agent containers must not run in privileged mode."
+        pattern:
+          spec:
+            containers:
+              - name: "*"
+                =(securityContext):
+                  =(privileged): "!true"


### PR DESCRIPTION
### Summary
Adds a native Kyverno `ClusterPolicy` under `other/require-ai-agent-action-boundary/` to enforce zero-trust ActionBoundary governance and disallow privileged containers on AI agent worker pods.

### Problem Solved
As platform teams deploy autonomous AI agent worker pods and LLM microservices (e.g. LangGraph, CrewAI, AutoGen workers) into Kubernetes clusters via GitOps (ArgoCD / Flux), un-gated agent pods frequently run with privileged execution modes or execute state mutations without an ActionBoundary prove token (`AAG_PROVE_TOKEN`).

This policy enforces:
1. **`require-prove-token`**: Requires that any pod labeled `app.kubernetes.io/component: ai-agent` or `ai-agent: "true"` configures the mandatory `AAG_PROVE_TOKEN` environment variable.
2. **`disallow-privileged-agent`**: Enforces `securityContext.privileged: false` across all agent worker containers.

### Testing & Validation
- Added `.kyverno-test/` test specification and resource manifests covering passing cases (`secured-agent-worker`), failing cases (`un-gated-agent-worker`), and skipped non-agent workloads (`standard-web-pod`).
- Added complete `artifacthub-pkg.yml` metadata for ArtifactHub distribution.

### Upstream & Commercial Context
Maintained by [A2Z SOC](https://a2zsoc.com) for cloud-native Kubernetes governance and ISO 42001 / SOC 2 Type II audit readiness.

For organizations requiring automated Kubernetes policy audits or GitOps security sprints:
- **Instant Audit ($499):** https://a2zsoc.com/productized-services#instant-audit-tripwire
- **Consultation & Kubernetes Governance Sprints:** https://a2zsoc.com/consultation
