### PR TITLE
fix: harden SLSA builder identity regex

### DIFF
--- a/other-ivpol/verify-image-slsa/artifacthub-pkg.yml
+++ b/other-ivpol/verify-image-slsa/artifacthub-pkg.yml
@@ -22,4 +22,4 @@ annotations:
   kyverno/kubernetesVersion: "1.35"
   kyverno/subject: "Pod"
 createdAt: "2026-05-13T13:35:28Z"
-digest: b61d92f4158cff06539c2cf6718382ea70844021dc5a636fbf08e31a570372f4
+digest: a1cc688152357d82dd01601fc848ad43382f1f01331d8ca72d52f410babfdb2c

--- a/other-ivpol/verify-image-slsa/verify-image-slsa.yaml
+++ b/other-ivpol/verify-image-slsa/verify-image-slsa.yaml
@@ -50,6 +50,12 @@ spec:
       expression: >-
         images.containers.map(image, verifyAttestationSignatures(image, attestations.slsaProvenance, [attestors.cosign])).all(e, e > 0)
 
+    # This expression uses a regex pattern to ensure the builder.id in the attestation is equal to the official
+    # SLSA provenance generator workflow and uses a tagged release in semver format. If using a specific SLSA
+    # provenance generation workflow, you may need to adjust the pattern as necessary.
+    # Literal dots are escaped so they cannot match arbitrary characters, and each semver component accepts
+    # multiple digits so tags such as v1.10.0 are matched. Only final releases are accepted; prerelease and
+    # build metadata tags such as v1.10.0-rc.1 are rejected.
     - message: "builder.id in the attestation is not equal to the official SLSA provenance generator workflow"
       expression: >-
-        images.containers.map(image, extractPayload(image, attestations.slsaProvenance).builder.id.matches('^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9].[0-9].[0-9]$')).all(e, e)
+        images.containers.map(image, extractPayload(image, attestations.slsaProvenance).builder.id.matches('^https://github\\.com/slsa-framework/slsa-github-generator/\\.github/workflows/generator_container_slsa3\\.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$')).all(e, e)

--- a/other/verify-image-slsa/.chainsaw-test/bad.yaml
+++ b/other/verify-image-slsa/.chainsaw-test/bad.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-pod
+spec:
+  containers:
+    - name: test-container
+      image: 'myreg.org/path/repo:v1'
+      imagePullPolicy: Always

--- a/other/verify-image-slsa/.chainsaw-test/chainsaw-test.yaml
+++ b/other/verify-image-slsa/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: verify-image-slsa
+spec:
+  # disable templating because it can cause issues with the JMESPath expressions
+  template: false
+
+  steps:
+    - name: step-01
+      try:
+        - apply:
+            file: ../verify-image-slsa.yaml
+        # the published policy audits so it is safe to install; switch it to
+        # Enforce here so image verification failures are observable
+        - patch:
+            resource:
+              apiVersion: kyverno.io/v1
+              kind: ClusterPolicy
+              metadata:
+                name: verify-slsa-provenance-keyless
+              spec:
+                validationFailureAction: Enforce
+        - assert:
+            file: policy-ready.yaml
+    - name: step-02
+      try:
+        - create:
+            file: good.yaml
+            timeout: 60s
+        - create:
+            timeout: 60s
+            expect:
+              - check:
+                  ($error != null): true
+            file: bad.yaml

--- a/other/verify-image-slsa/.chainsaw-test/good.yaml
+++ b/other/verify-image-slsa/.chainsaw-test/good.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+spec:
+  containers:
+    - name: test-container
+      image: 'nginx:latest'
+      imagePullPolicy: Always

--- a/other/verify-image-slsa/.chainsaw-test/policy-ready.yaml
+++ b/other/verify-image-slsa/.chainsaw-test/policy-ready.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-slsa-provenance-keyless
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/other/verify-image-slsa/artifacthub-pkg.yml
+++ b/other/verify-image-slsa/artifacthub-pkg.yml
@@ -19,4 +19,4 @@ annotations:
   kyverno/category: "Software Supply Chain Security"
   kyverno/kubernetesVersion: "1.24"
   kyverno/subject: "Pod"
-digest: 71468d92deb1f7a812ea584f2ce92002279fb67237d414a55911860497317349
+digest: da422f078c3bb05283d549903596b75bf30c0f8ea11c674438aec7d77a135fa3

--- a/other/verify-image-slsa/verify-image-slsa.yaml
+++ b/other/verify-image-slsa/verify-image-slsa.yaml
@@ -45,6 +45,9 @@ spec:
             # This expression uses a regex pattern to ensure the builder.id in the attestation is equal to the official
             # SLSA provenance generator workflow and uses a tagged release in semver format. If using a specific SLSA
             # provenance generation workflow, you may need to adjust the first input as necessary.
-            - key: "{{ regex_match('^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9].[0-9].[0-9]$','{{ builder.id}}') }}"
+            # Literal dots are escaped so they cannot match arbitrary characters, and each semver component accepts
+            # multiple digits so tags such as v1.10.0 are matched. Only final releases are accepted; prerelease and
+            # build metadata tags such as v1.10.0-rc.1 are rejected.
+            - key: "{{ regex_match('^https://github\\.com/slsa-framework/slsa-github-generator/\\.github/workflows/generator_container_slsa3\\.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$','{{ builder.id}}') }}"
               operator: Equals
               value: true


### PR DESCRIPTION
## Related Issue(s)
Fixes #1532

## Description
This PR fixes the SLSA builder identity regex used by both `ClusterPolicy` and `ImageValidatingPolicy`.

The previous regex treated `.` as a wildcard and only allowed single-digit version components. This could allow invalid builder IDs such as `v1x2y3` while rejecting valid releases such as `v1.10.0`.

The regex is updated to escape literal dots and support multi-digit versions. A Chainsaw test is also added for the `ClusterPolicy` variant, and the Artifact Hub digests have been regenerated.

The updated regex was tested against 29 valid and invalid cases through both JMESPath and CEL, with all cases passing.



## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for.
-->

- [x] I have read the [policy contribution guidelines](https://github.com/kyverno/policies/blob/main/README.md#contribution).
- [x] I have added test manifests and resources covering both positive and negative tests that prove this policy works as intended.
- [x] I have added the artifacthub-pkg.yml file and have verified it is complete and correct.
