### PR TITLE
Add policy to block setting .host field from probes and lifecycle hooks

### DIFF
--- a/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/chainsaw-test.yaml
+++ b/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: disallow-probes-host
+spec:
+  # disable templating because it can cause issues with CEL expressions
+  template: false
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: ../disallow-probes-host.yaml
+    - patch:
+        resource:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          metadata:
+            name: disallow-probes-host
+          spec:
+            validationFailureAction: Enforce
+    - assert:
+        file: policy-ready.yaml
+  - name: step-02
+    try:
+    - apply:
+        file: pod-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: pod-bad.yaml
+    - apply:
+        file: podcontroller-good.yaml
+    - apply:
+        expect:
+        - check:
+            ($error != null): true
+        file: podcontroller-bad.yaml

--- a/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/pod-bad.yaml
+++ b/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/pod-bad.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod01
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod02
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    readinessProbe:
+      tcpSocket:
+        host: 127.0.0.1
+        port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod03
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    startupProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 8080
+    lifecycle:
+      postStart:
+        httpGet:
+          host: 127.0.0.1
+          port: 8080
+      preStop:
+        tcpSocket:
+          host: 127.0.0.1
+          port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod04
+spec:
+  initContainers:
+  - name: busybox-init
+    image: ghcr.io/kyverno/test-busybox:1.35
+    restartPolicy: Always
+    readinessProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 8080
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod05
+spec:
+  containers:
+  - name: good
+    image: ghcr.io/kyverno/test-busybox:1.35
+  - name: bad
+    image: ghcr.io/kyverno/test-busybox:1.35
+    lifecycle:
+      preStop:
+        httpGet:
+          host: 127.0.0.1
+          port: 8080

--- a/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/pod-good.yaml
+++ b/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/pod-good.yaml
@@ -1,0 +1,99 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod01
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    livenessProbe:
+      httpGet:
+        port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod02
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+    lifecycle:
+      postStart:
+        httpGet:
+          port: 8080
+      preStop:
+        tcpSocket:
+          port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod03
+spec:
+  containers:
+  - name: busybox01
+    image: ghcr.io/kyverno/test-busybox:1.35
+  - name: busybox02
+    image: ghcr.io/kyverno/test-busybox:1.35
+    startupProbe:
+      httpGet:
+        port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod04
+spec:
+  initContainers:
+  - name: busybox-init
+    image: ghcr.io/kyverno/test-busybox:1.35
+    restartPolicy: Always
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+    lifecycle:
+      postStart:
+        tcpSocket:
+          port: 8080
+      preStop:
+        httpGet:
+          port: 8080
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod05
+spec:
+  initContainers:
+  - name: busybox-init
+    image: ghcr.io/kyverno/test-busybox:1.35
+    restartPolicy: Always
+    readinessProbe:
+      httpGet:
+        port: 8080
+    startupProbe:
+      tcpSocket:
+        port: 8080
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod06
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    readinessProbe:
+      httpGet:
+        host: ""
+        port: 8080

--- a/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/podcontroller-bad.yaml
+++ b/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/podcontroller-bad.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob01
+spec:
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          initContainers:
+          - name: busybox-init
+            image: ghcr.io/kyverno/test-busybox:1.35
+            restartPolicy: Always
+            lifecycle:
+              preStop:
+                tcpSocket:
+                  host: 127.0.0.1
+                  port: 8080
+          containers:
+          - name: busybox
+            image: ghcr.io/kyverno/test-busybox:1.35
+          restartPolicy: Never
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: baddeployment01
+  template:
+    metadata:
+      labels:
+        app: baddeployment01
+    spec:
+      containers:
+      - name: busybox
+        image: ghcr.io/kyverno/test-busybox:1.35
+        readinessProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /ready
+            port: 8080

--- a/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/podcontroller-good.yaml
+++ b/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/podcontroller-good.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gooddeployment01
+  template:
+    metadata:
+      labels:
+        app: gooddeployment01
+    spec:
+      containers:
+      - name: busybox
+        image: ghcr.io/kyverno/test-busybox:1.35
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gooddeployment02
+  template:
+    metadata:
+      labels:
+        app: gooddeployment02
+    spec:
+      containers:
+      - name: busybox
+        image: ghcr.io/kyverno/test-busybox:1.35
+        lifecycle:
+          postStart:
+            tcpSocket:
+              host: ""
+              port: 8080
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob01
+spec:
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          initContainers:
+          - name: busybox-init
+            image: ghcr.io/kyverno/test-busybox:1.35
+            restartPolicy: Always
+            startupProbe:
+              tcpSocket:
+                port: 8080
+          containers:
+          - name: busybox
+            image: ghcr.io/kyverno/test-busybox:1.35
+          restartPolicy: Never

--- a/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/policy-ready.yaml
+++ b/pod-security-cel/baseline/disallow-probes-host/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,10 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-probes-host
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready
+

--- a/pod-security-cel/baseline/disallow-probes-host/.kyverno-test/kyverno-test.yaml
+++ b/pod-security-cel/baseline/disallow-probes-host/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,55 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: disallow-probes-host
+policies:
+- ../disallow-probes-host.yaml
+resources:
+- resource.yaml
+results:
+- kind: CronJob
+  policy: disallow-probes-host
+  resources:
+  - badcronjob01
+  result: fail
+  rule: probes-host
+- kind: Deployment
+  policy: disallow-probes-host
+  resources:
+  - baddeployment01
+  result: fail
+  rule: probes-host
+- kind: Pod
+  policy: disallow-probes-host
+  resources:
+  - badpod01
+  - badpod02
+  - badpod03
+  - badpod04
+  - badpod05
+  result: fail
+  rule: probes-host
+- kind: CronJob
+  policy: disallow-probes-host
+  resources:
+  - goodcronjob01
+  result: pass
+  rule: probes-host
+- kind: Deployment
+  policy: disallow-probes-host
+  resources:
+  - gooddeployment01
+  - gooddeployment02
+  result: pass
+  rule: probes-host
+- kind: Pod
+  policy: disallow-probes-host
+  resources:
+  - goodpod01
+  - goodpod02
+  - goodpod03
+  - goodpod04
+  - goodpod05
+  - goodpod06
+  result: pass
+  rule: probes-host

--- a/pod-security-cel/baseline/disallow-probes-host/.kyverno-test/resource.yaml
+++ b/pod-security-cel/baseline/disallow-probes-host/.kyverno-test/resource.yaml
@@ -1,0 +1,300 @@
+###### Pods - Bad
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod01
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod02
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    readinessProbe:
+      tcpSocket:
+        host: 127.0.0.1
+        port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod03
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    startupProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 8080
+    lifecycle:
+      postStart:
+        httpGet:
+          host: 127.0.0.1
+          port: 8080
+      preStop:
+        tcpSocket:
+          host: 127.0.0.1
+          port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod04
+spec:
+  initContainers:
+  - name: busybox-init
+    image: ghcr.io/kyverno/test-busybox:1.35
+    restartPolicy: Always
+    readinessProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 8080
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: badpod05
+spec:
+  containers:
+  - name: good
+    image: ghcr.io/kyverno/test-busybox:1.35
+  - name: bad
+    image: ghcr.io/kyverno/test-busybox:1.35
+    lifecycle:
+      preStop:
+        httpGet:
+          host: 127.0.0.1
+          port: 8080
+---
+###### Pods - Good
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod01
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    livenessProbe:
+      httpGet:
+        port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod02
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+    lifecycle:
+      postStart:
+        httpGet:
+          port: 8080
+      preStop:
+        tcpSocket:
+          port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod03
+spec:
+  containers:
+  - name: busybox01
+    image: ghcr.io/kyverno/test-busybox:1.35
+  - name: busybox02
+    image: ghcr.io/kyverno/test-busybox:1.35
+    startupProbe:
+      httpGet:
+        port: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod04
+spec:
+  initContainers:
+  - name: busybox-init
+    image: ghcr.io/kyverno/test-busybox:1.35
+    restartPolicy: Always
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+    lifecycle:
+      postStart:
+        tcpSocket:
+          port: 8080
+      preStop:
+        httpGet:
+          port: 8080
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod05
+spec:
+  initContainers:
+  - name: busybox-init
+    image: ghcr.io/kyverno/test-busybox:1.35
+    restartPolicy: Always
+    readinessProbe:
+      httpGet:
+        port: 8080
+    startupProbe:
+      tcpSocket:
+        port: 8080
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goodpod06
+spec:
+  containers:
+  - name: busybox
+    image: ghcr.io/kyverno/test-busybox:1.35
+    readinessProbe:
+      httpGet:
+        host: ""
+        port: 8080
+---
+###### Deployments - Bad
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: baddeployment01
+  template:
+    metadata:
+      labels:
+        app: baddeployment01
+    spec:
+      containers:
+      - name: busybox
+        image: ghcr.io/kyverno/test-busybox:1.35
+        readinessProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /ready
+            port: 8080
+---
+###### Deployments - Good
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gooddeployment01
+  template:
+    metadata:
+      labels:
+        app: gooddeployment01
+    spec:
+      containers:
+      - name: busybox
+        image: ghcr.io/kyverno/test-busybox:1.35
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gooddeployment02
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gooddeployment02
+  template:
+    metadata:
+      labels:
+        app: gooddeployment02
+    spec:
+      containers:
+      - name: busybox
+        image: ghcr.io/kyverno/test-busybox:1.35
+        lifecycle:
+          postStart:
+            tcpSocket:
+              host: ""
+              port: 8080
+---
+###### CronJobs - Bad
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: badcronjob01
+spec:
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          initContainers:
+          - name: busybox-init
+            image: ghcr.io/kyverno/test-busybox:1.35
+            restartPolicy: Always
+            lifecycle:
+              preStop:
+                tcpSocket:
+                  host: 127.0.0.1
+                  port: 8080
+          containers:
+          - name: busybox
+            image: ghcr.io/kyverno/test-busybox:1.35
+          restartPolicy: Never
+---
+###### CronJobs - Good
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: goodcronjob01
+spec:
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          initContainers:
+          - name: busybox-init
+            image: ghcr.io/kyverno/test-busybox:1.35
+            restartPolicy: Always
+            startupProbe:
+              tcpSocket:
+                port: 8080
+          containers:
+          - name: busybox
+            image: ghcr.io/kyverno/test-busybox:1.35
+          restartPolicy: Never

--- a/pod-security-cel/baseline/disallow-probes-host/artifacthub-pkg.yml
+++ b/pod-security-cel/baseline/disallow-probes-host/artifacthub-pkg.yml
@@ -1,0 +1,31 @@
+name: disallow-probes-host-cel
+version: 1.0.0
+displayName: Disallow the host field in probes and lifecycle hooks in CEL
+description: >-
+  The `host` field is used for allowing users to specify another entity other than the podIP
+  (which is the default value) to which Kubelet should perform probes to. However this
+  opens it up for security attacks since the `host`` field can be set to pretty much any
+  value in the system including security sensitive external hosts or localhost on the node.
+  Kubelet will be probing this set `host` value which can lead to blind SSRF attacks.
+install: |-
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/kyverno/policies/main/pod-security-cel/baseline/disallow-probes-host/disallow-probes-host.yaml
+  ```
+keywords:
+  - kyverno
+  - Pod Security Standards (Baseline)
+  - CEL Expressions
+readme: |
+  The `host` field is used for allowing users to specify another entity other than the podIP
+  (which is the default value) to which Kubelet should perform probes to. However this
+  opens it up for security attacks since the `host`` field can be set to pretty much any
+  value in the system including security sensitive external hosts or localhost on the node.
+  Kubelet will be probing this set `host` value which can lead to blind SSRF attacks.
+  
+  Refer to the documentation for more details on Kyverno annotations: https://artifacthub.io/docs/topics/annotations/kyverno/
+annotations:
+  kyverno/category: "Pod Security Standards (Baseline) in CEL"
+  kyverno/kubernetesVersion: "1.34-1.37"
+  kyverno/subject: "Pod"
+digest: 73182a57fef336f94d47205ca7f0bf836de9b5db2b90e00ce333329afc172e36
+createdAt: "2026-08-29T15:02:34Z"

--- a/pod-security-cel/baseline/disallow-probes-host/disallow-probes-host.yaml
+++ b/pod-security-cel/baseline/disallow-probes-host/disallow-probes-host.yaml
@@ -1,0 +1,64 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-probes-host
+  annotations:
+    policies.kyverno.io/title: Disallow the host field in probes and lifecycle hooks in CEL
+    policies.kyverno.io/category: Pod Security Standards (Baseline) in CEL
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/minversion: 1.11.0
+    kyverno.io/kubernetes-version: "1.34-1.37"
+    policies.kyverno.io/description: >-
+      The `host` field is used for allowing users to specify another entity other than the podIP
+      (which is the default value) to which Kubelet should perform probes to. However this
+      opens it up for security attacks since the `host`` field can be set to pretty much any
+      value in the system including security sensitive external hosts or localhost on the node.
+      Kubelet will be probing this set `host` value which can lead to blind SSRF attacks.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: probes-host
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+            operations:
+            - CREATE
+            - UPDATE
+      validate:
+        cel:
+          variables:
+            - name: allContainers
+              expression: >-
+                object.spec.containers +
+                (has(object.spec.initContainers) ? object.spec.initContainers : [])
+          expressions:
+            - expression: >-
+                variables.allContainers.all(container,
+                  [
+                    container.?livenessProbe.orValue({}),
+                    container.?readinessProbe.orValue({}),
+                    container.?startupProbe.orValue({}),
+                    container.?lifecycle.?postStart.orValue({}),
+                    container.?lifecycle.?preStop.orValue({})
+                  ].all(probe,
+                    probe.?httpGet.?host.orValue("") == "" &&
+                    probe.?tcpSocket.?host.orValue("") == ""
+                  )
+                )
+              message: >-
+                The `host` field in probes and lifecycle hooks is disallowed. The fields
+                spec.containers[*].livenessProbe.httpGet.host, spec.containers[*].readinessProbe.httpGet.host,
+                spec.containers[*].startupProbe.httpGet.host, spec.containers[*].livenessProbe.tcpSocket.host,
+                spec.containers[*].readinessProbe.tcpSocket.host, spec.containers[*].startupProbe.tcpSocket.host,
+                spec.containers[*].lifecycle.postStart.tcpSocket.host, spec.containers[*].lifecycle.preStop.tcpSocket.host,
+                spec.containers[*].lifecycle.postStart.httpGet.host, spec.containers[*].lifecycle.preStop.httpGet.host,
+                spec.initContainers[*].livenessProbe.httpGet.host, spec.initContainers[*].readinessProbe.httpGet.host,
+                spec.initContainers[*].startupProbe.httpGet.host, spec.initContainers[*].livenessProbe.tcpSocket.host,
+                spec.initContainers[*].readinessProbe.tcpSocket.host, spec.initContainers[*].startupProbe.tcpSocket.host,
+                spec.initContainers[*].lifecycle.postStart.tcpSocket.host, spec.initContainers[*].lifecycle.preStop.tcpSocket.host,
+                spec.initContainers[*].lifecycle.postStart.httpGet.host, spec.initContainers[*].lifecycle.preStop.httpGet.host
+                must either be undefined or set to an empty string.

--- a/pod-security-cel/baseline/kustomization.yaml
+++ b/pod-security-cel/baseline/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - disallow-host-ports-range/disallow-host-ports-range.yaml
   - disallow-host-process/disallow-host-process.yaml
   - disallow-privileged-containers/disallow-privileged-containers.yaml
+  - disallow-probes-host/disallow-probes-host.yaml
   - disallow-proc-mount/disallow-proc-mount.yaml
   - disallow-selinux/disallow-selinux.yaml
   - restrict-seccomp/restrict-seccomp.yaml


### PR DESCRIPTION
## Description

In [0] the baseline pod security standard was extended to block setting the `.host` field in probes and lifecycle hooks.
This change adds the equivalent CEL policy.

[0] https://github.com/kubernetes/enhancements/issues/4940

## Checklist

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
