### PR TITLE
feat: add restrict-devicetaintrule-empty-selector policy

### DIFF
--- a/other/restrict-devicetaintrule-empty-selector/.kyverno-test/kyverno-test.yaml
+++ b/other/restrict-devicetaintrule-empty-selector/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,27 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: restrict-devicetaintrule-empty-selector
+policies:
+- ../restrict-devicetaintrule-empty-selector.yaml
+resources:
+- resources.yaml
+results:
+- policy: restrict-devicetaintrule-empty-selector
+  rule: require-devicetaintrule-selector-field
+  kind: DeviceTaintRule
+  resources:
+  - no-selector-field
+  result: skip
+- policy: restrict-devicetaintrule-empty-selector
+  rule: require-devicetaintrule-selector-field
+  kind: DeviceTaintRule
+  resources:
+  - empty-selector-object
+  result: fail
+- policy: restrict-devicetaintrule-empty-selector
+  rule: require-devicetaintrule-selector-field
+  kind: DeviceTaintRule
+  resources:
+  - good-scoped-selector
+  result: pass

--- a/other/restrict-devicetaintrule-empty-selector/.kyverno-test/resources.yaml
+++ b/other/restrict-devicetaintrule-empty-selector/.kyverno-test/resources.yaml
@@ -1,0 +1,31 @@
+apiVersion: resource.k8s.io/v1beta2
+kind: DeviceTaintRule
+metadata:
+  name: no-selector-field
+spec:
+  taint:
+    key: test.example.com/no-selector
+    effect: NoSchedule
+
+---
+apiVersion: resource.k8s.io/v1beta2
+kind: DeviceTaintRule
+metadata:
+  name: empty-selector-object
+spec:
+  deviceSelector: {}
+  taint:
+    key: test.example.com/empty-selector
+    effect: NoSchedule
+
+---
+apiVersion: resource.k8s.io/v1beta2
+kind: DeviceTaintRule
+metadata:
+  name: good-scoped-selector
+spec:
+  deviceSelector:
+    driver: gpu.example.com
+  taint:
+    key: test.example.com/scoped-selector
+    effect: NoSchedule

--- a/other/restrict-devicetaintrule-empty-selector/artifacthub-pkg.yml
+++ b/other/restrict-devicetaintrule-empty-selector/artifacthub-pkg.yml
@@ -1,0 +1,25 @@
+name: restrict-devicetaintrule-empty-selector
+version: 1.0.0
+displayName: Restrict Empty DeviceTaintRule Selector
+description: >-
+  Kubernetes Dynamic Resource Allocation's `DeviceTaintRule` has a `deviceSelector` field (`driver`/`pool`/`device`). Per the field's own API documentation, an *empty* selector (all three fields unset) matches every device in the cluster, while a *missing* selector matches no devices at all — two very different outcomes from what looks like the same "nothing set" state. Validation admits an empty selector without any warning, so a single templating mistake silently turns a rule meant to drain one device into a cluster-wide, cross-tenant, priority-blind `NoExecute` eviction. This policy requires at least one of `driver`, `pool`, or `device` to be set whenever `deviceSelector` is present at all — it does not touch `DeviceTaintRule`s that omit the field entirely, since that is the documented safe case.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/restrict-devicetaintrule-empty-selector/restrict-devicetaintrule-empty-selector.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+  - Dynamic Resource Allocation
+readme: |
+  Kubernetes Dynamic Resource Allocation's `DeviceTaintRule` has a `deviceSelector` field (`driver`/`pool`/`device`).
+
+  Per the field's own API documentation, an *empty* selector (all three fields unset) matches every device in the cluster, while a *missing* selector matches no devices at all — two very different outcomes from what looks like the same "nothing set" state. Validation (`validateDeviceTaintSelector` in `pkg/apis/resource/validation/validation.go`) admits an empty selector without any warning, so a single templating mistake — omitting `driver`/`pool`, or rendering `deviceSelector: {}` instead of a scoped selector — silently turns a rule meant to drain one device into a cluster-wide, cross-tenant, priority-blind `NoExecute` eviction. See [kubernetes/kubernetes#141422](https://github.com/kubernetes/kubernetes/issues/141422) for the live-verified finding this policy mitigates (fix pending upstream in [kubernetes/kubernetes#141425](https://github.com/kubernetes/kubernetes/pull/141425)).
+
+  This policy requires at least one of `driver`, `pool`, or `device` to be set whenever `deviceSelector` is present at all. It intentionally does not touch `DeviceTaintRule`s that omit the field entirely, since a missing selector is the documented safe case (matches no devices).
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.37"
+  kyverno/subject: "DeviceTaintRule"

--- a/other/restrict-devicetaintrule-empty-selector/restrict-devicetaintrule-empty-selector.yaml
+++ b/other/restrict-devicetaintrule-empty-selector/restrict-devicetaintrule-empty-selector.yaml
@@ -1,0 +1,65 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-devicetaintrule-empty-selector
+  annotations:
+    policies.kyverno.io/title: Restrict Empty DeviceTaintRule Selector
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: high
+    kyverno.io/kyverno-version: 1.18.2
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.37"
+    policies.kyverno.io/subject: DeviceTaintRule
+    policies.kyverno.io/description: >-
+      Kubernetes Dynamic Resource Allocation's DeviceTaintRule has a
+      deviceSelector field (driver/pool/device). Per the field's own API
+      documentation, an *empty* selector (all three fields unset) matches
+      every device in the cluster, while a *missing* selector matches no
+      devices at all -- two very different outcomes from what looks like the
+      same "nothing set" state. Validation admits an empty selector without
+      any warning (validateDeviceTaintSelector in
+      pkg/apis/resource/validation/validation.go), so a single templating
+      mistake -- omitting driver/pool, or rendering deviceSelector: {} instead
+      of a scoped selector -- silently turns a rule meant to drain one device
+      into a cluster-wide, cross-tenant, priority-blind NoExecute eviction.
+      See kubernetes/kubernetes#141422 for the live-verified finding this
+      policy mitigates (fix pending upstream in
+      kubernetes/kubernetes#141425). This policy requires at least one of
+      driver, pool, or device to be set whenever deviceSelector is present at
+      all -- it does not touch DeviceTaintRules that omit the field entirely,
+      since that is the documented safe case.
+spec:
+  validationFailureAction: Audit
+  background: false
+  rules:
+  - name: require-devicetaintrule-selector-field
+    match:
+      any:
+      - resources:
+          kinds:
+            - DeviceTaintRule
+    preconditions:
+      all:
+      - key: "{{ request.object.spec.deviceSelector != null }}"
+        operator: Equals
+        value: true
+    validate:
+      message: >-
+        This DeviceTaintRule's deviceSelector is present but has none of
+        driver, pool, or device set. Per the API's own documentation, that
+        matches every device in the cluster -- see
+        kubernetes/kubernetes#141422. Set at least one of driver/pool/device
+        to scope this rule, or omit deviceSelector entirely if a no-op rule
+        was intended (a missing selector matches no devices).
+      deny:
+        conditions:
+          all:
+          - key: "{{ length(request.object.spec.deviceSelector.driver || '') }}"
+            operator: Equals
+            value: 0
+          - key: "{{ length(request.object.spec.deviceSelector.pool || '') }}"
+            operator: Equals
+            value: 0
+          - key: "{{ length(request.object.spec.deviceSelector.device || '') }}"
+            operator: Equals
+            value: 0


### PR DESCRIPTION
## Related Issue(s)

Related to [kubernetes/kubernetes#141422](https://github.com/kubernetes/kubernetes/issues/141422) (filed,
live-verified) and its pending upstream fix
[kubernetes/kubernetes#141425](https://github.com/kubernetes/kubernetes/pull/141425) (open, under review).
This policy is a stopgap, not a replacement — it protects clusters today regardless of Kubernetes version,
and remains useful for anyone on an older/unpatched release even after `#141425` merges.

## Description

Kubernetes Dynamic Resource Allocation's `DeviceTaintRule` has a `deviceSelector` field
(`driver`/`pool`/`device`). Per the field's own API documentation, an **empty** selector (all three fields
unset) matches every device in the cluster, while a **missing** selector matches no devices at all — two
very different outcomes from what looks like the same "nothing set" state. Validation admits an empty
selector without any warning, so a single templating mistake — omitting `driver`/`pool`, or rendering
`deviceSelector: {}` instead of a scoped selector — silently produces far more impact than intended (see
the table below).

This policy requires at least one of `driver`, `pool`, or `device` to be set whenever `deviceSelector` is
present at all. It deliberately does **not** flag a `DeviceTaintRule` that omits the field entirely, since
a missing selector is the documented safe case (matches no devices) — only the present-but-empty case is
the actual hazard.

Ships with `validationFailureAction: Audit` by default, matching this repo's own convention for
restriction-style policies.

Live-verified on a real cluster (Kyverno v1.18.2 via Helm, `resource.k8s.io/v1beta2` `DeviceTaintRule` API
enabled) against all three cases — omitted selector, empty selector, and a properly scoped selector — in
both `Audit` and `Enforce` modes. Static `kyverno test` included and passing (3/3).

| Before this policy | After this policy |
|---|---|
| An empty `deviceSelector: {}` on a `DeviceTaintRule` is silently admitted and matches **every device in the cluster** — a single templating mistake turns a "drain one device" rule into a cluster-wide, cross-tenant, priority-blind `NoExecute` eviction, with zero warning (see #141422). | **Audit** (shipped default): the object is still admitted, but immediately flagged with a `PolicyViolation` Warning event — a real signal to catch the mistake before it causes damage.<br><br>**Enforce** (opt-in): the object is rejected outright at admission time — the mistake never reaches the API at all. |

<details>
<summary>Live output for both modes (click to expand)</summary>

Audit mode (shipped default) — Warning event on the flagged object:

```
Warning   PolicyViolation   restrict-devicetaintrule-empty-selector/require-devicetaintrule-selector-field
fail: This DeviceTaintRule's deviceSelector is present but has none of driver, pool, or device
set. Per the API's own documentation, that matches every device in the cluster -- see
kubernetes/kubernetes#141422. Set at least one of driver/pool/device to scope this rule, or omit
deviceSelector entirely if a no-op rule was intended (a missing selector matches no devices).
```

Enforce mode (tested, not shipped) — genuine admission-webhook block:

```
Error from server: admission webhook "validate.kyverno.svc-fail" denied the request:
resource DeviceTaintRule//test-empty-selector-object was blocked due to the following policies
restrict-devicetaintrule-empty-selector:
  require-devicetaintrule-selector-field: This DeviceTaintRule's deviceSelector is present but
    has none of driver, pool, or device set. Per the API's own documentation, that matches every
    device in the cluster -- see kubernetes/kubernetes#141422. Set at least one of driver/pool/
    device to scope this rule, or omit deviceSelector entirely if a no-op rule was intended (a
    missing selector matches no devices).
```

</details>

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
