### PR TITLE
fix: restrict require-probes vpol to regular and sidecar containers

### DIFF
--- a/best-practices-vpol/require-probes/.chainsaw-test/bad-pod-notall.yaml
+++ b/best-practices-vpol/require-probes/.chainsaw-test/bad-pod-notall.yaml
@@ -35,3 +35,23 @@ spec:
       tcpSocket:
         port: 8080
       periodSeconds: 10
+---
+# Sidecar container (init container with restartPolicy: Always) without any probe.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod04
+  labels:
+    app: myapp
+spec:
+  initContainers:
+  - name: sidecar
+    image: ghcr.io/kyverno/test-busybox:1.35
+    restartPolicy: Always
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      periodSeconds: 10

--- a/best-practices-vpol/require-probes/.chainsaw-test/good-pods.yaml
+++ b/best-practices-vpol/require-probes/.chainsaw-test/good-pods.yaml
@@ -47,3 +47,48 @@ spec:
     startupProbe:
       grpc:
         port: 8888
+---
+# Plain init container without a probe: allowed, since Kubernetes forbids probes
+# on init containers that do not set restartPolicy: Always.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod04
+  labels:
+    app: myapp
+spec:
+  initContainers:
+  - name: init-setup
+    image: ghcr.io/kyverno/test-busybox:1.35
+    command: ["sh", "-c", "echo setup"]
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      periodSeconds: 10
+---
+# Sidecar container (init container with restartPolicy: Always) with a probe.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod05
+  labels:
+    app: myapp
+spec:
+  initContainers:
+  - name: sidecar
+    image: ghcr.io/kyverno/test-busybox:1.35
+    restartPolicy: Always
+    startupProbe:
+      tcpSocket:
+        port: 9090
+      periodSeconds: 10
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      periodSeconds: 10

--- a/best-practices-vpol/require-probes/.kyverno-test/kyverno-test.yaml
+++ b/best-practices-vpol/require-probes/.kyverno-test/kyverno-test.yaml
@@ -12,6 +12,7 @@ results:
   resources:
   - badpod01
   - badpod02
+  - badpod03
   result: fail
 - kind: Pod
   policy: require-pod-probes
@@ -20,4 +21,7 @@ results:
   - goodpod02
   - goodpod03
   - goodpod04
+  - goodpod05
+  - goodpod06
+  - goodpod07
   result: pass

--- a/best-practices-vpol/require-probes/.kyverno-test/resource.yaml
+++ b/best-practices-vpol/require-probes/.kyverno-test/resource.yaml
@@ -108,3 +108,82 @@ spec:
       periodSeconds: 10
   - name: nginx
     image: nginx:latest
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod05
+  labels:
+    app: myapp
+spec:
+  initContainers:
+  - name: init-setup
+    image: registry.k8s.io/goproxy:0.1
+    command: ["sh", "-c", "echo setup"]
+  containers:
+  - name: goproxy
+    image: registry.k8s.io/goproxy:0.1
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      periodSeconds: 10
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod03
+  labels:
+    app: myapp
+spec:
+  initContainers:
+  - name: sidecar
+    image: registry.k8s.io/goproxy:0.1
+    restartPolicy: Always
+  containers:
+  - name: goproxy
+    image: registry.k8s.io/goproxy:0.1
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      periodSeconds: 10
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod06
+  labels:
+    app: myapp
+spec:
+  containers:
+  - name: goproxy
+    image: registry.k8s.io/goproxy:0.1
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      periodSeconds: 10
+  ephemeralContainers:
+  - name: debugger
+    image: busybox:1.36
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod07
+  labels:
+    app: myapp
+spec:
+  initContainers:
+  - name: sidecar
+    image: registry.k8s.io/goproxy:0.1
+    restartPolicy: Always
+    startupProbe:
+      tcpSocket:
+        port: 9090
+      periodSeconds: 10
+  containers:
+  - name: goproxy
+    image: registry.k8s.io/goproxy:0.1
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      periodSeconds: 10

--- a/best-practices-vpol/require-probes/artifacthub-pkg.yml
+++ b/best-practices-vpol/require-probes/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ readme: |
 annotations:
   kyverno/category: "Best Practices, EKS Best Practices"
   kyverno/subject: "Pod"
-digest: bb39d13e91397d65e435f9d89e3515b5d1544911afc493b47aea82b9424e134f
+digest: 14e394f3c9cd1076081fef5e51d6c5315852a99fc03bf1849e906cc9b7ca26a4

--- a/best-practices-vpol/require-probes/require-probes.yaml
+++ b/best-practices-vpol/require-probes/require-probes.yaml
@@ -12,8 +12,10 @@ metadata:
       deployments, restarts, and upgrades. Liveness probes help the kubelet determine
       when to restart containers, while readiness probes help Services and Deployments
       determine when Pods are ready to receive traffic. Startup probes provide additional
-      control during container startup. This policy validates that all containers have
-      at least one of livenessProbe, readinessProbe, or startupProbe defined.      
+      control during container startup. This policy validates that all containers and
+      sidecar containers (init containers with restartPolicy: Always) have at least one
+      of livenessProbe, readinessProbe, or startupProbe defined. Plain init containers
+      and ephemeral containers are not checked because Kubernetes forbids probes on them.
     policies.kyverno.io/minversion: "1.14.0"
 spec:
   validationActions: ["Deny"]
@@ -35,11 +37,22 @@ spec:
       resources: ["jobs", "cronjobs"]
       operations: ["CREATE", "UPDATE"]
   variables:
+  # Resolve the pod spec for both bare Pods and pod controllers.
+  - name: podSpec
+    expression: >-
+      has(object.spec.containers) ?
+        object.spec :
+        object.spec.template.spec
+  # Checked are regular containers plus sidecar containers, i.e. init containers with
+  # restartPolicy: Always (Kubernetes >= 1.29), which are long-running and therefore
+  # benefit from probes just like regular containers.
+  # Plain init containers and ephemeral containers are excluded because Kubernetes
+  # rejects probes on them ("may not be set for init containers without
+  # restartPolicy=Always"), which would make this policy impossible to satisfy.
   - name: allContainers
     expression: >-
-      has(object.spec.containers) ? 
-        object.spec.containers + object.spec.?initContainers.orValue([]) + object.spec.?ephemeralContainers.orValue([]) : 
-        object.spec.template.spec.containers + object.spec.template.spec.?initContainers.orValue([]) + object.spec.template.spec.?ephemeralContainers.orValue([])      
+      variables.podSpec.containers +
+      variables.podSpec.?initContainers.orValue([]).filter(container, container.?restartPolicy.orValue("") == "Always")
   validations:
   - expression: >-
       variables.allContainers.all(container, 


### PR DESCRIPTION
## Related Issue(s)

<!--
Please link the GitHub issue this pull request resolves by using the appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

N/A

## Description

<!--
What does this PR do?
-->
In https://github.com/kyverno/policies/pull/1432 more vpol examples have been added. One of them was `require-pod-probes`. Wheres the CPol only applies to regular containers, the VPol applies to ephemeral and initContainers as well. As described by the [docs](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#differences-from-regular-containers), init containers and ephemeral container don't support such probes, hence the policy will always fail if there is some initContainer specified.

This PR excludes ephemeral containers from the policy and only applies to initContainers which have `restart: always` set (sidecars), as they support probes. This implementation therefore also results in a different behavior compared to the old CPol.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
