### PR TITLE
feat: add report-dra-adminaccess-device-overlap policy

### DIFF
--- a/other/report-dra-adminaccess-device-overlap/artifacthub-pkg.yml
+++ b/other/report-dra-adminaccess-device-overlap/artifacthub-pkg.yml
@@ -1,0 +1,34 @@
+name: report-dra-adminaccess-device-overlap
+version: 1.0.0
+displayName: Report DRA AdminAccess Device Overlap
+description: >-
+  Kubernetes Dynamic Resource Allocation's `adminAccess` intentionally ignores ordinary claims'
+  exclusivity when allocating a device -- working as designed, not a bug (see
+  kubernetes/kubernetes#141293). That means two `ResourceClaim`s from completely unrelated
+  namespaces can end up allocated to the exact same physical device at the same time, with nothing
+  today surfacing that it happened. This policy runs in background mode and periodically correlates
+  every `ResourceClaim`'s allocated devices against every other claim's: whenever an
+  adminAccess-allocated device (driver/pool/device) also appears in a different claim's allocation
+  without adminAccess, it reports the claim. It intentionally never blocks anything -- adminAccess
+  device sharing is expected behavior; the point is giving cluster operators a standing signal for
+  when it is actually happening.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/other/report-dra-adminaccess-device-overlap/report-dra-adminaccess-device-overlap.yaml
+  ```
+keywords:
+  - kyverno
+  - Other
+  - Dynamic Resource Allocation
+readme: |
+  Kubernetes Dynamic Resource Allocation's `adminAccess` intentionally ignores ordinary claims' exclusivity when allocating a device -- working as designed, not a bug (see [kubernetes/kubernetes#141293](https://github.com/kubernetes/kubernetes/issues/141293)).
+
+  That means two `ResourceClaim`s from completely unrelated namespaces can end up allocated to the exact same physical device at the same time, and nothing today surfaces that it happened. This policy runs in background mode and periodically correlates every `ResourceClaim`'s allocated devices (`status.allocation.devices.results`) against every other claim's: whenever an adminAccess-allocated device (identified by `driver`/`pool`/`device`) also appears in a different claim's allocation without adminAccess, the adminAccess-holding claim is reported.
+
+  This policy intentionally never blocks anything -- adminAccess device sharing is expected, working-as-designed behavior. The point is giving cluster operators a standing PolicyReport signal for when it is actually happening, the same way PolicyReport-based access reviews already track other security-relevant conditions (see the companion policy `report-dra-adminaccess-namespaces`).
+
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Other"
+  kyverno/kubernetesVersion: "1.37"
+  kyverno/subject: "ResourceClaim"

--- a/other/report-dra-adminaccess-device-overlap/report-dra-adminaccess-device-overlap.yaml
+++ b/other/report-dra-adminaccess-device-overlap/report-dra-adminaccess-device-overlap.yaml
@@ -1,0 +1,76 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: report-dra-adminaccess-device-overlap
+  annotations:
+    policies.kyverno.io/title: Report DRA AdminAccess Device Overlap
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.18.2
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.37"
+    policies.kyverno.io/subject: ResourceClaim
+    policies.kyverno.io/description: >-
+      DRA's adminAccess intentionally ignores ordinary claims' exclusivity when allocating a
+      device -- working as designed, not a bug (see kubernetes/kubernetes#141293). That means two
+      ResourceClaims from completely unrelated namespaces can end up allocated to the exact same
+      physical device at the same time, and nothing today surfaces that it happened. This policy
+      runs in background mode and periodically correlates every ResourceClaim's allocated devices
+      against every other claim's: whenever an adminAccess-allocated device (driver/pool/device)
+      also appears in a different claim's allocation without adminAccess, it reports the claim.
+      It intentionally never blocks anything -- adminAccess device sharing is expected behavior;
+      the point is giving cluster operators a standing signal for when it is actually happening,
+      the same way PolicyReport-based access reviews already track other security-relevant
+      conditions.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+  - name: flag-adminaccess-device-overlap
+    match:
+      any:
+      - resources:
+          kinds:
+            - ResourceClaim
+    context:
+    - name: myAdminDeviceKeys
+      variable:
+        jmesPath: >-
+          request.object.status.allocation.devices.results[?adminAccess ==
+          `true`].join('/', [driver, pool, device])
+        default: []
+    - name: otherClaims
+      apiCall:
+        urlPath: "/apis/resource.k8s.io/v1/resourceclaims"
+        jmesPath: >-
+          items[?metadata.uid != '{{ request.object.metadata.uid }}' &&
+          status.allocation.devices.results[?adminAccess != `true`]][]
+    - name: otherDeviceKeys
+      variable:
+        jmesPath: >-
+          otherClaims[].status.allocation.devices.results[?adminAccess !=
+          `true`].join('/', [driver, pool, device])[]
+        default: []
+    - name: overlapKeys
+      variable:
+        jmesPath: "myAdminDeviceKeys[?contains(`{{ otherDeviceKeys }}`, @)]"
+        default: []
+    preconditions:
+      all:
+      - key: "{{ myAdminDeviceKeys | length(@) }}"
+        operator: GreaterThan
+        value: 0
+    validate:
+      message: >-
+        This ResourceClaim has at least one adminAccess-allocated device also currently
+        allocated, without adminAccess, to a different ResourceClaim: {{ overlapKeys }}.
+        adminAccess intentionally bypasses ordinary device exclusivity (see
+        kubernetes/kubernetes#141293) -- this is expected, working-as-designed behavior, not
+        something to block. This report exists purely for operator visibility into when device
+        sharing is actually happening.
+      deny:
+        conditions:
+          any:
+          - key: "{{ overlapKeys | length(@) }}"
+            operator: GreaterThan
+            value: 0


### PR DESCRIPTION
## Related Issue(s)

Related to [kubernetes/kubernetes#141293](https://github.com/kubernetes/kubernetes/issues/141293)
(closed, working-as-designed) and a companion observability request queued against
`kubernetes/kubernetes` proposing the equivalent signal natively (audit-log only, not yet filed).
This policy is a today-available mitigation, independent of whether that upstream ask lands --
it protects clusters on any Kubernetes version that supports DRA, and complements the existing
`report-dra-adminaccess-namespaces` policy from #1523, which reports the same self-escalation
chain's *entry point* (a labeled namespace); this one reports the chain's *consequence* (an actual
device shared between claims).

## Description

DRA's `adminAccess` intentionally ignores ordinary claims' exclusivity when allocating a device --
confirmed working-as-designed by `kubernetes/kubernetes` maintainers on #141293, not something this
policy tries to reopen. Practical effect: an `adminAccess: true` claim in one namespace can be
allocated to the exact same physical device an unrelated, ordinary claim in a different namespace
already holds -- and nothing today records that it happened.

This policy runs in **background mode** and correlates every `ResourceClaim`'s allocated devices
(`status.allocation.devices.results`, keyed by `driver`/`pool`/`device`) against every other claim
in the cluster. Whenever a claim has an adminAccess-allocated device that also appears, without
adminAccess, on a different claim, that claim is flagged.

It intentionally **never blocks anything** -- device sharing via adminAccess is expected behavior.
Ships with `validationFailureAction: Audit` only (no `Enforce` variant -- blocking it would
contradict #141293's own resolution). Same category and intent as the existing
`report-dra-adminaccess-namespaces` policy (#1523): a standing, queryable signal for a
security-relevant condition that otherwise leaves no trace anywhere.

| Before this policy | After this policy |
|---|---|
| An `adminAccess` claim silently sharing a device with an unrelated, ordinary claim leaves **no trace anywhere** -- not an `Event`, not a `Status` field, nothing a routine access review or `kubectl get events` would ever surface (see #141293's own follow-up investigation). | A `PolicyReport` entry appears on the adminAccess-holding claim, naming the exact device and the other claim(s) sharing it -- a standing, queryable signal for operators, without exposing anything to either tenant. |

<details>
<summary>More details: verification method, live output, and why there's no static <code>kyverno test</code></summary>

**Verification:** live-verified on a real cluster (Kyverno v1.18.2, `dra-example-driver` v0.4.0, a
single-device pool so allocation collision is deterministic rather than probabilistic). Created an
ordinary exclusive claim in one namespace, let it allocate the pool's only device, then created an
adminAccess claim in a completely separate namespace requesting the same `DeviceClass` -- confirming
live that the adminAccess claim allocates onto the *same* device
(`gpu.example.com/dra-repro-worker/gpu-0`) already held by the first claim. The background-controller
correctly reported the adminAccess claim as `fail` naming both claims, the ordinary claim itself as
`skip`, and four other unrelated, still-`pending` adminAccess claims elsewhere in the cluster as
`skip` -- no false positives across a full cluster sweep.

The adminAccess claim (`cross-tenant-a-admin/admin-claim`) correctly flagged:

```
$ kubectl get policyreport -n cross-tenant-a-admin <report-name> -o jsonpath='{.results[?(@.policy=="report-dra-adminaccess-device-overlap")]}'
{
  "result": "fail",
  "message": "This ResourceClaim has at least one adminAccess-allocated device also currently
    allocated, without adminAccess, to a different ResourceClaim:
    [\"gpu.example.com/dra-repro-worker/gpu-0\"]. adminAccess intentionally bypasses ordinary
    device exclusivity (see kubernetes/kubernetes#141293) -- this is expected, working-as-designed
    behavior, not something to block. This report exists purely for operator visibility into when
    device sharing is actually happening."
}
```

The ordinary claim on the other side of the same collision (`cross-tenant-b/exclusive-claim`) --
correctly not re-flagged from its own side:

```
$ kubectl get policyreport -n cross-tenant-b <report-name> -o jsonpath='{.results[?(@.policy=="report-dra-adminaccess-device-overlap")]}'
{ "result": "skip", "message": "preconditions not met" }
```

Full cluster sweep (6 `ResourceClaim`s total, 4 pending/unallocated adminAccess claims elsewhere in
the cluster) -- exactly one true positive, zero false positives:

```
admin-labeled          admin-claim           -> skip  (pending, no device allocated yet)
admin-unlabeled        admin-claim           -> skip  (pending, no device allocated yet)
admin-unlabeled        user-b-admin-claim    -> skip  (pending, no device allocated yet)
admin-unlabeled        user-b-admin-claim-2  -> skip  (pending, no device allocated yet)
cross-tenant-a-admin   admin-claim           -> fail  (the real, live double-allocation)
cross-tenant-b         exclusive-claim       -> skip  (the other side of the same pair)
```

**Why no static `kyverno test`:** this policy's correctness depends on a live cross-resource
`context.apiCall` correlating against real cluster state at scan time, which the CLI's static test
fixtures can't meaningfully exercise (confirmed by trying -- the CLI resolves `apiCall` context
independently of the declared test resources, so a static fixture would either pass trivially or
require mocking that defeats the point of testing the correlation at all). The live
background-controller verification above is the real, meaningful proof for a policy of this kind,
mirroring how the sibling `report-dra-adminaccess-namespaces` policy (#1523) was verified.

</details>

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [ ] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended -- no `.kyverno-test` fixtures included; see the note above on why the CLI's static test can't meaningfully exercise this policy's cross-resource `apiCall`. Positive and negative cases are instead demonstrated via live cluster output, documented above.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
